### PR TITLE
fix: anonymous shared view and locked-down shared topbar

### DIFF
--- a/src/lib/components/SharedResultsBanner.svelte
+++ b/src/lib/components/SharedResultsBanner.svelte
@@ -1,28 +1,14 @@
 <!-- src/lib/components/SharedResultsBanner.svelte -->
 <!-- Visible when viewing a shared results link. Informs the user they are       -->
-<!-- seeing someone else's data and offers a "Run Again" button to start fresh.  -->
+<!-- seeing a read-only snapshot and offers a "Run Again" button to start fresh. -->
 <script lang="ts">
   import { uiStore } from '$lib/stores/ui';
   import { measurementStore } from '$lib/stores/measurements';
   import { tokens } from '$lib/tokens';
 
-  let timestamp = $derived($uiStore.sharedResultsTimestamp);
-
-  function formatTimestamp(ts: number | null): string {
-    if (ts === null) return 'an earlier session';
-    return new Date(ts).toLocaleString(undefined, {
-      dateStyle: 'medium',
-      timeStyle: 'short',
-    });
-  }
-
   function handleRunAgain(): void {
-    // Clear shared state, reset measurements but keep endpoints
     uiStore.clearSharedView();
     measurementStore.reset();
-    // Keep the endpoints from the share so user can run the same test
-    // Kick off fresh test by transitioning to 'starting' via the controls
-    // (We just clear — the user clicks Start themselves)
   }
 </script>
 
@@ -42,17 +28,14 @@
 >
   <div class="banner-content">
     <span class="banner-icon" aria-hidden="true">↗</span>
-    <span class="banner-text">
-      Viewing shared results from {formatTimestamp(timestamp)}.
-      Start a new test to measure from your location.
-    </span>
+    <span class="banner-text">Shared results — read only. Run your own test to measure from your location.</span>
   </div>
   <button
     type="button"
     class="btn-run-again"
     onclick={handleRunAgain}
   >
-    Run Again
+    Run Your Own Test
   </button>
 </div>
 

--- a/src/lib/components/Topbar.svelte
+++ b/src/lib/components/Topbar.svelte
@@ -12,8 +12,10 @@
 
   let lifecycle: TestLifecycleState = $derived($measurementStore.lifecycle);
   let roundCounter: number = $derived($measurementStore.roundCounter);
+  let isSharedView: boolean = $derived($uiStore.isSharedView);
 
   let runLabel: string = $derived.by(() => {
+    if (isSharedView) return 'Shared Results';
     if (lifecycle === 'running') return `Running · Round ${roundCounter}`;
     if (lifecycle === 'starting') return 'Starting…';
     if (lifecycle === 'stopping') return 'Stopping…';
@@ -37,6 +39,11 @@
     } else if (lifecycle === 'idle' || lifecycle === 'stopped' || lifecycle === 'completed') {
       onStart?.();
     }
+  }
+
+  function handleRunOwn(): void {
+    uiStore.clearSharedView();
+    measurementStore.reset();
   }
 
   function handleSettings(): void { uiStore.toggleSettings(); }
@@ -79,10 +86,15 @@
   <div class="spacer"></div>
 
   <nav class="actions" aria-label="Test controls">
-    <button type="button" class="btn" aria-label="Add or remove endpoints" aria-expanded={$uiStore.showEndpoints} aria-controls="endpoint-drawer" onclick={handleEndpoints}>+ Endpoint</button>
-    <button type="button" class="btn" aria-label="Open settings" aria-expanded={$uiStore.showSettings} aria-controls="settings-drawer" onclick={handleSettings}>Settings</button>
-    <button type="button" class="btn" aria-label="Share results" aria-expanded={$uiStore.showShare} aria-controls="share-popover" onclick={handleShare}>Share</button>
-    <button type="button" class="btn btn-accent" class:btn-stop={isRunning} disabled={isTransitioning} aria-disabled={isTransitioning} aria-label={startStopLabel} onclick={handleStartStop}>{startStopLabel}</button>
+    {#if isSharedView}
+      <button type="button" class="btn" aria-label="Share results" aria-expanded={$uiStore.showShare} aria-controls="share-popover" onclick={handleShare}>Share</button>
+      <button type="button" class="btn btn-run-own" aria-label="Run your own test" onclick={handleRunOwn}>Run Your Own Test</button>
+    {:else}
+      <button type="button" class="btn" aria-label="Add or remove endpoints" aria-expanded={$uiStore.showEndpoints} aria-controls="endpoint-drawer" onclick={handleEndpoints}>+ Endpoint</button>
+      <button type="button" class="btn" aria-label="Open settings" aria-expanded={$uiStore.showSettings} aria-controls="settings-drawer" onclick={handleSettings}>Settings</button>
+      <button type="button" class="btn" aria-label="Share results" aria-expanded={$uiStore.showShare} aria-controls="share-popover" onclick={handleShare}>Share</button>
+      <button type="button" class="btn btn-accent" class:btn-stop={isRunning} disabled={isTransitioning} aria-disabled={isTransitioning} aria-label={startStopLabel} onclick={handleStartStop}>{startStopLabel}</button>
+    {/if}
   </nav>
 </header>
 
@@ -171,6 +183,16 @@
     box-shadow: 0 2px 16px rgba(249,168,212,.1);
   }
   .btn-stop { border-color: rgba(249,168,212,.2); color: var(--accent-pink); }
