### PR TITLE
fix: compile worker bundle correctly via Vite ?worker import

### DIFF
--- a/src/lib/engine/measurement-engine.ts
+++ b/src/lib/engine/measurement-engine.ts
@@ -233,7 +233,7 @@ export class MeasurementEngine {
   private _spawnWorkers(endpoints: Endpoint[]): void {
     this.workers = endpoints.map(ep => {
       // Uses the injected factory — allows test environments to substitute mock workers.
-      const worker = this.workerFactory.create(new URL('./worker.ts', import.meta.url));
+      const worker = this.workerFactory.create();
       worker.addEventListener('message', (event: MessageEvent<WorkerToMainMessage>) => {
         // Inject the correct endpointId — the worker doesn't know its own ID,
         // it only sets endpointId to the URL as a placeholder.

--- a/src/lib/engine/worker-factory.ts
+++ b/src/lib/engine/worker-factory.ts
@@ -1,12 +1,18 @@
 // src/lib/engine/worker-factory.ts
 // Abstracts Worker construction to enable test injection of mock workers.
 
+// Vite's ?worker import compiles and bundles the worker at build time.
+// This must live here (not in measurement-engine.ts) so that new Worker()
+// and the ?worker import appear together in the same module, which is
+// required for Vite's static analysis to emit a compiled worker bundle.
+import MeasurementWorker from './worker.ts?worker';
+
 export interface WorkerFactory {
-  create(url: URL): Worker;
+  create(): Worker;
 }
 
 export const defaultWorkerFactory: WorkerFactory = {
-  create(url: URL): Worker {
-    return new Worker(url, { type: 'module' });
+  create(): Worker {
+    return new MeasurementWorker();
   },
 };


### PR DESCRIPTION
## Summary
- Vite requires `new Worker()` and the `?worker` import to be co-located in the same module for its static analysis to emit a compiled worker bundle
- The previous pattern put `new URL('./worker.ts', import.meta.url)` in `measurement-engine.ts` and `new Worker(url)` in `worker-factory.ts` — Vite saw the asset reference but skipped the worker transform, emitting raw `.ts` source
- Moved the `?worker` import into `worker-factory.ts` so both the import and `new Worker()` are in the same file — build now emits `worker-*.js` instead of `worker-*.ts`

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (382 tests)
- [x] `npm run build` emits `worker-DVndlBm7.js` (compiled JS, not raw TS)
- [ ] Deploy to production and verify Start button launches measurement engine