### PR TITLE
feat: response-gated two-phase measurement engine

### DIFF
--- a/src/lib/components/FooterBar.svelte
+++ b/src/lib/components/FooterBar.svelte
@@ -8,7 +8,8 @@
   let lifecycle = $derived($measurementStore.lifecycle);
   let roundCounter = $derived($measurementStore.roundCounter);
   let cap = $derived($settingsStore.cap);
-  let delay = $derived($settingsStore.delay);
+  let burstRounds = $derived($settingsStore.burstRounds);
+  let monitorDelay = $derived($settingsStore.monitorDelay);
   let timeout = $derived($settingsStore.timeout);
 
   let errorCount = $derived.by(() => {
@@ -44,7 +45,12 @@
   let startedAt = $derived($measurementStore.startedAt);
   let elapsed = $derived(startedAt !== null ? Math.max(0, now - startedAt) : 0);
 
-  let configLabel = $derived(`${delay / 1000}s interval · ${timeout / 1000}s timeout`);
+  let isBurst = $derived(roundCounter < burstRounds);
+  let configLabel = $derived(
+    isBurst
+      ? `Burst · ${roundCounter}/${burstRounds} · ${timeout / 1000}s timeout`
+      : `${monitorDelay / 1000}s interval · ${timeout / 1000}s timeout`
+  );
 </script>
 
 <footer

--- a/src/lib/components/SettingsDrawer.svelte
+++ b/src/lib/components/SettingsDrawer.svelte
@@ -18,14 +18,16 @@
 
   // Local copies of settings for binding
   let timeout: number = $state(get(settingsStore).timeout);
-  let delay: number = $state(get(settingsStore).delay);
+  let burstRounds: number = $state(get(settingsStore).burstRounds);
+  let monitorDelay: number = $state(get(settingsStore).monitorDelay);
   let cap: number = $state(get(settingsStore).cap);
   let corsMode: 'no-cors' | 'cors' = $state(get(settingsStore).corsMode);
 
   // Sync local state when store changes externally (e.g. loaded from persistence)
   $effect(() => {
     timeout = $settingsStore.timeout;
-    delay = $settingsStore.delay;
+    burstRounds = $settingsStore.burstRounds;
+    monitorDelay = $settingsStore.monitorDelay;
     cap = $settingsStore.cap;
     corsMode = $settingsStore.corsMode;
   });
@@ -77,12 +79,20 @@
     settingsStore.update(s => ({ ...s, timeout: val }));
   }
 
-  function applyDelay(e: Event): void {
+  function applyBurstRounds(e: Event): void {
+    const raw = parseInt((e.target as HTMLInputElement).value, 10);
+    if (isNaN(raw)) return;
+    const val = Math.max(0, Math.min(500, raw));
+    burstRounds = val;
+    settingsStore.update(s => ({ ...s, burstRounds: val }));
+  }
+
+  function applyMonitorDelay(e: Event): void {
     const raw = parseInt((e.target as HTMLInputElement).value, 10);
     if (isNaN(raw)) return;
     const val = Math.max(0, Math.min(60000, raw));
-    delay = val;
-    settingsStore.update(s => ({ ...s, delay: val }));
+    monitorDelay = val;
+    settingsStore.update(s => ({ ...s, monitorDelay: val }));
   }
 
   function applyCap(e: Event): void {
@@ -180,11 +190,19 @@
       </div>
 
       <div class="field">
-        <label class="field-label" for="setting-delay">
-          Interval
+        <label class="field-label" for="setting-burst-rounds">
+          Burst rounds
+          <span class="field-hint">0–500, 0 = skip burst</span>
+        </label>
+        <input id="setting-burst-rounds" type="number" class="field-input" min="0" max="500" step="10" bind:value={burstRounds} onchange={applyBurstRounds} />
+      </div>
+
+      <div class="field">
+        <label class="field-label" for="setting-monitor-delay">
+          Monitor interval
           <span class="field-hint">ms, 0–60000</span>
         </label>
-        <input id="setting-delay" type="number" class="field-input" min="0" max="60000" step="100" bind:value={delay} onchange={applyDelay} />
+        <input id="setting-monitor-delay" type="number" class="field-input" min="0" max="60000" step="100" bind:value={monitorDelay} onchange={applyMonitorDelay} />
       </div>
 
       <div class="field">

--- a/src/lib/engine/measurement-engine.ts
+++ b/src/lib/engine/measurement-engine.ts
@@ -1,6 +1,6 @@
 // src/lib/engine/measurement-engine.ts
-// Orchestrates one Worker per enabled endpoint, synchronized round dispatch,
-// AbortController-based cancellation, and epoch-based stale-message invalidation.
+// Orchestrates one Worker per enabled endpoint, response-gated round dispatch,
+// two-phase cadence (burst → monitor), and epoch-based stale-message invalidation.
 
 import { get } from 'svelte/store';
 import { measurementStore } from '../stores/measurements';
@@ -25,6 +25,7 @@ export class MeasurementEngine {
   private roundBuffer: Map<number, WorkerToMainMessage[]> = new Map();
   private expectedResponses: number = 0;
   private flushTimers: Map<number, ReturnType<typeof setTimeout>> = new Map();
+  private flushedRounds: Set<number> = new Set();
 
   constructor(workerFactory?: WorkerFactory) {
     this.workerFactory = workerFactory ?? defaultWorkerFactory;
@@ -67,7 +68,8 @@ export class MeasurementEngine {
       this._spawnWorkers(endpoints);
       measurementStore.setLifecycle('running');
       this.freezeDetector.start();
-      this._scheduleNextRound();
+      // Dispatch the first round immediately (no delay for the very first round).
+      this._dispatchRound();
     } catch {
       // Worker creation failed (e.g., jsdom environment).
       // Stay in 'starting' — tests that only check epoch / lifecycle transition still pass.
@@ -97,12 +99,13 @@ export class MeasurementEngine {
 
     this.workers = [];
 
-    // Clean up flush timers and round buffer
+    // Clean up flush timers, round buffer, and flushed rounds tracking
     for (const timer of this.flushTimers.values()) {
       clearTimeout(timer);
     }
     this.flushTimers.clear();
     this.roundBuffer.clear();
+    this.flushedRounds.clear();
     this.expectedResponses = 0;
 
     this.freezeDetector.stop();
@@ -135,6 +138,10 @@ export class MeasurementEngine {
     if (msg.epoch !== currentEpoch) return; // stale — discard
 
     const roundId = msg.roundId;
+
+    // Discard orphaned responses for already-flushed rounds
+    if (this.flushedRounds.has(roundId)) return;
+
     if (!this.roundBuffer.has(roundId)) {
       this.roundBuffer.set(roundId, []);
     }
@@ -151,6 +158,9 @@ export class MeasurementEngine {
     const messages = this.roundBuffer.get(roundId);
     if (!messages || messages.length === 0) return;
     this.roundBuffer.delete(roundId);
+
+    // Mark this round as flushed to discard late-arriving orphaned responses
+    this.flushedRounds.add(roundId);
 
     // Clear any pending flush timeout for this round
     if (this.flushTimers.has(roundId)) {
@@ -190,6 +200,12 @@ export class MeasurementEngine {
     });
 
     measurementStore.addSamples(entries);
+
+    // Response-gated: schedule next round only AFTER this round is fully flushed.
+    // This prevents round overlap and self-inflicted network contention.
+    if (get(measurementStore).lifecycle === 'running') {
+      this._scheduleNextRound();
+    }
   }
 
   // ── Private helpers ───────────────────────────────────────────────────────
@@ -208,8 +224,17 @@ export class MeasurementEngine {
     });
   }
 
+  /**
+   * Two-phase cadence: burst (0ms delay) for the first N rounds, then
+   * monitor (configurable delay) for all subsequent rounds.
+   */
   private _scheduleNextRound(): void {
-    const { delay } = get(settingsStore);
+    const { burstRounds, monitorDelay } = get(settingsStore);
+    const { roundCounter } = get(measurementStore);
+
+    const isBurst = roundCounter < burstRounds;
+    const delay = isBurst ? 0 : monitorDelay;
+
     this.roundTimer = setTimeout(() => this._dispatchRound(), delay);
   }
 
@@ -251,12 +276,14 @@ export class MeasurementEngine {
       }
     }
 
-    // Flush timeout for stragglers (200ms)
+    // Flush timeout for stragglers — ensures the round doesn't hang forever
+    // if a worker dies or takes excessively long
     this.flushTimers.set(roundCounter, setTimeout(() => {
       this._flushRound(roundCounter);
     }, 200));
 
     measurementStore.incrementRound();
-    this._scheduleNextRound();
+    // NOTE: _scheduleNextRound() is NOT called here — it's called from
+    // _flushRound() after all responses arrive (response-gated dispatch).
   }
 }

--- a/src/lib/engine/measurement-engine.ts
+++ b/src/lib/engine/measurement-engine.ts
@@ -155,17 +155,24 @@ export class MeasurementEngine {
   }
 
   private _flushRound(roundId: number): void {
-    const messages = this.roundBuffer.get(roundId);
-    if (!messages || messages.length === 0) return;
+    const messages = this.roundBuffer.get(roundId) ?? [];
     this.roundBuffer.delete(roundId);
 
     // Mark this round as flushed to discard late-arriving orphaned responses
-    this.lastFlushedRound = roundId;
+    this.lastFlushedRound = Math.max(this.lastFlushedRound, roundId);
 
     // Clear any pending flush timeout for this round
     if (this.flushTimers.has(roundId)) {
       clearTimeout(this.flushTimers.get(roundId)!);
       this.flushTimers.delete(roundId);
+    }
+
+    // Still advance cadence even if no responses arrived for this round
+    if (messages.length === 0) {
+      if (get(measurementStore).lifecycle === 'running') {
+        this._scheduleNextRound();
+      }
+      return;
     }
 
     const timestamp = Date.now();

--- a/src/lib/engine/measurement-engine.ts
+++ b/src/lib/engine/measurement-engine.ts
@@ -25,7 +25,7 @@ export class MeasurementEngine {
   private roundBuffer: Map<number, WorkerToMainMessage[]> = new Map();
   private expectedResponses: number = 0;
   private flushTimers: Map<number, ReturnType<typeof setTimeout>> = new Map();
-  private flushedRounds: Set<number> = new Set();
+  private lastFlushedRound = -1;
 
   constructor(workerFactory?: WorkerFactory) {
     this.workerFactory = workerFactory ?? defaultWorkerFactory;
@@ -105,7 +105,7 @@ export class MeasurementEngine {
     }
     this.flushTimers.clear();
     this.roundBuffer.clear();
-    this.flushedRounds.clear();
+    this.lastFlushedRound = -1;
     this.expectedResponses = 0;
 
     this.freezeDetector.stop();
@@ -140,7 +140,7 @@ export class MeasurementEngine {
     const roundId = msg.roundId;
 
     // Discard orphaned responses for already-flushed rounds
-    if (this.flushedRounds.has(roundId)) return;
+    if (roundId <= this.lastFlushedRound) return;
 
     if (!this.roundBuffer.has(roundId)) {
       this.roundBuffer.set(roundId, []);
@@ -160,7 +160,7 @@ export class MeasurementEngine {
     this.roundBuffer.delete(roundId);
 
     // Mark this round as flushed to discard late-arriving orphaned responses
-    this.flushedRounds.add(roundId);
+    this.lastFlushedRound = roundId;
 
     // Clear any pending flush timeout for this round
     if (this.flushTimers.has(roundId)) {
@@ -276,11 +276,13 @@ export class MeasurementEngine {
       }
     }
 
-    // Flush timeout for stragglers — ensures the round doesn't hang forever
-    // if a worker dies or takes excessively long
+    // Flush timeout for stragglers — derived from configured timeout plus margin.
+    // Ensures the round doesn't hang forever if a worker dies, while not
+    // dropping valid responses from slow endpoints.
+    const flushDeadline = timeout + 500;
     this.flushTimers.set(roundCounter, setTimeout(() => {
       this._flushRound(roundCounter);
-    }, 200));
+    }, flushDeadline));
 
     measurementStore.incrementRound();
     // NOTE: _scheduleNextRound() is NOT called here — it's called from

--- a/src/lib/engine/worker.ts
+++ b/src/lib/engine/worker.ts
@@ -44,6 +44,8 @@ export function extractTimingPayload(entry: PerformanceResourceTiming): TimingPa
       tlsHandshake: 0,
       ttfb: 0,
       contentTransfer: 0,
+      connectionReused: undefined,
+      protocol: (entry as PerformanceResourceTiming).nextHopProtocol || undefined,
     };
   }
 
@@ -61,6 +63,8 @@ export function extractTimingPayload(entry: PerformanceResourceTiming): TimingPa
     tlsHandshake,
     ttfb,
     contentTransfer,
+    connectionReused: connectStart === connectEnd,
+    protocol: (entry as PerformanceResourceTiming).nextHopProtocol || undefined,
   };
 }
 
@@ -72,6 +76,76 @@ export function classifyLatencyTier(
   if (latency < 50) return 'fast';
   if (latency < 200) return 'medium';
   return 'slow';
+}
+
+// ── Resource Timing extraction helpers ─────────────────────────────────────
+
+const hasPerformanceObserver = typeof PerformanceObserver !== 'undefined';
+
+/**
+ * Wait for a Resource Timing entry matching `url` using PerformanceObserver.
+ * Races against the AbortController signal — if aborted, returns null.
+ */
+function waitForResourceEntry(
+  url: string,
+  signal: AbortSignal,
+): Promise<PerformanceResourceTiming | null> {
+  if (!hasPerformanceObserver) {
+    // Fallback: poll once after a microtask yield
+    return new Promise(resolve => {
+      setTimeout(() => {
+        const entries = performance.getEntriesByType('resource') as PerformanceResourceTiming[];
+        const filtered = entries.filter(e => e.name === url);
+        const entry = filtered.length > 0 ? (filtered[filtered.length - 1] ?? null) : null;
+        performance.clearResourceTimings();
+        resolve(entry);
+      }, 0);
+    });
+  }
+
+  return new Promise(resolve => {
+    if (signal.aborted) {
+      resolve(null);
+      return;
+    }
+
+    let settled = false;
+
+    const cleanup = () => {
+      if (settled) return;
+      settled = true;
+      observer.disconnect();
+      signal.removeEventListener('abort', abortHandler);
+      performance.clearResourceTimings();
+    };
+
+    const observer = new PerformanceObserver((list) => {
+      const match = list.getEntries().find(e => e.name === url) as PerformanceResourceTiming | undefined;
+      if (match && !settled) {
+        cleanup();
+        resolve(match);
+      }
+    });
+
+    const abortHandler = () => {
+      cleanup();
+      resolve(null);
+    };
+
+    signal.addEventListener('abort', abortHandler, { once: true });
+    observer.observe({ type: 'resource', buffered: true });
+
+    // Safety timeout: if observer never fires (e.g. no-cors opaque response
+    // that doesn't create a Resource Timing entry), resolve after 100ms
+    setTimeout(() => {
+      if (settled) return;
+      // Check entries one last time before giving up
+      const entries = performance.getEntriesByType('resource') as PerformanceResourceTiming[];
+      const fallback = entries.filter(e => e.name === url);
+      cleanup();
+      resolve(fallback.length > 0 ? (fallback[fallback.length - 1] ?? null) : null);
+    }, 100);
+  });
 }
 
 // ── Worker event loop ───────────────────────────────────────────────────────
@@ -112,16 +186,8 @@ if (typeof (globalThis as any).WorkerGlobalScope !== 'undefined' && self instanc
 
         clearTimeout(timeoutId);
 
-        // Wait a tick for the Resource Timing entry to be committed.
-        await new Promise<void>(resolve => setTimeout(resolve, 0));
-
-        const entries = performance.getEntriesByType(
-          'resource'
-        ) as PerformanceResourceTiming[];
-
-        // Find the most recent entry for this URL.
-        const filtered = entries.filter(e => e.name === url);
-        const entry = filtered[filtered.length - 1];
+        // Use PerformanceObserver to get the Resource Timing entry (push-based).
+        const entry = await waitForResourceEntry(url, signal);
 
         const timing: TimingPayload = entry
           ? extractTimingPayload(entry)
@@ -145,6 +211,7 @@ if (typeof (globalThis as any).WorkerGlobalScope !== 'undefined' && self instanc
         (self as unknown as Worker).postMessage(reply);
       } catch (err: unknown) {
         clearTimeout(timeoutId);
+        performance.clearResourceTimings();
 
         if (signal.aborted) {
           const timeoutReply: WorkerToMainMessage = {

--- a/src/lib/share/hash-router.ts
+++ b/src/lib/share/hash-router.ts
@@ -7,6 +7,7 @@ import { endpointStore } from '../stores/endpoints';
 import { settingsStore } from '../stores/settings';
 import { measurementStore } from '../stores/measurements';
 import { uiStore } from '../stores/ui';
+import { DEFAULT_SETTINGS } from '../types';
 import type { SharePayload, MeasurementState, Endpoint } from '../types';
 import { tokens } from '../tokens';
 
@@ -30,7 +31,12 @@ export function applySharePayload(payload: SharePayload): string[] {
   }));
 
   endpointStore.setEndpoints(endpoints);
-  settingsStore.set(payload.settings);
+  settingsStore.set({
+    ...DEFAULT_SETTINGS,
+    ...payload.settings,
+    burstRounds: payload.settings.burstRounds ?? DEFAULT_SETTINGS.burstRounds,
+    monitorDelay: payload.settings.monitorDelay ?? DEFAULT_SETTINGS.monitorDelay,
+  });
 
   const ids = endpoints.map((ep) => ep.id);
 

--- a/src/lib/share/hash-router.ts
+++ b/src/lib/share/hash-router.ts
@@ -34,8 +34,10 @@ export function applySharePayload(payload: SharePayload): string[] {
   settingsStore.set({
     ...DEFAULT_SETTINGS,
     ...payload.settings,
+    delay: DEFAULT_SETTINGS.delay,
     burstRounds: payload.settings.burstRounds ?? DEFAULT_SETTINGS.burstRounds,
-    monitorDelay: payload.settings.monitorDelay ?? DEFAULT_SETTINGS.monitorDelay,
+    monitorDelay:
+      payload.settings.monitorDelay ?? payload.settings.delay ?? DEFAULT_SETTINGS.monitorDelay,
   });
 
   const ids = endpoints.map((ep) => ep.id);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -39,6 +39,8 @@ export interface TimingPayload {
   tlsHandshake: number;
   ttfb: number;
   contentTransfer: number;
+  connectionReused?: boolean;
+  protocol?: string;
 }
 
 export type WorkerToMainMessage =
@@ -137,13 +139,17 @@ export type StatisticsState = Record<string, EndpointStatistics>;
 export interface Settings {
   timeout: number;
   delay: number;
+  burstRounds: number;
+  monitorDelay: number;
   cap: number;
   corsMode: 'no-cors' | 'cors';
 }
 
 export const DEFAULT_SETTINGS: Settings = {
   timeout: 5000,
-  delay: 1000,
+  delay: 0,
+  burstRounds: 50,
+  monitorDelay: 3000,
   cap: 0,
   corsMode: 'no-cors',
 };
@@ -207,6 +213,8 @@ export interface SharePayload {
   readonly settings: {
     readonly timeout: number;
     readonly delay: number;
+    readonly burstRounds?: number;
+    readonly monitorDelay?: number;
     readonly cap: number;
     readonly corsMode: 'no-cors' | 'cors';
   };
@@ -222,7 +230,7 @@ export interface SharePayload {
 
 // ── Persistence schema ─────────────────────────────────────────────────────
 export interface PersistedSettings {
-  version: 2;
+  version: 2 | 3;
   endpoints: { url: string; enabled: boolean }[];
   settings: Settings;
   ui: {

--- a/src/lib/utils/persistence.ts
+++ b/src/lib/utils/persistence.ts
@@ -5,7 +5,7 @@ import { DEFAULT_SETTINGS } from '../types';
 import type { PersistedSettings, ActiveView } from '../types';
 
 const STORAGE_KEY = 'sonde_v2_settings';
-const CURRENT_VERSION = 2;
+const CURRENT_VERSION = 3;
 
 export function loadPersistedSettings(): PersistedSettings | null {
   try {
@@ -33,12 +33,28 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
   const version = typeof record['version'] === 'number' ? record['version'] : 0;
 
   if (version === CURRENT_VERSION) {
-    // Validate shape minimally before returning
-    return normalizeV2(record);
+    return normalizeV3(record);
+  }
+
+  if (version === 2) {
+    // v2 → v3: add burstRounds + monitorDelay, migrate delay
+    const v2 = normalizeV2(record);
+    if (!v2) return null;
+    const oldDelay = v2.settings.delay;
+    return {
+      ...v2,
+      version: 3,
+      settings: {
+        ...v2.settings,
+        delay: DEFAULT_SETTINGS.delay,
+        burstRounds: DEFAULT_SETTINGS.burstRounds,
+        monitorDelay: oldDelay > 0 ? oldDelay : DEFAULT_SETTINGS.monitorDelay,
+      },
+    };
   }
 
   if (version === 1) {
-    // v1 → v2: add ui object, normalize settings shape
+    // v1 → v2 → v3: add ui object, normalize settings, then migrate to v3
     const rawEndpoints = Array.isArray(record['endpoints']) ? record['endpoints'] : [];
     const endpoints = rawEndpoints
       .filter((e): e is Record<string, unknown> => e !== null && typeof e === 'object')
@@ -47,8 +63,8 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
         enabled: typeof e['enabled'] === 'boolean' ? e['enabled'] : true,
       }));
 
-    const v2: PersistedSettings = {
-      version: 2,
+    return {
+      version: 3,
       endpoints,
       settings: { ...DEFAULT_SETTINGS },
       ui: {
@@ -56,7 +72,6 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
         activeView: 'split' as ActiveView,
       },
     };
-    return v2;
   }
 
   return null;
@@ -82,6 +97,8 @@ function normalizeV2(record: Record<string, unknown>): PersistedSettings | null 
         typeof rawSettings['timeout'] === 'number' ? rawSettings['timeout'] : DEFAULT_SETTINGS.timeout,
       delay:
         typeof rawSettings['delay'] === 'number' ? rawSettings['delay'] : DEFAULT_SETTINGS.delay,
+      burstRounds: DEFAULT_SETTINGS.burstRounds,
+      monitorDelay: DEFAULT_SETTINGS.monitorDelay,
       cap: typeof rawSettings['cap'] === 'number' ? rawSettings['cap'] : DEFAULT_SETTINGS.cap,
       corsMode:
         rawSettings['corsMode'] === 'cors' || rawSettings['corsMode'] === 'no-cors'
@@ -107,6 +124,64 @@ function normalizeV2(record: Record<string, unknown>): PersistedSettings | null 
 
     return {
       version: 2,
+      endpoints,
+      settings,
+      ui: { expandedCards, activeView },
+    };
+  } catch {
+    return null;
+  }
+}
+
+function normalizeV3(record: Record<string, unknown>): PersistedSettings | null {
+  try {
+    const rawEndpoints = Array.isArray(record['endpoints']) ? record['endpoints'] : [];
+    const endpoints = rawEndpoints
+      .filter((e): e is Record<string, unknown> => e !== null && typeof e === 'object')
+      .map((e) => ({
+        url: typeof e['url'] === 'string' ? e['url'] : '',
+        enabled: typeof e['enabled'] === 'boolean' ? e['enabled'] : true,
+      }));
+
+    const rawSettings =
+      record['settings'] !== null && typeof record['settings'] === 'object'
+        ? (record['settings'] as Record<string, unknown>)
+        : {};
+
+    const settings = {
+      timeout:
+        typeof rawSettings['timeout'] === 'number' ? rawSettings['timeout'] : DEFAULT_SETTINGS.timeout,
+      delay:
+        typeof rawSettings['delay'] === 'number' ? rawSettings['delay'] : DEFAULT_SETTINGS.delay,
+      burstRounds:
+        typeof rawSettings['burstRounds'] === 'number' ? rawSettings['burstRounds'] : DEFAULT_SETTINGS.burstRounds,
+      monitorDelay:
+        typeof rawSettings['monitorDelay'] === 'number' ? rawSettings['monitorDelay'] : DEFAULT_SETTINGS.monitorDelay,
+      cap: typeof rawSettings['cap'] === 'number' ? rawSettings['cap'] : DEFAULT_SETTINGS.cap,
+      corsMode:
+        rawSettings['corsMode'] === 'cors' || rawSettings['corsMode'] === 'no-cors'
+          ? rawSettings['corsMode']
+          : DEFAULT_SETTINGS.corsMode,
+    };
+
+    const rawUi =
+      record['ui'] !== null && typeof record['ui'] === 'object'
+        ? (record['ui'] as Record<string, unknown>)
+        : {};
+
+    const expandedCards = Array.isArray(rawUi['expandedCards'])
+      ? (rawUi['expandedCards'] as unknown[]).filter((x): x is string => typeof x === 'string')
+      : [];
+
+    const activeView: ActiveView =
+      rawUi['activeView'] === 'timeline' ||
+      rawUi['activeView'] === 'heatmap' ||
+      rawUi['activeView'] === 'split'
+        ? rawUi['activeView']
+        : 'split';
+
+    return {
+      version: 3,
       endpoints,
       settings,
       ui: { expandedCards, activeView },

--- a/src/lib/utils/persistence.ts
+++ b/src/lib/utils/persistence.ts
@@ -48,7 +48,7 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
         ...v2.settings,
         delay: DEFAULT_SETTINGS.delay,
         burstRounds: DEFAULT_SETTINGS.burstRounds,
-        monitorDelay: oldDelay > 0 ? oldDelay : DEFAULT_SETTINGS.monitorDelay,
+        monitorDelay: oldDelay >= 0 ? oldDelay : DEFAULT_SETTINGS.monitorDelay,
       },
     };
   }

--- a/src/lib/utils/statistics.ts
+++ b/src/lib/utils/statistics.ts
@@ -124,7 +124,7 @@ export function computeEndpointStatistics(
   // ── Tier 2 averages ───────────────────────────────────────────────────
   let tier2Averages: EndpointStatistics['tier2Averages'];
   if (tier2Samples.length > 0) {
-    const avg = (field: keyof NonNullable<MeasurementSample['tier2']>) =>
+    const avg = (field: 'dnsLookup' | 'tcpConnect' | 'tlsHandshake' | 'ttfb' | 'contentTransfer') =>
       tier2Samples.reduce((sum, s) => sum + s.tier2![field], 0) / tier2Samples.length;
 
     tier2Averages = {

--- a/tests/unit/persistence.test.ts
+++ b/tests/unit/persistence.test.ts
@@ -20,17 +20,19 @@ describe('persistence', () => {
     expect(loadPersistedSettings()).toBeNull();
   });
 
-  it('round-trips settings correctly', () => {
+  it('round-trips v3 settings correctly', () => {
     const settings: PersistedSettings = {
-      version: 2,
+      version: 3,
       endpoints: [{ url: 'https://example.com', enabled: true }],
-      settings: { timeout: 5000, delay: 1000, cap: 0, corsMode: 'no-cors' },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 3000, cap: 0, corsMode: 'no-cors' },
       ui: { expandedCards: [], activeView: 'timeline' },
     };
     saveSettings(settings);
     const loaded = loadPersistedSettings();
-    expect(loaded?.version).toBe(2);
+    expect(loaded?.version).toBe(3);
     expect(loaded?.endpoints[0]?.url).toBe('https://example.com');
+    expect(loaded?.settings.burstRounds).toBe(50);
+    expect(loaded?.settings.monitorDelay).toBe(3000);
   });
 
   it('returns null for corrupt data', () => {
@@ -39,9 +41,25 @@ describe('persistence', () => {
     expect(loadPersistedSettings()).toBeNull();
   });
 
-  it('migrates v1 data to v2', () => {
+  it('migrates v1 data to v3', () => {
     const v1Data = { version: 1, endpoints: [{ url: 'https://example.com' }] };
     const migrated = migrateSettings(v1Data);
-    expect(migrated?.version).toBe(2);
+    expect(migrated?.version).toBe(3);
+    expect(migrated?.settings.burstRounds).toBe(50);
+    expect(migrated?.settings.monitorDelay).toBe(3000);
+  });
+
+  it('migrates v2 data to v3 with old delay as monitorDelay', () => {
+    const v2Data = {
+      version: 2,
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 500, cap: 0, corsMode: 'no-cors' },
+      ui: { expandedCards: [], activeView: 'split' },
+    };
+    const migrated = migrateSettings(v2Data);
+    expect(migrated?.version).toBe(3);
+    expect(migrated?.settings.monitorDelay).toBe(500);
+    expect(migrated?.settings.burstRounds).toBe(50);
+    expect(migrated?.settings.delay).toBe(0);
   });
 });

--- a/tests/unit/types.test.ts
+++ b/tests/unit/types.test.ts
@@ -80,7 +80,9 @@ describe('types', () => {
 
   it('DEFAULT_SETTINGS has correct values', () => {
     expect(DEFAULT_SETTINGS.timeout).toBe(5000);
-    expect(DEFAULT_SETTINGS.delay).toBe(1000);
+    expect(DEFAULT_SETTINGS.delay).toBe(0);
+    expect(DEFAULT_SETTINGS.burstRounds).toBe(50);
+    expect(DEFAULT_SETTINGS.monitorDelay).toBe(3000);
     expect(DEFAULT_SETTINGS.cap).toBe(0);
     expect(DEFAULT_SETTINGS.corsMode).toBe('no-cors');
   });


### PR DESCRIPTION
## Summary

- **Response-gated dispatch**: next round fires only after all workers respond (or straggler timeout), eliminating round overlap and self-inflicted network contention that caused high variance
- **Two-phase cadence**: burst phase (50 rounds, 0ms delay) establishes baseline rapidly, then auto-transitions to monitor phase (3s interval) for stability tracking
- **PerformanceObserver**: replaces `setTimeout(0)` + `getEntriesByType` polling with push-based Resource Timing extraction; `clearResourceTimings()` prevents unbounded buffer growth
- **Orphan protection**: `flushedRounds` set discards late responses for already-processed rounds, fixing a memory leak
- **Extended TimingPayload**: `connectionReused` and `protocol` fields extracted when TAO headers present
- **Settings v3 migration**: `burstRounds` and `monitorDelay` added with backward-compatible persistence migration from v2

## Motivation

S80 (s80.us) shows significantly more stable latency readings than Sonde. Root cause analysis identified three issues: time-gated dispatch creating overlapping rounds, Resource Timing buffer growing unbounded (O(n) scans), and a fixed delay providing no distinction between baseline establishment and ongoing monitoring.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 new errors (51 pre-existing)
- [x] `npm test` — 329 passing (328→329, added v2→v3 migration test)
- [ ] Visual verification: burst phase fires rapidly, auto-transitions to monitor, footer shows phase label
- [ ] Compare jitter to S80 — burst phase should show comparable stability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Burst rounds" and "Monitor interval" settings; UI now shows burst vs. monitor labels in the footer.
  * Timing payload now exposes connection reuse and protocol info.

* **Improvements**
  * More reliable resource-timing capture with fallback handling.
  * Measurement rounds gated to avoid late/duplicate responses.
  * Persisted settings schema upgraded with automatic migrations and updated defaults.

* **Tests**
  * Unit tests updated for the new settings schema and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->