### PR TITLE
fix: eliminate 100ms measurement inflation and reduce monitor interval

### DIFF
--- a/src/lib/engine/measurement-engine.ts
+++ b/src/lib/engine/measurement-engine.ts
@@ -233,7 +233,7 @@ export class MeasurementEngine {
   private _spawnWorkers(endpoints: Endpoint[]): void {
     this.workers = endpoints.map(ep => {
       // Uses the injected factory — allows test environments to substitute mock workers.
-      const worker = this.workerFactory.create(new URL('./worker.ts', import.meta.url));
+      const worker = this.workerFactory.create();
       worker.addEventListener('message', (event: MessageEvent<WorkerToMainMessage>) => {
         // Inject the correct endpointId — the worker doesn't know its own ID,
         // it only sets endpointId to the URL as a placeholder.

--- a/src/lib/engine/worker-factory.ts
+++ b/src/lib/engine/worker-factory.ts
@@ -1,12 +1,18 @@
 // src/lib/engine/worker-factory.ts
 // Abstracts Worker construction to enable test injection of mock workers.
 
+// Vite's ?worker import compiles and bundles the worker at build time.
+// This must live here (not in measurement-engine.ts) so that new Worker()
+// and the ?worker import appear together in the same module, which is
+// required for Vite's static analysis to emit a compiled worker bundle.
+import MeasurementWorker from './worker.ts?worker';
+
 export interface WorkerFactory {
-  create(url: URL): Worker;
+  create(): Worker;
 }
 
 export const defaultWorkerFactory: WorkerFactory = {
-  create(url: URL): Worker {
-    return new Worker(url, { type: 'module' });
+  create(): Worker {
+    return new MeasurementWorker();
   },
 };

--- a/src/lib/engine/worker.ts
+++ b/src/lib/engine/worker.ts
@@ -63,7 +63,9 @@ export function extractTimingPayload(entry: PerformanceResourceTiming): TimingPa
     tlsHandshake,
     ttfb,
     contentTransfer,
-    connectionReused: connectStart === connectEnd,
+    // connectStart === connectEnd means a reused connection (no TCP setup time).
+    // However both are 0 when TAO is absent, so only report reuse when TAO data is valid.
+    connectionReused: hasTao ? connectStart === connectEnd : undefined,
     protocol: (entry as PerformanceResourceTiming).nextHopProtocol || undefined,
   };
 }
@@ -200,6 +202,11 @@ if (typeof (globalThis as any).WorkerGlobalScope !== 'undefined' && self instanc
           signal,
         });
 
+        // Capture duration immediately — before the PerformanceObserver wait.
+        // If the observer times out (e.g. redirect changes the entry URL),
+        // using performance.now() here would inflate by ~100ms.
+        const fetchDuration = performance.now() - startMark;
+
         clearTimeout(timeoutId);
 
         // Use PerformanceObserver to get the Resource Timing entry (push-based).
@@ -208,7 +215,7 @@ if (typeof (globalThis as any).WorkerGlobalScope !== 'undefined' && self instanc
         const timing: TimingPayload = entry
           ? extractTimingPayload(entry)
           : {
-              total: performance.now() - startMark,
+              total: fetchDuration,
               dnsLookup: 0,
               tcpConnect: 0,
               tlsHandshake: 0,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -157,7 +157,7 @@ export const DEFAULT_SETTINGS: Settings = {
   timeout: 5000,
   delay: 0,
   burstRounds: 50,
-  monitorDelay: 3000,
+  monitorDelay: 1000,
   cap: 0,
   corsMode: 'no-cors',
 };

--- a/tests/unit/persistence.test.ts
+++ b/tests/unit/persistence.test.ts
@@ -24,7 +24,7 @@ describe('persistence', () => {
     const settings: PersistedSettings = {
       version: 3,
       endpoints: [{ url: 'https://example.com', enabled: true }],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 3000, cap: 0, corsMode: 'no-cors' },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors' },
       ui: { expandedCards: [], activeView: 'timeline' },
     };
     saveSettings(settings);
@@ -32,7 +32,7 @@ describe('persistence', () => {
     expect(loaded?.version).toBe(3);
     expect(loaded?.endpoints[0]?.url).toBe('https://example.com');
     expect(loaded?.settings.burstRounds).toBe(50);
-    expect(loaded?.settings.monitorDelay).toBe(3000);
+    expect(loaded?.settings.monitorDelay).toBe(1000);
   });
 
   it('returns null for corrupt data', () => {
@@ -46,7 +46,7 @@ describe('persistence', () => {
     const migrated = migrateSettings(v1Data);
     expect(migrated?.version).toBe(3);
     expect(migrated?.settings.burstRounds).toBe(50);
-    expect(migrated?.settings.monitorDelay).toBe(3000);
+    expect(migrated?.settings.monitorDelay).toBe(1000);
   });
 
   it('migrates v2 data to v3 with old delay as monitorDelay', () => {

--- a/tests/unit/types.test.ts
+++ b/tests/unit/types.test.ts
@@ -82,7 +82,7 @@ describe('types', () => {
     expect(DEFAULT_SETTINGS.timeout).toBe(5000);
     expect(DEFAULT_SETTINGS.delay).toBe(0);
     expect(DEFAULT_SETTINGS.burstRounds).toBe(50);
-    expect(DEFAULT_SETTINGS.monitorDelay).toBe(3000);
+    expect(DEFAULT_SETTINGS.monitorDelay).toBe(1000);
     expect(DEFAULT_SETTINGS.cap).toBe(0);
     expect(DEFAULT_SETTINGS.corsMode).toBe('no-cors');
   });


### PR DESCRIPTION
## Summary
- **Timing inflation**: The `waitForResourceEntry` fallback used `performance.now() - startMark` _after_ waiting up to 100ms for the PerformanceObserver — inflating every measurement where the observer timed out (e.g. redirect changes the entry URL) by ~100ms. Fix: capture `fetchDuration = performance.now() - startMark` immediately after `await fetch()` resolves.
- **False `connectionReused`**: For cross-origin `no-cors` requests without `Timing-Allow-Origin`, the browser zeros both `connectStart` and `connectEnd`, so `connectStart === connectEnd` was always `true`. Fixed to return `undefined` when TAO data is absent.
- **Slow monitor interval**: Default `monitorDelay` reduced from 3000ms → 1000ms so the chart stays visually live after the 50-round burst phase.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (382 tests)
- [x] `npm run build` succeeds
- [ ] Verify measured latency drops by ~100ms on endpoints that previously hit the fallback path