+  .btn-run-own {
+    border-color: rgba(103,232,249,.25);
+    color: var(--accent-cyan);
+    background: rgba(103,232,249,.04);
+  }
+  .btn-run-own:hover:not(:disabled) {
+    background: rgba(103,232,249,.1);
+    border-color: rgba(103,232,249,.4);
+    box-shadow: 0 2px 16px rgba(103,232,249,.1);
+  }
   .btn:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
   @media (max-width: 767px) {
     .topbar { padding: 0 12px; gap: 8px; }

--- a/src/lib/share/hash-router.ts
+++ b/src/lib/share/hash-router.ts
@@ -88,9 +88,9 @@ export function applySharePayload(payload: SharePayload): string[] {
 
     measurementStore.loadSnapshot(snapshot);
 
-    uiStore.setSharedView(true, Date.now());
+    uiStore.setSharedView(true);
   } else {
-    uiStore.setSharedView(false, null);
+    uiStore.setSharedView(false);
   }
 
   return ids;

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -15,7 +15,6 @@ const initialState = (): UIState => ({
   showShare: false,
   showKeyboardHelp: false,
   isSharedView: false,
-  sharedResultsTimestamp: null,
   laneHoverRound: null,
   laneHoverX: null,
   laneHoverY: null,
@@ -56,19 +55,11 @@ function createUiStore() {
     toggleKeyboardHelp(): void {
       update((s) => ({ ...s, showKeyboardHelp: !s.showKeyboardHelp }));
     },
-    setSharedView(isShared: boolean, timestamp: number | null = null): void {
-      update((s) => ({
-        ...s,
-        isSharedView: isShared,
-        sharedResultsTimestamp: timestamp,
-      }));
+    setSharedView(isShared: boolean): void {
+      update((s) => ({ ...s, isSharedView: isShared }));
     },
     clearSharedView(): void {
-      update((s) => ({
-        ...s,
-        isSharedView: false,
-        sharedResultsTimestamp: null,
-      }));
+      update((s) => ({ ...s, isSharedView: false }));
     },
     setLaneHover(round: number, x: number, y: number): void {
       update((s) => ({ ...s, laneHoverRound: round, laneHoverX: x, laneHoverY: y }));

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -190,7 +190,6 @@ export interface UIState {
   showShare: boolean;
   showKeyboardHelp: boolean;
   isSharedView: boolean;
-  sharedResultsTimestamp: number | null;
   laneHoverRound: number | null;
   laneHoverX: number | null;
   laneHoverY: number | null;

--- a/tests/unit/types.test.ts
+++ b/tests/unit/types.test.ts
@@ -104,7 +104,6 @@ describe('types', () => {
       showShare: false,
       showKeyboardHelp: false,
       isSharedView: false,
-      sharedResultsTimestamp: null,
     };
     expect(state.showKeyboardHelp).toBe(false);
   });
@@ -120,7 +119,6 @@ describe('types', () => {
       showShare: false,
       showKeyboardHelp: false,
       isSharedView: false,
-      sharedResultsTimestamp: null,
     };
     expect(state.isSharedView).toBe(false);
   });


### PR DESCRIPTION
## Summary

- Removes all identifying information from shared links — `sharedResultsTimestamp` is dropped from `UIState` entirely, so no timing metadata leaks through shares
- Shared view topbar now hides `+ Endpoint`, `Settings`, and `Start` (which was silently broken), replacing them with a single **Run Your Own Test** button
- Run-status label reads **Shared Results** instead of **Complete** in shared view
- Banner copy simplified to: *"Shared results — read only. Run your own test to measure from your location."*
- `Share` button remains visible so recipients can re-share the same link

## Test plan

- [ ] Open a results share URL — topbar shows only `Share` + `Run Your Own Test`, no `+ Endpoint` / `Settings` / `Start`
- [ ] Run-status reads "Shared Results"
- [ ] Banner reads "Shared results — read only..."
- [ ] Clicking "Run Your Own Test" clears shared state and returns to a fresh idle view
- [ ] Clicking "Share" in shared view opens the share popover normally
- [ ] All 382 unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced shared results experience with clearer messaging. Results shared by others now explicitly display as "read-only snapshots," and the interface provides a more intuitive way to run your own tests through the updated "Run Your Own Test" button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->