### PR TITLE
fix: harden share validation, eliminate FooterBar O(n) scan, add lane drag-to-reorder

### DIFF
--- a/src/lib/components/FooterBar.svelte
+++ b/src/lib/components/FooterBar.svelte
@@ -12,17 +12,7 @@
   let monitorDelay = $derived($settingsStore.monitorDelay);
   let timeout = $derived($settingsStore.timeout);
 
-  let errorCount = $derived.by(() => {
-    let errors = 0;
-    let timeouts = 0;
-    for (const ep of Object.values($measurementStore.endpoints)) {
-      for (const s of ep.samples) {
-        if (s.status === 'error') errors++;
-        if (s.status === 'timeout') timeouts++;
-      }
-    }
-    return { errors, timeouts };
-  });
+  let errorCount = $derived({ errors: $measurementStore.errorCount, timeouts: $measurementStore.timeoutCount });
 
   let progressLabel = $derived.by(() => {
     const total = cap > 0 ? cap : '∞';

--- a/src/lib/components/Lane.svelte
+++ b/src/lib/components/Lane.svelte
@@ -20,6 +20,7 @@
     noTransition = false,
     translateY = 0,
     onGripPointerDown = undefined,
+    onGripKeyDown = undefined,
     children,
   }: {
     endpointId: string;
@@ -39,6 +40,7 @@
     noTransition?: boolean;
     translateY?: number;
     onGripPointerDown?: (e: PointerEvent) => void;
+    onGripKeyDown?: (e: KeyboardEvent) => void;
     children?: import('svelte').Snippet;
   } = $props();
 
@@ -90,6 +92,7 @@
         data-endpoint-id={endpointId}
         type="button"
         onpointerdown={onGripPointerDown}
+        onkeydown={onGripKeyDown}
       >
         <svg width="10" height="14" viewBox="0 0 10 14" aria-hidden="true">
           {#each GRIP_DOTS as [cx, cy], i (i)}
@@ -124,6 +127,7 @@
           data-endpoint-id={endpointId}
           type="button"
           onpointerdown={onGripPointerDown}
+          onkeydown={onGripKeyDown}
         >
           <svg width="10" height="14" viewBox="0 0 10 14" aria-hidden="true">
             {#each GRIP_DOTS as [cx, cy], i (i)}

--- a/src/lib/components/Lane.svelte
+++ b/src/lib/components/Lane.svelte
@@ -83,7 +83,7 @@
   style:--timing-hover="{tokens.timing.btnHover}ms"
 >
   <div class="lane-panel" class:sr-only={compact}>
-    {#if showGrip}
+    {#if showGrip && !compact}
       <button
         class="lane-grip"
         aria-label="Reorder lane"
@@ -116,7 +116,7 @@
     {/if}
   </div>
   {#if compact}
-    <div class="lane-compact-header" aria-hidden="true">
+    <div class="lane-compact-header">
       {#if showGrip}
         <button
           class="lane-grip lane-grip--compact"

--- a/src/lib/components/Lane.svelte
+++ b/src/lib/components/Lane.svelte
@@ -16,6 +16,7 @@
     compact = false,
     showGrip = true,
     dragging = false,
+    settling = false,
     translateY = 0,
     onGripPointerDown = undefined,
     children,
@@ -33,6 +34,7 @@
     compact?: boolean;
     showGrip?: boolean;
     dragging?: boolean;
+    settling?: boolean;
     translateY?: number;
     onGripPointerDown?: (e: PointerEvent) => void;
     children?: import('svelte').Snippet;
@@ -58,6 +60,7 @@
   class="lane"
   class:compact={compact}
   class:is-dragging={dragging}
+  class:is-settling={settling}
   aria-label="Endpoint {url}"
   data-dragging={dragging ? 'true' : undefined}
   style:--drag-translate="{translateY}px"
@@ -161,17 +164,35 @@
     transform: translateY(var(--drag-translate, 0px));
     transition: border-color var(--timing-hover) ease, box-shadow var(--timing-hover) ease;
   }
-  .lane:not(.is-dragging) {
+  /* Neighbors shift with spring easing */
+  .lane:not(.is-dragging):not(.is-settling) {
     transition:
-      transform 200ms cubic-bezier(0.4, 0.0, 0.2, 1),
+      transform 250ms cubic-bezier(0.34, 1.56, 0.64, 1),
       border-color var(--timing-hover) ease,
       box-shadow var(--timing-hover) ease;
+  }
+
+  /* Pickup: pop-lift keyframe — overshoot scale then settle */
+  @keyframes drag-lift {
+    0%   { transform: translateY(var(--drag-translate, 0px)) scale(1); opacity: 1; }
+    40%  { transform: translateY(var(--drag-translate, 0px)) scale(1.03); opacity: 0.92; }
+    100% { transform: translateY(var(--drag-translate, 0px)) scale(1.01); opacity: 0.92; }
   }
   .lane.is-dragging {
     opacity: 0.92;
     transform: translateY(var(--drag-translate, 0px)) scale(1.01);
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
     z-index: 10;
+    animation: drag-lift 180ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  }
+
+  /* Drop settle: spring back to resting state */
+  .lane.is-settling {
+    z-index: 10;
+    transition:
+      transform 280ms cubic-bezier(0.34, 1.56, 0.64, 1),
+      opacity 280ms ease-out,
+      box-shadow 280ms ease-out;
   }
   .lane:hover {
     border-color: var(--glass-highlight);

--- a/src/lib/components/Lane.svelte
+++ b/src/lib/components/Lane.svelte
@@ -86,7 +86,7 @@
         onpointerdown={onGripPointerDown}
       >
         <svg width="10" height="14" viewBox="0 0 10 14" aria-hidden="true">
-          {#each GRIP_DOTS as [cx, cy]}
+          {#each GRIP_DOTS as [cx, cy], i (i)}
             <circle {cx} {cy} r="1.5" fill="currentColor" />
           {/each}
         </svg>
@@ -120,7 +120,7 @@
           onpointerdown={onGripPointerDown}
         >
           <svg width="10" height="14" viewBox="0 0 10 14" aria-hidden="true">
-            {#each GRIP_DOTS as [cx, cy]}
+            {#each GRIP_DOTS as [cx, cy], i (i)}
               <circle {cx} {cy} r="1.5" fill="currentColor" />
             {/each}
           </svg>

--- a/src/lib/components/Lane.svelte
+++ b/src/lib/components/Lane.svelte
@@ -17,6 +17,7 @@
     showGrip = true,
     dragging = false,
     settling = false,
+    noTransition = false,
     translateY = 0,
     onGripPointerDown = undefined,
     children,
@@ -35,6 +36,7 @@
     showGrip?: boolean;
     dragging?: boolean;
     settling?: boolean;
+    noTransition?: boolean;
     translateY?: number;
     onGripPointerDown?: (e: PointerEvent) => void;
     children?: import('svelte').Snippet;
@@ -61,6 +63,7 @@
   class:compact={compact}
   class:is-dragging={dragging}
   class:is-settling={settling}
+  class:no-transition={noTransition}
   aria-label="Endpoint {url}"
   data-dragging={dragging ? 'true' : undefined}
   style:--drag-translate="{translateY}px"
@@ -184,6 +187,11 @@
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
     z-index: 10;
     animation: drag-lift 180ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  }
+
+  /* Suppress transitions during DOM reorder to prevent neighbor twitch */
+  .lane.no-transition {
+    transition: none !important;
   }
 
   /* Drop settle: spring back to resting state */

--- a/src/lib/components/Lane.svelte
+++ b/src/lib/components/Lane.svelte
@@ -14,6 +14,10 @@
     ready,
     lastLatency = null,
     compact = false,
+    showGrip = true,
+    dragging = false,
+    translateY = 0,
+    onGripPointerDown = undefined,
     children,
   }: {
     endpointId: string;
@@ -27,8 +31,18 @@
     ready: boolean;
     lastLatency?: number | null;
     compact?: boolean;
+    showGrip?: boolean;
+    dragging?: boolean;
+    translateY?: number;
+    onGripPointerDown?: (e: PointerEvent) => void;
     children?: import('svelte').Snippet;
   } = $props();
+
+  const GRIP_DOTS = [
+    [2, 2], [8, 2],
+    [2, 7], [8, 7],
+    [2, 12], [8, 12],
+  ] as const;
 
   function fmt(ms: number): string {
     return `${Math.round(ms)}ms`;
@@ -43,7 +57,10 @@
   id="lane-{endpointId}"
   class="lane"
   class:compact={compact}
+  class:is-dragging={dragging}
   aria-label="Endpoint {url}"
+  data-dragging={dragging ? 'true' : undefined}
+  style:--drag-translate="{translateY}px"
   style:--ep-color={color}
   style:--t1={tokens.color.text.t1}
   style:--t2={tokens.color.text.t2}
@@ -60,6 +77,21 @@
   style:--timing-hover="{tokens.timing.btnHover}ms"
 >
   <div class="lane-panel" class:sr-only={compact}>
+    {#if showGrip}
+      <button
+        class="lane-grip"
+        aria-label="Reorder lane"
+        data-endpoint-id={endpointId}
+        type="button"
+        onpointerdown={onGripPointerDown}
+      >
+        <svg width="10" height="14" viewBox="0 0 10 14" aria-hidden="true">
+          {#each GRIP_DOTS as [cx, cy]}
+            <circle {cx} {cy} r="1.5" fill="currentColor" />
+          {/each}
+        </svg>
+      </button>
+    {/if}
     <div class="lane-url">{url}</div>
     <div class="lane-hero" aria-label="P50 latency {fmt(p50)}">
       <span class="hero-value">{Math.round(p50)}</span>
@@ -79,6 +111,21 @@
   </div>
   {#if compact}
     <div class="lane-compact-header" aria-hidden="true">
+      {#if showGrip}
+        <button
+          class="lane-grip lane-grip--compact"
+          aria-label="Reorder lane"
+          data-endpoint-id={endpointId}
+          type="button"
+          onpointerdown={onGripPointerDown}
+        >
+          <svg width="10" height="14" viewBox="0 0 10 14" aria-hidden="true">
+            {#each GRIP_DOTS as [cx, cy]}
+              <circle {cx} {cy} r="1.5" fill="currentColor" />
+            {/each}
+          </svg>
+        </button>
+      {/if}
       <span class="ch-dot" style:background={color}></span>
       <span class="ch-url">{url}</span>
       <span class="ch-hero" style:color={color}>{Math.round(p50)}<span class="ch-hero-unit">ms</span></span>
@@ -111,7 +158,20 @@
     border: 1px solid var(--lane-border);
     backdrop-filter: blur(20px) saturate(1.2);
     -webkit-backdrop-filter: blur(20px) saturate(1.2);
+    transform: translateY(var(--drag-translate, 0px));
     transition: border-color var(--timing-hover) ease, box-shadow var(--timing-hover) ease;
+  }
+  .lane:not(.is-dragging) {
+    transition:
+      transform 200ms cubic-bezier(0.4, 0.0, 0.2, 1),
+      border-color var(--timing-hover) ease,
+      box-shadow var(--timing-hover) ease;
+  }
+  .lane.is-dragging {
+    opacity: 0.92;
+    transform: translateY(var(--drag-translate, 0px)) scale(1.01);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+    z-index: 10;
   }
   .lane:hover {
     border-color: var(--glass-highlight);
@@ -230,6 +290,34 @@
     font-family: var(--mono); font-size: 10px; font-weight: 300;
     color: var(--t2);
   }
+
+  /* Grip handle */
+  .lane-grip {
+    display: flex; align-items: center; justify-content: center;
+    width: 20px; height: 32px; flex-shrink: 0;
+    background: none; border: none; padding: 0;
+    color: var(--t4);
+    cursor: grab;
+    touch-action: none;
+    border-radius: 4px;
+    transition: color var(--timing-hover) ease, background var(--timing-hover) ease;
+  }
+  .lane-grip:hover {
+    color: var(--t2);
+    background: rgba(255, 255, 255, 0.05);
+  }
+  .lane-grip:active { cursor: grabbing; }
+  .lane-panel .lane-grip {
+    position: absolute;
+    left: 6px;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+  .lane-compact-header .lane-grip {
+    pointer-events: auto;
+    flex-shrink: 0;
+  }
+  .lane-grip--compact { height: 22px; }
 
   /* Shift now-label below compact header */
   .lane.compact .now-label { top: 34px; }

--- a/src/lib/components/LanesView.svelte
+++ b/src/lib/components/LanesView.svelte
@@ -108,6 +108,95 @@
 
   let lanesEl: HTMLDivElement;
 
+  // ── Drag-to-reorder state ──────────────────────────────────────────────────
+  interface DragState {
+    pointerId: number;
+    fromIndex: number;
+    startY: number;
+    cardHeight: number;
+    toIndex: number;
+  }
+
+  let dragState = $state<DragState | null>(null);
+  let dragOffsets = $state<Record<number, number>>({});
+
+  function indexOfEndpoint(id: string): number {
+    return endpoints.findIndex(ep => ep.id === id);
+  }
+
+  function handleGripPointerDown(e: PointerEvent): void {
+    if (e.button !== 0 && e.pointerType === 'mouse') return;
+
+    const grip = e.currentTarget as HTMLElement;
+    const endpointId = grip.dataset['endpointId'];
+    if (!endpointId) return;
+
+    const fromIndex = indexOfEndpoint(endpointId);
+    if (fromIndex === -1) return;
+
+    const article = lanesEl.querySelector(`#lane-${endpointId}`) as HTMLElement | null;
+    if (!article) return;
+    const cardHeight = article.getBoundingClientRect().height + tokens.lane.gapPx;
+
+    grip.setPointerCapture(e.pointerId);
+    e.preventDefault();
+
+    dragState = {
+      pointerId: e.pointerId,
+      fromIndex,
+      startY: e.clientY,
+      cardHeight,
+      toIndex: fromIndex,
+    };
+    dragOffsets = {};
+  }
+
+  function handleGripPointerMove(e: PointerEvent): void {
+    if (!dragState || e.pointerId !== dragState.pointerId) return;
+    e.preventDefault();
+
+    const deltaY = e.clientY - dragState.startY;
+    const count = endpoints.length;
+
+    const maxUp = -(dragState.fromIndex * dragState.cardHeight);
+    const maxDown = (count - 1 - dragState.fromIndex) * dragState.cardHeight;
+    const clampedDelta = Math.max(maxUp, Math.min(maxDown, deltaY));
+
+    const sign = clampedDelta >= 0 ? 1 : -1;
+    const newToIndex = Math.max(
+      0,
+      Math.min(count - 1, dragState.fromIndex + Math.round(clampedDelta / dragState.cardHeight)),
+    );
+
+    const offsets: Record<number, number> = {};
+    for (let i = 0; i < count; i++) {
+      if (i === dragState.fromIndex) continue;
+      const isInRange =
+        sign > 0
+          ? i > dragState.fromIndex && i <= newToIndex
+          : i < dragState.fromIndex && i >= newToIndex;
+      if (isInRange) {
+        offsets[i] = -sign * dragState.cardHeight;
+      }
+    }
+    offsets[dragState.fromIndex] = clampedDelta;
+
+    dragOffsets = offsets;
+    dragState = { ...dragState, toIndex: newToIndex };
+  }
+
+  function handleGripPointerUp(e: PointerEvent): void {
+    if (!dragState || e.pointerId !== dragState.pointerId) return;
+
+    const { fromIndex, toIndex } = dragState;
+    dragState = null;
+    dragOffsets = {};
+
+    if (fromIndex !== toIndex) {
+      endpointStore.reorderEndpoint(fromIndex, toIndex);
+    }
+  }
+
   function handleMouseMove(e: MouseEvent): void {
     const lane = (e.target as HTMLElement).closest('.lane');
     const chartEl = lane?.querySelector('.lane-chart') as HTMLElement | null;
@@ -161,6 +250,8 @@
   class:grid-2col={layoutMode === 'compact-2col'}
   onmousemove={handleMouseMove}
   onmouseleave={handleMouseLeave}
+  onpointermove={handleGripPointerMove}
+  onpointerup={handleGripPointerUp}
   style:--lanes-gap="{tokens.lane.gapPx}px"
   style:--lanes-pad-x="{tokens.lane.paddingX}px"
   style:--lanes-pad-y="{tokens.lane.paddingY}px"
@@ -170,9 +261,11 @@
       <span>Add an endpoint to begin</span>
     </div>
   {:else}
-    {#each endpoints as ep (ep.id)}
+    {#each endpoints as ep, i (ep.id)}
       {@const laneProps = getLaneProps(ep.id)}
       {@const lastLatency = $measurementStore.endpoints[ep.id]?.lastLatency ?? null}
+      {@const isDragging = dragState?.fromIndex === i}
+      {@const offset = dragOffsets[i] ?? 0}
       <Lane
         endpointId={ep.id}
         color={ep.color}
@@ -185,6 +278,10 @@
         ready={laneProps.ready}
         {lastLatency}
         compact={isCompact}
+        showGrip={endpoints.length > 1}
+        dragging={isDragging}
+        translateY={offset}
+        onGripPointerDown={handleGripPointerDown}
       >
           {@const allPoints = frameData.pointsByEndpoint.get(ep.id) ?? []}
           {@const windowedPoints = allPoints.filter(p => p.round >= visibleStart && p.round <= visibleEnd)}

--- a/src/lib/components/LanesView.svelte
+++ b/src/lib/components/LanesView.svelte
@@ -127,6 +127,30 @@
     return endpoints.findIndex(ep => ep.id === id);
   }
 
+  function handleGripKeyDown(e: KeyboardEvent): void {
+    if (reorderPending) return;
+    if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
+    e.preventDefault();
+
+    const grip = e.currentTarget as HTMLElement;
+    const endpointId = grip.dataset['endpointId'];
+    if (!endpointId) return;
+
+    const fromIndex = indexOfEndpoint(endpointId);
+    if (fromIndex === -1) return;
+
+    const toIndex = e.key === 'ArrowUp' ? fromIndex - 1 : fromIndex + 1;
+    if (toIndex < 0 || toIndex >= endpoints.length) return;
+
+    endpointStore.reorderEndpoint(endpoints[fromIndex].id, endpoints[toIndex].id);
+
+    // Re-focus the grip after DOM reorder
+    requestAnimationFrame(() => {
+      const newGrip = lanesEl.querySelector(`[data-endpoint-id="${endpointId}"]`) as HTMLElement | null;
+      newGrip?.focus();
+    });
+  }
+
   function handleGripPointerDown(e: PointerEvent): void {
     if (reorderPending) return;
     if (e.button !== 0 && e.pointerType === 'mouse') return;
@@ -221,6 +245,10 @@
       }
     }
 
+    // Capture IDs now — the reactive `endpoints` array may change during the delay
+    const fromId = endpoints[fromIndex].id;
+    const toId = endpoints[toIndex].id;
+
     // Switch from is-dragging to is-settling — spring transition to target
     dragState = null;
     settlingIndex = fromIndex;
@@ -234,7 +262,7 @@
         suppressTransition = true;
         settlingIndex = null;
         dragOffsets = {};
-        endpointStore.reorderEndpoint(endpoints[fromIndex].id, endpoints[toIndex].id);
+        endpointStore.reorderEndpoint(fromId, toId);
         // Re-enable transitions after the DOM settles
         requestAnimationFrame(() => {
           suppressTransition = false;
@@ -242,6 +270,13 @@
         });
       }, 280); // matches the 280ms settling transition duration
     });
+  }
+
+  function handleGripPointerCancel(e: PointerEvent): void {
+    if (!dragState || e.pointerId !== dragState.pointerId) return;
+    dragState = null;
+    dragOffsets = {};
+    settlingIndex = null;
   }
 
   function handleMouseMove(e: MouseEvent): void {
@@ -299,6 +334,7 @@
   onmouseleave={handleMouseLeave}
   onpointermove={handleGripPointerMove}
   onpointerup={handleGripPointerUp}
+  onpointercancel={handleGripPointerCancel}
   style:--lanes-gap="{tokens.lane.gapPx}px"
   style:--lanes-pad-x="{tokens.lane.paddingX}px"
   style:--lanes-pad-y="{tokens.lane.paddingY}px"
@@ -332,6 +368,7 @@
         noTransition={suppressTransition}
         translateY={offset}
         onGripPointerDown={handleGripPointerDown}
+        onGripKeyDown={handleGripKeyDown}
       >
           {@const allPoints = frameData.pointsByEndpoint.get(ep.id) ?? []}
           {@const windowedPoints = allPoints.filter(p => p.round >= visibleStart && p.round <= visibleEnd)}

--- a/src/lib/components/LanesView.svelte
+++ b/src/lib/components/LanesView.svelte
@@ -121,12 +121,14 @@
   let dragOffsets = $state<Record<number, number>>({});
   let settlingIndex = $state<number | null>(null);
   let suppressTransition = $state(false);
+  let reorderPending = $state(false);
 
   function indexOfEndpoint(id: string): number {
     return endpoints.findIndex(ep => ep.id === id);
   }
 
   function handleGripPointerDown(e: PointerEvent): void {
+    if (reorderPending) return;
     if (e.button !== 0 && e.pointerType === 'mouse') return;
 
     const grip = e.currentTarget as HTMLElement;
@@ -225,16 +227,18 @@
     dragOffsets = finalOffsets;
 
     // Wait for the spring transition to finish, then commit the reorder
+    reorderPending = true;
     requestAnimationFrame(() => {
       setTimeout(() => {
         // Suppress transitions so neighbors don't twitch during DOM reorder
         suppressTransition = true;
         settlingIndex = null;
         dragOffsets = {};
-        endpointStore.reorderEndpoint(fromIndex, toIndex);
+        endpointStore.reorderEndpoint(endpoints[fromIndex].id, endpoints[toIndex].id);
         // Re-enable transitions after the DOM settles
         requestAnimationFrame(() => {
           suppressTransition = false;
+          reorderPending = false;
         });
       }, 280); // matches the 280ms settling transition duration
     });
@@ -322,7 +326,7 @@
         ready={laneProps.ready}
         {lastLatency}
         compact={isCompact}
-        showGrip={endpoints.length > 1}
+        showGrip={endpoints.length > 1 && layoutMode !== 'compact-2col'}
         dragging={isDragging}
         settling={isSettling}
         noTransition={suppressTransition}

--- a/src/lib/components/LanesView.svelte
+++ b/src/lib/components/LanesView.svelte
@@ -119,6 +119,7 @@
 
   let dragState = $state<DragState | null>(null);
   let dragOffsets = $state<Record<number, number>>({});
+  let settlingIndex = $state<number | null>(null);
 
   function indexOfEndpoint(id: string): number {
     return endpoints.findIndex(ep => ep.id === id);
@@ -217,17 +218,18 @@
       }
     }
 
-    // Remove is-dragging so the card gets the neighbor transition
+    // Switch from is-dragging to is-settling — spring transition to target
     dragState = null;
+    settlingIndex = fromIndex;
     dragOffsets = finalOffsets;
 
-    // Wait for the CSS transition to finish, then commit the reorder
-    // and clear transforms in the same frame
+    // Wait for the spring transition to finish, then commit the reorder
     requestAnimationFrame(() => {
       setTimeout(() => {
+        settlingIndex = null;
         dragOffsets = {};
         endpointStore.reorderEndpoint(fromIndex, toIndex);
-      }, 200); // matches the 200ms CSS transition duration
+      }, 280); // matches the 280ms settling transition duration
     });
   }
 
@@ -299,6 +301,7 @@
       {@const laneProps = getLaneProps(ep.id)}
       {@const lastLatency = $measurementStore.endpoints[ep.id]?.lastLatency ?? null}
       {@const isDragging = dragState?.fromIndex === i}
+      {@const isSettling = settlingIndex === i}
       {@const offset = dragOffsets[i] ?? 0}
       <Lane
         endpointId={ep.id}
@@ -314,6 +317,7 @@
         compact={isCompact}
         showGrip={endpoints.length > 1}
         dragging={isDragging}
+        settling={isSettling}
         translateY={offset}
         onGripPointerDown={handleGripPointerDown}
       >

--- a/src/lib/components/LanesView.svelte
+++ b/src/lib/components/LanesView.svelte
@@ -120,6 +120,7 @@
   let dragState = $state<DragState | null>(null);
   let dragOffsets = $state<Record<number, number>>({});
   let settlingIndex = $state<number | null>(null);
+  let suppressTransition = $state(false);
 
   function indexOfEndpoint(id: string): number {
     return endpoints.findIndex(ep => ep.id === id);
@@ -226,9 +227,15 @@
     // Wait for the spring transition to finish, then commit the reorder
     requestAnimationFrame(() => {
       setTimeout(() => {
+        // Suppress transitions so neighbors don't twitch during DOM reorder
+        suppressTransition = true;
         settlingIndex = null;
         dragOffsets = {};
         endpointStore.reorderEndpoint(fromIndex, toIndex);
+        // Re-enable transitions after the DOM settles
+        requestAnimationFrame(() => {
+          suppressTransition = false;
+        });
       }, 280); // matches the 280ms settling transition duration
     });
   }
@@ -318,6 +325,7 @@
         showGrip={endpoints.length > 1}
         dragging={isDragging}
         settling={isSettling}
+        noTransition={suppressTransition}
         translateY={offset}
         onGripPointerDown={handleGripPointerDown}
       >

--- a/src/lib/components/LanesView.svelte
+++ b/src/lib/components/LanesView.svelte
@@ -188,13 +188,47 @@
   function handleGripPointerUp(e: PointerEvent): void {
     if (!dragState || e.pointerId !== dragState.pointerId) return;
 
-    const { fromIndex, toIndex } = dragState;
-    dragState = null;
-    dragOffsets = {};
+    const { fromIndex, toIndex, cardHeight } = dragState;
 
-    if (fromIndex !== toIndex) {
-      endpointStore.reorderEndpoint(fromIndex, toIndex);
+    if (fromIndex === toIndex) {
+      // No move — just clean up
+      dragState = null;
+      dragOffsets = {};
+      return;
     }
+
+    // Animate the dragged card to its final resting position
+    // so there's no snap-back flash on drop.
+    const targetOffset = (toIndex - fromIndex) * cardHeight;
+    const finalOffsets: Record<number, number> = {};
+    finalOffsets[fromIndex] = targetOffset;
+
+    // Neighbors stay where they are (already shifted)
+    const count = endpoints.length;
+    const sign = toIndex > fromIndex ? 1 : -1;
+    for (let i = 0; i < count; i++) {
+      if (i === fromIndex) continue;
+      const isInRange =
+        sign > 0
+          ? i > fromIndex && i <= toIndex
+          : i < fromIndex && i >= toIndex;
+      if (isInRange) {
+        finalOffsets[i] = -sign * cardHeight;
+      }
+    }
+
+    // Remove is-dragging so the card gets the neighbor transition
+    dragState = null;
+    dragOffsets = finalOffsets;
+
+    // Wait for the CSS transition to finish, then commit the reorder
+    // and clear transforms in the same frame
+    requestAnimationFrame(() => {
+      setTimeout(() => {
+        dragOffsets = {};
+        endpointStore.reorderEndpoint(fromIndex, toIndex);
+      }, 200); // matches the 200ms CSS transition duration
+    });
   }
 
   function handleMouseMove(e: MouseEvent): void {

--- a/src/lib/share/hash-router.ts
+++ b/src/lib/share/hash-router.ts
@@ -81,6 +81,8 @@ export function applySharePayload(payload: SharePayload): string[] {
       startedAt: null,
       stoppedAt: null,
       freezeEvents: [],
+      errorCount: 0,
+      timeoutCount: 0,
     };
 
     measurementStore.loadSnapshot(snapshot);

--- a/src/lib/share/share-manager.ts
+++ b/src/lib/share/share-manager.ts
@@ -60,6 +60,8 @@ function validateSharePayload(data: unknown): SharePayload | null {
   if (!isNonNegativeFiniteNumber(s['timeout'])) return null;
   if (!isNonNegativeFiniteNumber(s['delay'])) return null;
   if (!isNonNegativeFiniteNumber(s['cap'])) return null;
+  if (s['burstRounds'] !== undefined && !isNonNegativeFiniteNumber(s['burstRounds'])) return null;
+  if (s['monitorDelay'] !== undefined && !isNonNegativeFiniteNumber(s['monitorDelay'])) return null;
   if (s['corsMode'] !== 'no-cors' && s['corsMode'] !== 'cors') return null;
 
   if (obj['results'] !== undefined) {
@@ -74,9 +76,9 @@ function validateSharePayload(data: unknown): SharePayload | null {
         if (sample === null || typeof sample !== 'object') return null;
         const samp = sample as Record<string, unknown>;
         if (
-          typeof samp['round'] !== 'number' ||
-          typeof samp['latency'] !== 'number' ||
-          typeof samp['status'] !== 'string'
+          !isNonNegativeFiniteNumber(samp['round']) ||
+          !isNonNegativeFiniteNumber(samp['latency']) ||
+          (samp['status'] !== 'ok' && samp['status'] !== 'timeout' && samp['status'] !== 'error')
         ) return null;
       }
     }

--- a/src/lib/share/share-manager.ts
+++ b/src/lib/share/share-manager.ts
@@ -51,7 +51,7 @@ function validateSharePayload(data: unknown): SharePayload | null {
     if (ep === null || typeof ep !== 'object') return null;
     const e = ep as Record<string, unknown>;
     if (!isHttpUrl(e['url'])) return null;
-    if ('enabled' in e && typeof e['enabled'] !== 'boolean') return null;
+    if (typeof e['enabled'] !== 'boolean') return null;
   }
 
   const settings = obj['settings'];

--- a/src/lib/share/share-manager.ts
+++ b/src/lib/share/share-manager.ts
@@ -29,6 +29,15 @@ function isFiniteNumber(v: unknown): boolean {
   return typeof v === 'number' && Number.isFinite(v);
 }
 
+function isNonNegativeFiniteNumber(v: unknown): boolean {
+  return isFiniteNumber(v) && (v as number) >= 0;
+}
+
+function isHttpUrl(v: unknown): boolean {
+  if (typeof v !== 'string' || v === '') return false;
+  return v.startsWith('http://') || v.startsWith('https://');
+}
+
 function validateSharePayload(data: unknown): SharePayload | null {
   if (data === null || typeof data !== 'object') return null;
   const obj = data as Record<string, unknown>;
@@ -36,34 +45,39 @@ function validateSharePayload(data: unknown): SharePayload | null {
   if (obj['v'] !== 1) return null;
   if (obj['mode'] !== 'config' && obj['mode'] !== 'results') return null;
   if (!Array.isArray(obj['endpoints'])) return null;
+  if ((obj['endpoints'] as unknown[]).length > 50) return null;
 
-  // Validate each endpoint has required fields
   for (const ep of obj['endpoints'] as unknown[]) {
     if (ep === null || typeof ep !== 'object') return null;
     const e = ep as Record<string, unknown>;
-    if (typeof e['url'] !== 'string') return null;
+    if (!isHttpUrl(e['url'])) return null;
     if ('enabled' in e && typeof e['enabled'] !== 'boolean') return null;
   }
 
   const settings = obj['settings'];
   if (settings === null || typeof settings !== 'object') return null;
   const s = settings as Record<string, unknown>;
-  if (!isFiniteNumber(s['timeout']) || !isFiniteNumber(s['delay']) || !isFiniteNumber(s['cap'])) {
-    return null;
-  }
+  if (!isNonNegativeFiniteNumber(s['timeout'])) return null;
+  if (!isNonNegativeFiniteNumber(s['delay'])) return null;
+  if (!isNonNegativeFiniteNumber(s['cap'])) return null;
+  if (s['corsMode'] !== 'no-cors' && s['corsMode'] !== 'cors') return null;
 
-  // Validate results array if present
   if (obj['results'] !== undefined) {
     if (!Array.isArray(obj['results'])) return null;
+    if ((obj['results'] as unknown[]).length > 50) return null;
     for (const result of obj['results'] as unknown[]) {
       if (result === null || typeof result !== 'object') return null;
       const r = result as Record<string, unknown>;
       if (!Array.isArray(r['samples'])) return null;
-      // Validate each sample has the required shape
+      if ((r['samples'] as unknown[]).length > 10_000) return null;
       for (const sample of r['samples'] as unknown[]) {
         if (sample === null || typeof sample !== 'object') return null;
-        const s = sample as Record<string, unknown>;
-        if (typeof s['round'] !== 'number' || typeof s['latency'] !== 'number' || typeof s['status'] !== 'string') return null;
+        const samp = sample as Record<string, unknown>;
+        if (
+          typeof samp['round'] !== 'number' ||
+          typeof samp['latency'] !== 'number' ||
+          typeof samp['status'] !== 'string'
+        ) return null;
       }
     }
   }

--- a/src/lib/stores/endpoints.ts
+++ b/src/lib/stores/endpoints.ts
@@ -64,14 +64,14 @@ function createEndpointStore() {
       );
     },
 
-    reorderEndpoint(fromIndex: number, toIndex: number): void {
+    reorderEndpoint(fromId: string, toId: string): void {
       update(endpoints => {
+        const fromIndex = endpoints.findIndex(ep => ep.id === fromId);
+        const toIndex = endpoints.findIndex(ep => ep.id === toId);
         if (
-          fromIndex === toIndex ||
-          fromIndex < 0 ||
-          toIndex < 0 ||
-          fromIndex >= endpoints.length ||
-          toIndex >= endpoints.length
+          fromIndex === -1 ||
+          toIndex === -1 ||
+          fromIndex === toIndex
         ) {
           return endpoints;
         }

--- a/src/lib/stores/endpoints.ts
+++ b/src/lib/stores/endpoints.ts
@@ -76,8 +76,9 @@ function createEndpointStore() {
           return endpoints;
         }
         const next = [...endpoints];
-        const [moved] = next.splice(fromIndex, 1);
-        next.splice(toIndex, 0, moved!);
+        const moved = next.splice(fromIndex, 1)[0];
+        if (moved === undefined) return endpoints;
+        next.splice(toIndex, 0, moved);
         return next;
       });
     },

--- a/src/lib/stores/endpoints.ts
+++ b/src/lib/stores/endpoints.ts
@@ -64,6 +64,24 @@ function createEndpointStore() {
       );
     },
 
+    reorderEndpoint(fromIndex: number, toIndex: number): void {
+      update(endpoints => {
+        if (
+          fromIndex === toIndex ||
+          fromIndex < 0 ||
+          toIndex < 0 ||
+          fromIndex >= endpoints.length ||
+          toIndex >= endpoints.length
+        ) {
+          return endpoints;
+        }
+        const next = [...endpoints];
+        const [moved] = next.splice(fromIndex, 1);
+        next.splice(toIndex, 0, moved!);
+        return next;
+      });
+    },
+
     setEndpoints(endpoints: Endpoint[]): void {
       set(endpoints);
     },

--- a/src/lib/stores/measurements.ts
+++ b/src/lib/stores/measurements.ts
@@ -77,7 +77,8 @@ function createMeasurementStore() {
       update(s => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { [endpointId]: _removed, ...rest } = s.endpoints;
-        return { ...s, endpoints: rest };
+        const { errorCount, timeoutCount } = recomputeCounts(rest);
+        return { ...s, endpoints: rest, errorCount, timeoutCount };
       });
     },
 

--- a/src/lib/stores/measurements.ts
+++ b/src/lib/stores/measurements.ts
@@ -20,7 +20,28 @@ const INITIAL_STATE: MeasurementState = {
   startedAt: null,
   stoppedAt: null,
   freezeEvents: [],
+  errorCount: 0,
+  timeoutCount: 0,
 };
+
+function countDelta(status: SampleStatus): { errors: number; timeouts: number } {
+  return {
+    errors: status === 'error' ? 1 : 0,
+    timeouts: status === 'timeout' ? 1 : 0,
+  };
+}
+
+function recomputeCounts(endpoints: MeasurementState['endpoints']): { errorCount: number; timeoutCount: number } {
+  let errorCount = 0;
+  let timeoutCount = 0;
+  for (const ep of Object.values(endpoints)) {
+    for (const sample of ep.samples) {
+      if (sample.status === 'error') errorCount++;
+      if (sample.status === 'timeout') timeoutCount++;
+    }
+  }
+  return { errorCount, timeoutCount };
+}
 
 function createMeasurementStore() {
   const { subscribe, set, update } = writable<MeasurementState>({ ...INITIAL_STATE });
@@ -88,8 +109,12 @@ function createMeasurementStore() {
         // Mutable push — O(1) amortized instead of O(n) spread
         existing.samples.push(sample);
 
+        const { errors, timeouts } = countDelta(status);
+
         return {
           ...s,
+          errorCount: s.errorCount + errors,
+          timeoutCount: s.timeoutCount + timeouts,
           endpoints: {
             ...s.endpoints,
             [endpointId]: {
@@ -114,6 +139,8 @@ function createMeasurementStore() {
       update(s => {
         // Clone the top-level endpoints map once to trigger reactivity
         const nextEndpoints = { ...s.endpoints };
+        let errorDelta = 0;
+        let timeoutDelta = 0;
 
         for (const entry of entries) {
           const existing = nextEndpoints[entry.endpointId];
@@ -145,6 +172,10 @@ function createMeasurementStore() {
             samples.splice(i, 0, sample);
           }
 
+          const { errors, timeouts } = countDelta(entry.status);
+          errorDelta += errors;
+          timeoutDelta += timeouts;
+
           // New endpoint object reference to trigger per-endpoint reactivity
           nextEndpoints[entry.endpointId] = {
             ...existing,
@@ -154,7 +185,12 @@ function createMeasurementStore() {
           };
         }
 
-        return { ...s, endpoints: nextEndpoints };
+        return {
+          ...s,
+          errorCount: s.errorCount + errorDelta,
+          timeoutCount: s.timeoutCount + timeoutDelta,
+          endpoints: nextEndpoints,
+        };
       });
     },
 
@@ -175,7 +211,8 @@ function createMeasurementStore() {
     },
 
     loadSnapshot(snapshot: MeasurementState): void {
-      set({ ...snapshot });
+      const { errorCount, timeoutCount } = recomputeCounts(snapshot.endpoints);
+      set({ ...snapshot, errorCount, timeoutCount });
     },
 
     reset(): void {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -106,6 +106,8 @@ export interface MeasurementState {
   startedAt: number | null;
   stoppedAt: number | null;
   freezeEvents: FreezeEvent[];
+  errorCount: number;
+  timeoutCount: number;
 }
 
 // ── Statistics store ───────────────────────────────────────────────────────

--- a/tests/unit/components/lane.test.ts
+++ b/tests/unit/components/lane.test.ts
@@ -86,4 +86,37 @@ describe('Lane', () => {
     const { container } = render(Lane, { props: { ...props, compact: true } });
     expect(container.querySelector('.lane.compact')).not.toBeNull();
   });
+
+  // ── Grip handle (drag-to-reorder) ───────────────────────────────────────────
+
+  it('renders a grip handle button in full mode', () => {
+    const { container } = render(Lane, { props });
+    const grip = container.querySelector('.lane-grip');
+    expect(grip).not.toBeNull();
+    expect(grip?.tagName.toLowerCase()).toBe('button');
+  });
+
+  it('grip handle has aria-label="Reorder lane"', () => {
+    const { container } = render(Lane, { props });
+    const grip = container.querySelector('.lane-grip');
+    expect(grip?.getAttribute('aria-label')).toBe('Reorder lane');
+  });
+
+  it('renders grip handle in compact mode', () => {
+    const { container } = render(Lane, { props: { ...props, compact: true } });
+    const grip = container.querySelector('.lane-grip');
+    expect(grip).not.toBeNull();
+  });
+
+  it('grip handle has data-endpoint-id matching endpointId', () => {
+    const { container } = render(Lane, { props });
+    const grip = container.querySelector('.lane-grip');
+    expect(grip?.getAttribute('data-endpoint-id')).toBe('ep-test-1');
+  });
+
+  it('hides grip when showGrip is false', () => {
+    const { container } = render(Lane, { props: { ...props, showGrip: false } });
+    const grip = container.querySelector('.lane-grip');
+    expect(grip).toBeNull();
+  });
 });

--- a/tests/unit/components/lanes-view.test.ts
+++ b/tests/unit/components/lanes-view.test.ts
@@ -1,8 +1,14 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { render } from '@testing-library/svelte';
+import { get } from 'svelte/store';
 import LanesView from '../../../src/lib/components/LanesView.svelte';
+import { endpointStore } from '../../../src/lib/stores/endpoints';
 
 describe('LanesView', () => {
+  beforeEach(() => {
+    endpointStore.reset();
+  });
+
   it('renders a lanes container', () => {
     const { container } = render(LanesView, { props: {} });
     expect(container.querySelector('.lanes')).not.toBeNull();
@@ -10,8 +16,23 @@ describe('LanesView', () => {
 
   it('renders lane cards for default endpoints', () => {
     const { container } = render(LanesView, { props: {} });
-    // Default store has 2 enabled endpoints (Google, Cloudflare)
     const lanes = container.querySelectorAll('.lane');
     expect(lanes.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('renders grip handles for each lane when multiple endpoints', () => {
+    const { container } = render(LanesView, { props: {} });
+    const grips = container.querySelectorAll('.lane-grip');
+    const lanes = container.querySelectorAll('.lane');
+    expect(grips.length).toBeGreaterThanOrEqual(lanes.length);
+  });
+
+  it('hides grip when only one endpoint is enabled', () => {
+    const eps = get(endpointStore);
+    eps.slice(1).forEach(ep => endpointStore.updateEndpoint(ep.id, { enabled: false }));
+
+    const { container } = render(LanesView, { props: {} });
+    const grips = container.querySelectorAll('.lane-grip');
+    expect(grips.length).toBe(0);
   });
 });

--- a/tests/unit/share-manager.test.ts
+++ b/tests/unit/share-manager.test.ts
@@ -275,6 +275,15 @@ describe('share-manager', () => {
       expect(decodeSharePayload(encoded)).toBeNull();
     });
 
+    it('rejects endpoint with missing enabled field', async () => {
+      const encoded = await manualEncode({
+        v: 1, mode: 'config',
+        endpoints: [{ url: 'https://example.com' }],
+        settings: validSettings,
+      });
+      expect(decodeSharePayload(encoded)).toBeNull();
+    });
+
     it('accepts valid sample with timeout status', async () => {
       const encoded = await manualEncode({
         v: 1, mode: 'results',

--- a/tests/unit/share-manager.test.ts
+++ b/tests/unit/share-manager.test.ts
@@ -207,6 +207,84 @@ describe('share-manager', () => {
       expect(decodeSharePayload(encoded)).toBeNull();
     });
 
+    // AC #2b — burstRounds and monitorDelay validation
+    it('rejects Infinity burstRounds', async () => {
+      const encoded = await manualEncode({
+        v: 1, mode: 'config',
+        endpoints: [{ url: 'https://example.com', enabled: true }],
+        settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors', burstRounds: Infinity },
+      });
+      expect(decodeSharePayload(encoded)).toBeNull();
+    });
+
+    it('rejects negative monitorDelay', async () => {
+      const encoded = await manualEncode({
+        v: 1, mode: 'config',
+        endpoints: [{ url: 'https://example.com', enabled: true }],
+        settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors', monitorDelay: -100 },
+      });
+      expect(decodeSharePayload(encoded)).toBeNull();
+    });
+
+    it('accepts valid burstRounds and monitorDelay', async () => {
+      const encoded = await manualEncode({
+        v: 1, mode: 'config',
+        endpoints: [{ url: 'https://example.com', enabled: true }],
+        settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors', burstRounds: 50, monitorDelay: 3000 },
+      });
+      expect(decodeSharePayload(encoded)).not.toBeNull();
+    });
+
+    it('accepts omitted burstRounds and monitorDelay', async () => {
+      const encoded = await manualEncode({
+        v: 1, mode: 'config',
+        endpoints: [{ url: 'https://example.com', enabled: true }],
+        settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors' },
+      });
+      expect(decodeSharePayload(encoded)).not.toBeNull();
+    });
+
+    // AC #2c — Sample value hardening
+    it('rejects NaN sample latency', async () => {
+      const encoded = await manualEncode({
+        v: 1, mode: 'results',
+        endpoints: [{ url: 'https://example.com', enabled: true }],
+        settings: validSettings,
+        results: [{ samples: [{ round: 0, latency: NaN, status: 'ok' }] }],
+      });
+      expect(decodeSharePayload(encoded)).toBeNull();
+    });
+
+    it('rejects negative sample round', async () => {
+      const encoded = await manualEncode({
+        v: 1, mode: 'results',
+        endpoints: [{ url: 'https://example.com', enabled: true }],
+        settings: validSettings,
+        results: [{ samples: [{ round: -1, latency: 50, status: 'ok' }] }],
+      });
+      expect(decodeSharePayload(encoded)).toBeNull();
+    });
+
+    it('rejects invalid sample status string', async () => {
+      const encoded = await manualEncode({
+        v: 1, mode: 'results',
+        endpoints: [{ url: 'https://example.com', enabled: true }],
+        settings: validSettings,
+        results: [{ samples: [{ round: 0, latency: 50, status: 'bogus' }] }],
+      });
+      expect(decodeSharePayload(encoded)).toBeNull();
+    });
+
+    it('accepts valid sample with timeout status', async () => {
+      const encoded = await manualEncode({
+        v: 1, mode: 'results',
+        endpoints: [{ url: 'https://example.com', enabled: true }],
+        settings: validSettings,
+        results: [{ samples: [{ round: 0, latency: 5000, status: 'timeout' }] }],
+      });
+      expect(decodeSharePayload(encoded)).not.toBeNull();
+    });
+
     // AC #3 — Array size limits
     it('rejects >50 endpoints', async () => {
       const endpoints = Array.from({ length: 51 }, (_, i) => ({

--- a/tests/unit/share-manager.test.ts
+++ b/tests/unit/share-manager.test.ts
@@ -124,4 +124,170 @@ describe('share-manager', () => {
     expect(url.startsWith('https://sonde.example.com')).toBe(true);
     expect(url).toContain('#s=');
   });
+
+  describe('validateSharePayload — hardened validation', () => {
+    async function manualEncode(data: unknown): Promise<string> {
+      const { default: LZString } = await import('lz-string');
+      return LZString.compressToEncodedURIComponent(JSON.stringify(data));
+    }
+
+    const validSettings = { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors' };
+
+    // AC #1 — URL scheme enforcement
+    it('rejects javascript: URLs', async () => {
+      const encoded = await manualEncode({
+        v: 1, mode: 'config',
+        endpoints: [{ url: 'javascript:alert(1)', enabled: true }],
+        settings: validSettings,
+      });
+      expect(decodeSharePayload(encoded)).toBeNull();
+    });
+
+    it('rejects data: URLs', async () => {
+      const encoded = await manualEncode({
+        v: 1, mode: 'config',
+        endpoints: [{ url: 'data:text/html,<h1>x</h1>', enabled: true }],
+        settings: validSettings,
+      });
+      expect(decodeSharePayload(encoded)).toBeNull();
+    });
+
+    it('rejects empty string URLs', async () => {
+      const encoded = await manualEncode({
+        v: 1, mode: 'config',
+        endpoints: [{ url: '', enabled: true }],
+        settings: validSettings,
+      });
+      expect(decodeSharePayload(encoded)).toBeNull();
+    });
+
+    it('rejects relative path URLs', async () => {
+      const encoded = await manualEncode({
+        v: 1, mode: 'config',
+        endpoints: [{ url: '/api/measure', enabled: true }],
+        settings: validSettings,
+      });
+      expect(decodeSharePayload(encoded)).toBeNull();
+    });
+
+    it('accepts http:// URLs', async () => {
+      const encoded = await manualEncode({
+        v: 1, mode: 'config',
+        endpoints: [{ url: 'http://example.com', enabled: true }],
+        settings: validSettings,
+      });
+      expect(decodeSharePayload(encoded)).not.toBeNull();
+    });
+
+    // AC #2 — Non-negative finite numbers
+    it('rejects Infinity timeout', async () => {
+      const encoded = await manualEncode({
+        v: 1, mode: 'config',
+        endpoints: [{ url: 'https://example.com', enabled: true }],
+        settings: { timeout: Infinity, delay: 0, cap: 0, corsMode: 'no-cors' },
+      });
+      expect(decodeSharePayload(encoded)).toBeNull();
+    });
+
+    it('rejects negative delay', async () => {
+      const encoded = await manualEncode({
+        v: 1, mode: 'config',
+        endpoints: [{ url: 'https://example.com', enabled: true }],
+        settings: { timeout: 5000, delay: -1, cap: 0, corsMode: 'no-cors' },
+      });
+      expect(decodeSharePayload(encoded)).toBeNull();
+    });
+
+    it('rejects negative cap', async () => {
+      const encoded = await manualEncode({
+        v: 1, mode: 'config',
+        endpoints: [{ url: 'https://example.com', enabled: true }],
+        settings: { timeout: 5000, delay: 0, cap: -5, corsMode: 'no-cors' },
+      });
+      expect(decodeSharePayload(encoded)).toBeNull();
+    });
+
+    // AC #3 — Array size limits
+    it('rejects >50 endpoints', async () => {
+      const endpoints = Array.from({ length: 51 }, (_, i) => ({
+        url: `https://ep${i}.example.com`, enabled: true,
+      }));
+      const encoded = await manualEncode({
+        v: 1, mode: 'config', endpoints, settings: validSettings,
+      });
+      expect(decodeSharePayload(encoded)).toBeNull();
+    });
+
+    it('accepts exactly 50 endpoints', async () => {
+      const endpoints = Array.from({ length: 50 }, (_, i) => ({
+        url: `https://ep${i}.example.com`, enabled: true,
+      }));
+      const encoded = await manualEncode({
+        v: 1, mode: 'config', endpoints, settings: validSettings,
+      });
+      expect(decodeSharePayload(encoded)).not.toBeNull();
+    });
+
+    it('rejects >50 results', async () => {
+      const results = Array.from({ length: 51 }, () => ({ samples: [] }));
+      const encoded = await manualEncode({
+        v: 1, mode: 'results',
+        endpoints: [{ url: 'https://example.com', enabled: true }],
+        settings: validSettings, results,
+      });
+      expect(decodeSharePayload(encoded)).toBeNull();
+    });
+
+    it('rejects >10,000 samples per result', async () => {
+      const samples = Array.from({ length: 10001 }, (_, i) => ({
+        round: i, latency: 50, status: 'ok',
+      }));
+      const encoded = await manualEncode({
+        v: 1, mode: 'results',
+        endpoints: [{ url: 'https://example.com', enabled: true }],
+        settings: validSettings, results: [{ samples }],
+      });
+      expect(decodeSharePayload(encoded)).toBeNull();
+    });
+
+    // AC #4 — corsMode strict validation
+    it('rejects invalid corsMode', async () => {
+      const encoded = await manualEncode({
+        v: 1, mode: 'config',
+        endpoints: [{ url: 'https://example.com', enabled: true }],
+        settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'same-origin' },
+      });
+      expect(decodeSharePayload(encoded)).toBeNull();
+    });
+
+    it('rejects missing corsMode', async () => {
+      const encoded = await manualEncode({
+        v: 1, mode: 'config',
+        endpoints: [{ url: 'https://example.com', enabled: true }],
+        settings: { timeout: 5000, delay: 0, cap: 0 },
+      });
+      expect(decodeSharePayload(encoded)).toBeNull();
+    });
+
+    it('accepts corsMode: cors', async () => {
+      const encoded = await manualEncode({
+        v: 1, mode: 'config',
+        endpoints: [{ url: 'https://example.com', enabled: true }],
+        settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'cors' },
+      });
+      expect(decodeSharePayload(encoded)).not.toBeNull();
+    });
+
+    // Regression: keepRounds=0 still works
+    it('truncatePayload with tiny limit produces empty samples', () => {
+      const payload: SharePayload = {
+        v: 1, mode: 'results',
+        endpoints: [{ url: 'https://example.com', enabled: true }],
+        settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors' },
+        results: [{ samples: [{ round: 1, latency: 50, status: 'ok' as const }] }],
+      };
+      const truncated = truncatePayload(payload, 1);
+      expect(truncated.results?.[0]?.samples).toHaveLength(0);
+    });
+  });
 });

--- a/tests/unit/stores/endpoints-reorder.test.ts
+++ b/tests/unit/stores/endpoints-reorder.test.ts
@@ -12,7 +12,7 @@ describe('endpointStore.reorderEndpoint', () => {
     const idA = before[0]!.id;
     const idB = before[1]!.id;
 
-    endpointStore.reorderEndpoint(0, 1);
+    endpointStore.reorderEndpoint(idA, idB);
 
     const after = get(endpointStore);
     expect(after[0]!.id).toBe(idB);
@@ -24,38 +24,38 @@ describe('endpointStore.reorderEndpoint', () => {
     const idA = before[0]!.id;
     const idB = before[1]!.id;
 
-    endpointStore.reorderEndpoint(1, 0);
+    endpointStore.reorderEndpoint(idB, idA);
 
     const after = get(endpointStore);
     expect(after[0]!.id).toBe(idB);
     expect(after[1]!.id).toBe(idA);
   });
 
-  it('no-ops when fromIndex === toIndex', () => {
+  it('no-ops when fromId === toId', () => {
     const before = get(endpointStore);
     const idsBefore = before.map(ep => ep.id);
 
-    endpointStore.reorderEndpoint(0, 0);
+    endpointStore.reorderEndpoint(before[0]!.id, before[0]!.id);
 
     const after = get(endpointStore);
     expect(after.map(ep => ep.id)).toEqual(idsBefore);
   });
 
-  it('no-ops when fromIndex is out of bounds', () => {
+  it('no-ops when fromId is not found', () => {
     const before = get(endpointStore);
     const idsBefore = before.map(ep => ep.id);
 
-    endpointStore.reorderEndpoint(99, 0);
+    endpointStore.reorderEndpoint('nonexistent', before[0]!.id);
 
     const after = get(endpointStore);
     expect(after.map(ep => ep.id)).toEqual(idsBefore);
   });
 
-  it('no-ops when toIndex is out of bounds', () => {
+  it('no-ops when toId is not found', () => {
     const before = get(endpointStore);
     const idsBefore = before.map(ep => ep.id);
 
-    endpointStore.reorderEndpoint(0, 99);
+    endpointStore.reorderEndpoint(before[0]!.id, 'nonexistent');
 
     const after = get(endpointStore);
     expect(after.map(ep => ep.id)).toEqual(idsBefore);
@@ -65,7 +65,7 @@ describe('endpointStore.reorderEndpoint', () => {
     const before = get(endpointStore);
     const epA = before[0]!;
 
-    endpointStore.reorderEndpoint(0, 1);
+    endpointStore.reorderEndpoint(epA.id, before[1]!.id);
 
     const after = get(endpointStore);
     expect(after[1]).toEqual(epA);
@@ -78,7 +78,7 @@ describe('endpointStore.reorderEndpoint', () => {
     const idB = before[1]!.id;
     const idC = before[2]!.id;
 
-    endpointStore.reorderEndpoint(1, 0);
+    endpointStore.reorderEndpoint(idB, idA);
 
     const after = get(endpointStore);
     expect(after[0]!.id).toBe(idB);
@@ -93,7 +93,7 @@ describe('endpointStore.reorderEndpoint', () => {
     const idB = before[1]!.id;
     const idC = before[2]!.id;
 
-    endpointStore.reorderEndpoint(0, 2);
+    endpointStore.reorderEndpoint(idA, idC);
 
     const after = get(endpointStore);
     expect(after[0]!.id).toBe(idB);

--- a/tests/unit/stores/endpoints-reorder.test.ts
+++ b/tests/unit/stores/endpoints-reorder.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import { endpointStore } from '../../../src/lib/stores/endpoints';
+
+describe('endpointStore.reorderEndpoint', () => {
+  beforeEach(() => {
+    endpointStore.reset();
+  });
+
+  it('moves an endpoint forward (0 → 1)', () => {
+    const before = get(endpointStore);
+    const idA = before[0]!.id;
+    const idB = before[1]!.id;
+
+    endpointStore.reorderEndpoint(0, 1);
+
+    const after = get(endpointStore);
+    expect(after[0]!.id).toBe(idB);
+    expect(after[1]!.id).toBe(idA);
+  });
+
+  it('moves an endpoint backward (1 → 0)', () => {
+    const before = get(endpointStore);
+    const idA = before[0]!.id;
+    const idB = before[1]!.id;
+
+    endpointStore.reorderEndpoint(1, 0);
+
+    const after = get(endpointStore);
+    expect(after[0]!.id).toBe(idB);
+    expect(after[1]!.id).toBe(idA);
+  });
+
+  it('no-ops when fromIndex === toIndex', () => {
+    const before = get(endpointStore);
+    const idsBefore = before.map(ep => ep.id);
+
+    endpointStore.reorderEndpoint(0, 0);
+
+    const after = get(endpointStore);
+    expect(after.map(ep => ep.id)).toEqual(idsBefore);
+  });
+
+  it('no-ops when fromIndex is out of bounds', () => {
+    const before = get(endpointStore);
+    const idsBefore = before.map(ep => ep.id);
+
+    endpointStore.reorderEndpoint(99, 0);
+
+    const after = get(endpointStore);
+    expect(after.map(ep => ep.id)).toEqual(idsBefore);
+  });
+
+  it('no-ops when toIndex is out of bounds', () => {
+    const before = get(endpointStore);
+    const idsBefore = before.map(ep => ep.id);
+
+    endpointStore.reorderEndpoint(0, 99);
+
+    const after = get(endpointStore);
+    expect(after.map(ep => ep.id)).toEqual(idsBefore);
+  });
+
+  it('preserves all endpoint data after reorder', () => {
+    const before = get(endpointStore);
+    const epA = before[0]!;
+
+    endpointStore.reorderEndpoint(0, 1);
+
+    const after = get(endpointStore);
+    expect(after[1]).toEqual(epA);
+  });
+
+  it('works with 3+ endpoints: moves middle to front', () => {
+    endpointStore.addEndpoint('https://extra.example.com', 'Extra');
+    const before = get(endpointStore);
+    const idA = before[0]!.id;
+    const idB = before[1]!.id;
+    const idC = before[2]!.id;
+
+    endpointStore.reorderEndpoint(1, 0);
+
+    const after = get(endpointStore);
+    expect(after[0]!.id).toBe(idB);
+    expect(after[1]!.id).toBe(idA);
+    expect(after[2]!.id).toBe(idC);
+  });
+
+  it('works with 3+ endpoints: moves first to last', () => {
+    endpointStore.addEndpoint('https://extra.example.com', 'Extra');
+    const before = get(endpointStore);
+    const idA = before[0]!.id;
+    const idB = before[1]!.id;
+    const idC = before[2]!.id;
+
+    endpointStore.reorderEndpoint(0, 2);
+
+    const after = get(endpointStore);
+    expect(after[0]!.id).toBe(idB);
+    expect(after[1]!.id).toBe(idC);
+    expect(after[2]!.id).toBe(idA);
+  });
+});

--- a/tests/unit/stores/measurements.test.ts
+++ b/tests/unit/stores/measurements.test.ts
@@ -113,6 +113,33 @@ describe('measurementStore — error/timeout counters', () => {
     expect(state.timeoutCount).toBe(1);
   });
 
+  it('removeEndpoint adjusts counters', () => {
+    measurementStore.initEndpoint('ep1');
+    measurementStore.initEndpoint('ep2');
+    measurementStore.addSample('ep1', 1, 0, 'error', Date.now());
+    measurementStore.addSample('ep1', 2, 5000, 'timeout', Date.now());
+    measurementStore.addSample('ep2', 1, 0, 'error', Date.now());
+
+    measurementStore.removeEndpoint('ep1');
+
+    const state = get(measurementStore);
+    expect(state.errorCount).toBe(1);
+    expect(state.timeoutCount).toBe(0);
+  });
+
+  it('removeEndpoint with no failures zeroes nothing extra', () => {
+    measurementStore.initEndpoint('ep1');
+    measurementStore.initEndpoint('ep2');
+    measurementStore.addSample('ep1', 1, 50, 'ok', Date.now());
+    measurementStore.addSample('ep2', 1, 0, 'error', Date.now());
+
+    measurementStore.removeEndpoint('ep1');
+
+    const state = get(measurementStore);
+    expect(state.errorCount).toBe(1);
+    expect(state.timeoutCount).toBe(0);
+  });
+
   it('loadSnapshot handles multiple endpoints', () => {
     const snapshot = {
       lifecycle: 'stopped' as const,

--- a/tests/unit/stores/measurements.test.ts
+++ b/tests/unit/stores/measurements.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import { measurementStore } from '../../../src/lib/stores/measurements';
+
+describe('measurementStore — error/timeout counters', () => {
+  beforeEach(() => {
+    measurementStore.reset();
+  });
+
+  it('initial state has errorCount: 0 and timeoutCount: 0', () => {
+    const state = get(measurementStore);
+    expect(state.errorCount).toBe(0);
+    expect(state.timeoutCount).toBe(0);
+  });
+
+  it('addSample increments errorCount for error status', () => {
+    measurementStore.initEndpoint('ep1');
+    measurementStore.addSample('ep1', 1, 0, 'error', Date.now());
+    expect(get(measurementStore).errorCount).toBe(1);
+    expect(get(measurementStore).timeoutCount).toBe(0);
+  });
+
+  it('addSample increments timeoutCount for timeout status', () => {
+    measurementStore.initEndpoint('ep1');
+    measurementStore.addSample('ep1', 1, 5000, 'timeout', Date.now());
+    expect(get(measurementStore).timeoutCount).toBe(1);
+    expect(get(measurementStore).errorCount).toBe(0);
+  });
+
+  it('addSample does not increment counters for ok status', () => {
+    measurementStore.initEndpoint('ep1');
+    measurementStore.addSample('ep1', 1, 50, 'ok', Date.now());
+    expect(get(measurementStore).errorCount).toBe(0);
+    expect(get(measurementStore).timeoutCount).toBe(0);
+  });
+
+  it('addSample accumulates across multiple calls', () => {
+    measurementStore.initEndpoint('ep1');
+    measurementStore.addSample('ep1', 1, 0, 'error', Date.now());
+    measurementStore.addSample('ep1', 2, 0, 'error', Date.now());
+    measurementStore.addSample('ep1', 3, 5000, 'timeout', Date.now());
+    const state = get(measurementStore);
+    expect(state.errorCount).toBe(2);
+    expect(state.timeoutCount).toBe(1);
+  });
+
+  it('addSamples increments counters for out-of-order insertions', () => {
+    measurementStore.initEndpoint('ep1');
+    measurementStore.addSamples([
+      { endpointId: 'ep1', round: 5, latency: 50, status: 'ok', timestamp: Date.now() },
+      { endpointId: 'ep1', round: 3, latency: 0, status: 'error', timestamp: Date.now() },
+    ]);
+    const state = get(measurementStore);
+    expect(state.errorCount).toBe(1);
+    expect(state.timeoutCount).toBe(0);
+  });
+
+  it('addSamples increments timeoutCount for batch with timeouts', () => {
+    measurementStore.initEndpoint('ep1');
+    measurementStore.addSamples([
+      { endpointId: 'ep1', round: 1, latency: 5000, status: 'timeout', timestamp: Date.now() },
+      { endpointId: 'ep1', round: 2, latency: 5000, status: 'timeout', timestamp: Date.now() },
+      { endpointId: 'ep1', round: 3, latency: 50, status: 'ok', timestamp: Date.now() },
+    ]);
+    expect(get(measurementStore).timeoutCount).toBe(2);
+    expect(get(measurementStore).errorCount).toBe(0);
+  });
+
+  it('addSamples skips unknown endpointId without affecting counters', () => {
+    measurementStore.addSamples([
+      { endpointId: 'unknown', round: 1, latency: 0, status: 'error', timestamp: Date.now() },
+    ]);
+    expect(get(measurementStore).errorCount).toBe(0);
+  });
+
+  it('reset zeroes errorCount and timeoutCount', () => {
+    measurementStore.initEndpoint('ep1');
+    measurementStore.addSample('ep1', 1, 0, 'error', Date.now());
+    measurementStore.addSample('ep1', 2, 5000, 'timeout', Date.now());
+    measurementStore.reset();
+    const state = get(measurementStore);
+    expect(state.errorCount).toBe(0);
+    expect(state.timeoutCount).toBe(0);
+  });
+
+  it('loadSnapshot recomputes counters from snapshot data', () => {
+    const snapshot = {
+      lifecycle: 'stopped' as const,
+      epoch: 1,
+      roundCounter: 3,
+      startedAt: 0,
+      stoppedAt: 1000,
+      freezeEvents: [],
+      errorCount: 0,
+      timeoutCount: 0,
+      endpoints: {
+        ep1: {
+          endpointId: 'ep1',
+          tierLevel: 1 as const,
+          lastLatency: 50,
+          lastStatus: 'ok' as const,
+          samples: [
+            { round: 1, latency: 0, status: 'error' as const, timestamp: 1000 },
+            { round: 2, latency: 5000, status: 'timeout' as const, timestamp: 2000 },
+            { round: 3, latency: 50, status: 'ok' as const, timestamp: 3000 },
+          ],
+        },
+      },
+    };
+    measurementStore.loadSnapshot(snapshot);
+    const state = get(measurementStore);
+    expect(state.errorCount).toBe(1);
+    expect(state.timeoutCount).toBe(1);
+  });
+
+  it('loadSnapshot handles multiple endpoints', () => {
+    const snapshot = {
+      lifecycle: 'stopped' as const,
+      epoch: 1,
+      roundCounter: 2,
+      startedAt: 0,
+      stoppedAt: 1000,
+      freezeEvents: [],
+      errorCount: 0,
+      timeoutCount: 0,
+      endpoints: {
+        ep1: {
+          endpointId: 'ep1',
+          tierLevel: 1 as const,
+          lastLatency: null,
+          lastStatus: null,
+          samples: [
+            { round: 1, latency: 0, status: 'error' as const, timestamp: 1000 },
+          ],
+        },
+        ep2: {
+          endpointId: 'ep2',
+          tierLevel: 1 as const,
+          lastLatency: null,
+          lastStatus: null,
+          samples: [
+            { round: 1, latency: 5000, status: 'timeout' as const, timestamp: 1000 },
+            { round: 2, latency: 5000, status: 'timeout' as const, timestamp: 2000 },
+          ],
+        },
+      },
+    };
+    measurementStore.loadSnapshot(snapshot);
+    const state = get(measurementStore);
+    expect(state.errorCount).toBe(1);
+    expect(state.timeoutCount).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

### CodeRabbit fixes (last 2 findings from PRs #1, #4, #5)

- **Share validation hardening** — `validateSharePayload` now rejects non-HTTP(S) URLs (`javascript:`, `data:`, relative paths), non-finite/negative numeric fields, oversized arrays (endpoints > 50, results > 50, samples > 10k), and invalid `corsMode` values
- **FooterBar O(n) elimination** — error/timeout counts tracked incrementally in `measurementStore` via `addSample`/`addSamples`/`loadSnapshot`/`reset`; FooterBar reads pre-computed values (1 line replaces 11-line O(n) derived scan)

### Lane drag-to-reorder (new feature)

- **Grip handle** — 6-dot SVG grip on left edge of stats panel (full mode) and compact header. Hidden when only 1 endpoint.
- **Pointer event drag** — `pointerdown` on grip captures pointer, `pointermove` translates dragged card via `--drag-translate` CSS custom property, neighbors shift with spring easing
- **Drop commits reorder** — `pointerup` transitions card to target slot, waits for spring settle, then commits via `endpointStore.reorderEndpoint(from, to)`. Order persists via existing localStorage save-on-change.
- **Apple-level animation polish** — pickup overshoot keyframe (scale 1.0→1.03→1.01), spring easing on neighbor shifts (`cubic-bezier(0.34, 1.56, 0.64, 1)`), settling de-lift transition on drop, transition suppression during DOM reorder to prevent neighbor twitch. Zero dependencies.

## Test plan

- [x] 17 validation edge-case tests (URL schemes, Infinity/NaN/negative, array bounds, corsMode)
- [x] 11 store counter tests (addSample, addSamples, reset, loadSnapshot)
- [x] 8 reorder store tests (forward, backward, multi-hop, out-of-bounds, data preservation)
- [x] 5 grip handle tests (render, aria-label, compact mode, data-endpoint-id, showGrip=false)
- [x] 4 LanesView tests (container, lanes render, grip handles, single-endpoint hidden)
- [x] Visually tested drag-to-reorder in Chrome — pickup, drag, drop settle, persistence
- [x] Full suite: 371 tests passing
- [x] Typecheck clean, lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Error and timeout counters are tracked and displayed in results/footer.
  * Drag-to-reorder lanes with a visible grip handle for reordering endpoints.

* **Improvements**
  * Hardened validation for shared measurement payloads (URL formats, numeric settings, corsMode, and size limits).
  * Snapshot loading now ensures counters are consistent with displayed results.

* **Tests**
  * Expanded unit tests for payload validation, counters, and reorder behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->