### PR TITLE
fix: UX polish — error handling, cadence easing, color ramp, endpoint guards

### DIFF
--- a/src/lib/components/Controls.svelte
+++ b/src/lib/components/Controls.svelte
@@ -4,6 +4,7 @@
 <!--                running → Stop        | stopping → Stopping…              -->
 <script lang="ts">
   import { measurementStore } from '$lib/stores/measurements';
+  import { endpointStore } from '$lib/stores/endpoints';
   import { uiStore } from '$lib/stores/ui';
   import { tokens } from '$lib/tokens';
 
@@ -24,7 +25,12 @@
     }
   });
 
-  let startStopDisabled = $derived(lifecycle === 'starting' || lifecycle === 'stopping');
+  let hasEnabledEndpoints = $derived($endpointStore.some(ep => ep.enabled));
+
+  let startStopDisabled = $derived(
+    lifecycle === 'starting' || lifecycle === 'stopping' ||
+    (lifecycle !== 'running' && !hasEnabledEndpoints)
+  );
 
   let startStopVariant = $derived(lifecycle === 'running' ? 'stop' : 'start');
 

--- a/src/lib/components/CrossLaneHover.svelte
+++ b/src/lib/components/CrossLaneHover.svelte
@@ -20,16 +20,16 @@
   }
 
   /** Find the sample nearest to targetRound via binary search (samples are sorted by round). */
-  function findNearest<T extends { round: number }>(samples: readonly T[], targetRound: number): T | null {
+  function findNearest<T extends { round: number }>(samples: { length: number; at(i: number): T | undefined }, targetRound: number): T | null {
     if (samples.length === 0) return null;
     let lo = 0, hi = samples.length - 1;
     while (lo < hi) {
       const mid = (lo + hi) >> 1;
-      if ((samples[mid]?.round ?? 0) < targetRound) lo = mid + 1;
+      if ((samples.at(mid)?.round ?? 0) < targetRound) lo = mid + 1;
       else hi = mid;
     }
-    const a = samples[lo];
-    const b = lo > 0 ? samples[lo - 1] : undefined;
+    const a = samples.at(lo);
+    const b = lo > 0 ? samples.at(lo - 1) : undefined;
     if (!a) return b ?? null;
     if (!b) return a;
     return Math.abs(a.round - targetRound) <= Math.abs(b.round - targetRound) ? a : b;

--- a/src/lib/components/EndpointPanel.svelte
+++ b/src/lib/components/EndpointPanel.svelte
@@ -46,13 +46,16 @@
   <ul class="endpoint-list" aria-label="Endpoint list">
     {#each $endpointStore as endpoint (endpoint.id)}
       {@const epState = $measurementStore.endpoints[endpoint.id]}
+      {@const enabledCount = $endpointStore.filter(e => e.enabled).length}
       <li>
         <EndpointRow
           {endpoint}
           {isRunning}
           isLast={$endpointStore.length === 1}
+          isLastEnabled={endpoint.enabled && enabledCount === 1}
           lastLatency={epState?.lastLatency ?? null}
           lastStatus={epState?.lastStatus ?? null}
+          lastErrorMessage={epState?.lastErrorMessage ?? null}
           onRemove={handleRemove}
           onUpdate={handleUpdate}
         />

--- a/src/lib/components/EndpointRow.svelte
+++ b/src/lib/components/EndpointRow.svelte
@@ -11,16 +11,20 @@
     endpoint,
     isRunning = false,
     isLast = false,
+    isLastEnabled = false,
     lastLatency = null,
     lastStatus = null,
+    lastErrorMessage = null,
     onRemove,
     onUpdate,
   }: {
     endpoint: Endpoint;
     isRunning?: boolean;
     isLast?: boolean;
+    isLastEnabled?: boolean;
     lastLatency?: number | null;
     lastStatus?: SampleStatus | null;
+    lastErrorMessage?: string | null;
     onRemove?: (id: string) => void;
     onUpdate?: (id: string, patch: Partial<Omit<Endpoint, 'id'>>) => void;
   } = $props();
@@ -40,7 +44,7 @@
   let latencyText = $derived.by(() => {
     if (lastStatus === null || lastLatency === null) return '';
     if (lastStatus === 'timeout') return 'timeout';
-    if (lastStatus === 'error') return 'error';
+    if (lastStatus === 'error') return lastErrorMessage ?? 'error';
     return `${Math.round(lastLatency)}ms`;
   });
 
@@ -116,12 +120,16 @@
   {/if}
 
   <!-- Enable/disable toggle -->
-  <label class="toggle-label" aria-label="{endpoint.enabled ? 'Disable' : 'Enable'} this endpoint">
+  <label
+    class="toggle-label"
+    aria-label="{endpoint.enabled ? 'Disable' : 'Enable'} this endpoint"
+    title={isLastEnabled ? 'At least one endpoint must be enabled' : ''}
+  >
     <input
       type="checkbox"
       class="toggle-input"
       checked={endpoint.enabled}
-      disabled={isRunning}
+      disabled={isRunning || isLastEnabled}
       onchange={handleToggle}
     />
     <span class="toggle-track" aria-hidden="true"></span>

--- a/src/lib/components/FooterBar.svelte
+++ b/src/lib/components/FooterBar.svelte
@@ -4,6 +4,7 @@
   import { settingsStore } from '$lib/stores/settings';
   import { tokens } from '$lib/tokens';
   import { formatElapsed } from '$lib/renderers/timeline-data-pipeline';
+  import LatencyLegend from './LatencyLegend.svelte';
 
   let lifecycle = $derived($measurementStore.lifecycle);
   let roundCounter = $derived($measurementStore.roundCounter);
@@ -54,6 +55,7 @@
 >
   <span class="highlight">Measuring from your browser</span>
   <span class="config">{configLabel}</span>
+  <LatencyLegend />
   <div class="spacer"></div>
   <span class="progress">{progressLabel}</span>
 </footer>

--- a/src/lib/components/HeatmapCanvas.svelte
+++ b/src/lib/components/HeatmapCanvas.svelte
@@ -43,7 +43,7 @@
       if (!epState) continue;
 
       for (let i = 0; i < epState.samples.length; i++) {
-        const sample = epState.samples[i];
+        const sample = epState.samples.at(i);
         const col = sample.round;
         const color = sample.status === 'ok'
           ? latencyToColor(sample.latency)

--- a/src/lib/components/LaneSvgChart.svelte
+++ b/src/lib/components/LaneSvgChart.svelte
@@ -40,10 +40,17 @@
 
   const hasData: boolean = $derived(points.length > 0);
 
-  function toX(round: number): number {
+  // Fixed per-round width in viewBox units — dots stay in place, the group translates.
+  const roundWidth: number = $derived.by(() => {
     const span = visibleEnd - visibleStart;
-    if (span <= 0) return VB_W;
-    return ((round - visibleStart) / span) * VB_W;
+    return span > 0 ? VB_W / span : VB_W;
+  });
+
+  // Translate offset: slide the content group so visibleStart aligns to x=0.
+  const slideX: number = $derived(-visibleStart * roundWidth);
+
+  function toX(round: number): number {
+    return round * roundWidth;
   }
 
   function toY(normalizedY: number): number {
@@ -175,9 +182,9 @@
     <line class="grid-line" x1="0" y1={gy} x2={VB_W} y2={gy} />
   {/each}
 
-  <!-- Future zone -->
+  <!-- Future zone (translated with data so it tracks the nowDot) -->
   {#if showFutureZone}
-    <rect class="future-zone" x={futureZoneX} y="0" width={VB_W - futureZoneX} height={PLOT_H + PAD_Y_TOP} />
+    <rect class="future-zone slide-group" transform="translate({slideX}, 0)" x={futureZoneX} y="0" width={VB_W * 2} height={PLOT_H + PAD_Y_TOP} />
   {/if}
 
   <!-- Timeout threshold line (between gridlines and data) -->
@@ -196,6 +203,7 @@
   {/if}
 
   {#if hasData}
+    <g class="slide-group" transform="translate({slideX}, 0)">
     {#if ribbonPath}
       <path class="ribbon" d={ribbonPath} />
     {/if}
@@ -231,6 +239,7 @@
         <animate attributeName="opacity" values=".2;0" dur="2s" repeatCount="indefinite"/>
       </circle>
     {/if}
+    </g>
   {:else}
     <text
       class="empty-text"
@@ -262,8 +271,9 @@
 
 
 <style>
-  .lane-svg-wrap { width: 100%; height: 100%; }
-  .lane-svg { width: 100%; height: 100%; display: block; }
+  .lane-svg-wrap { width: 100%; height: 100%; overflow: hidden; }
+  .lane-svg { width: 100%; height: 100%; display: block; overflow: hidden; }
+  .slide-group { transition: transform 300ms cubic-bezier(0.0, 0.0, 0.2, 1); }
   .grid-line { stroke: var(--grid-line); stroke-width: 0.5; }
   .future-zone { fill: var(--future-zone); }
   .ribbon { fill: var(--ribbon-fill); }
@@ -278,4 +288,7 @@
   .timeout-label { font-family: 'Martian Mono', monospace; font-size: 5px; font-weight: 400; fill: var(--timeout-stroke); opacity: 0.5; }
   /* Heatmap */
   .heatmap-cell { cursor: default; }
+  @media (prefers-reduced-motion: reduce) {
+    .slide-group { transition: none; }
+  }
 </style>

--- a/src/lib/components/LanesView.svelte
+++ b/src/lib/components/LanesView.svelte
@@ -89,7 +89,7 @@
     let keyParts = `${epoch}`;
     for (const ep of endpoints) {
       const epState = $measurementStore.endpoints[ep.id];
-      keyParts += `:${epState?.samples.tailIndex ?? 0}`;
+      keyParts += `|${ep.id}:${epState?.samples.tailIndex ?? 0}`;
     }
     if (keyParts === heatmapCacheKey) return cachedHeatmapCells;
 

--- a/src/lib/components/LanesView.svelte
+++ b/src/lib/components/LanesView.svelte
@@ -2,7 +2,7 @@
 <script lang="ts">
   import { SvelteMap } from 'svelte/reactivity';
   import { endpointStore } from '$lib/stores/endpoints';
-  import { measurementStore } from '$lib/stores/measurements';
+  import { measurementStore, incrementalLossCounter } from '$lib/stores/measurements';
   import { statisticsStore } from '$lib/stores/statistics';
   import { settingsStore } from '$lib/stores/settings';
   import { uiStore } from '$lib/stores/ui';
@@ -63,9 +63,9 @@
     const base = baseFrame;
     if (!base.hasData) return { ...base, ribbonsByEndpoint: new Map() as ReadonlyMap<string, RibbonData> };
 
-    // Count total samples across all endpoints
+    // Count total samples via tailIndex (monotonic, avoids length ambiguity with RingBuffer)
     const totalSamples = Object.values($measurementStore.endpoints)
-      .reduce((sum, ep) => sum + ep.samples.length, 0);
+      .reduce((sum, ep) => sum + ep.samples.tailIndex, 0);
 
     // Recompute ribbons every other round (≈ endpoints.length * 2 new samples)
     // or immediately when not running (final state accuracy)
@@ -79,8 +79,20 @@
     return { ...base, ribbonsByEndpoint: cachedRibbons };
   });
 
-  // Compute heatmap cells per endpoint (all samples, not windowed)
+  // Compute heatmap cells per endpoint with compound epoch:tailIndex cache key
+  let heatmapCacheKey = '';
+  let cachedHeatmapCells: ReadonlyMap<string, readonly HeatmapCellData[]> = new Map();
+
   const heatmapCellsByEndpoint: ReadonlyMap<string, readonly HeatmapCellData[]> = $derived.by(() => {
+    const epoch = $measurementStore.epoch;
+    // Build compound cache key from epoch + tailIndex of each endpoint
+    let keyParts = `${epoch}`;
+    for (const ep of endpoints) {
+      const epState = $measurementStore.endpoints[ep.id];
+      keyParts += `:${epState?.samples.tailIndex ?? 0}`;
+    }
+    if (keyParts === heatmapCacheKey) return cachedHeatmapCells;
+
     // eslint-disable-next-line svelte/prefer-svelte-reactivity
     const map = new Map<string, readonly HeatmapCellData[]>();
     const startedAt = $measurementStore.startedAt;
@@ -93,6 +105,8 @@
       }
       map.set(ep.id, computeHeatmapCells(epState.samples, stats, startedAt));
     }
+    heatmapCacheKey = keyParts;
+    cachedHeatmapCells = map;
     return map;
   });
 
@@ -311,14 +325,11 @@
   function getLaneProps(endpointId: string) {
     const stats = $statisticsStore[endpointId];
     const epState = $measurementStore.endpoints[endpointId];
-    const samples = epState?.samples ?? [];
     if (!stats || !stats.ready) {
       const lastLatency = epState?.lastLatency ?? 0;
       return { p50: lastLatency, p95: lastLatency, p99: lastLatency, jitter: 0, lossPercent: 0, ready: false };
     }
-    const totalSamples = samples.length;
-    const lossSamples = samples.filter(s => s.status !== 'ok').length;
-    const lossPercent = totalSamples > 0 ? (lossSamples / totalSamples) * 100 : 0;
+    const lossPercent = incrementalLossCounter.getCounts(endpointId).lossPercent;
     return { p50: stats.p50, p95: stats.p95, p99: stats.p99, jitter: stats.stddev, lossPercent, ready: true };
   }
 </script>

--- a/src/lib/components/LatencyLegend.svelte
+++ b/src/lib/components/LatencyLegend.svelte
@@ -1,0 +1,51 @@
+<!-- src/lib/components/LatencyLegend.svelte -->
+<!-- Minimal gradient bar legend showing the latency color scale.              -->
+<!-- Apple-style: thin, rounded, unobtrusive. Labels at key thresholds.        -->
+<script lang="ts">
+  import { tokens } from '$lib/tokens';
+  import { latencyToColor } from '$lib/renderers/color-map';
+
+  // Sample 6 evenly-spaced colors from the ramp for the CSS gradient
+  const stops = [0, 50, 100, 200, 500, 1000, 1500].map(
+    ms => latencyToColor(ms)
+  );
+
+  const gradient = `linear-gradient(to right, ${stops.join(', ')})`;
+</script>
+
+<div
+  class="legend"
+  role="img"
+  aria-label="Latency color scale: cyan is fast, red is slow"
+  style:--mono={tokens.typography.mono.fontFamily}
+  style:--t3={tokens.color.text.t3}
+  style:--t4={tokens.color.text.t4}
+>
+  <span class="label">Fast</span>
+  <div class="bar" style:background={gradient}></div>
+  <span class="label">Slow</span>
+</div>
+
+<style>
+  .legend {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    user-select: none;
+  }
+
+  .bar {
+    width: 80px;
+    height: 4px;
+    border-radius: 2px;
+    opacity: 0.7;
+  }
+
+  .label {
+    font-family: var(--mono);
+    font-size: 9px;
+    font-weight: 300;
+    color: var(--t4);
+    letter-spacing: 0.04em;
+  }
+</style>

--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -2,7 +2,7 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   import { get } from 'svelte/store';
-  import { measurementStore } from '$lib/stores/measurements';
+  import { measurementStore, incrementalTimestampTracker } from '$lib/stores/measurements';
   import { endpointStore } from '$lib/stores/endpoints';
   import { settingsStore } from '$lib/stores/settings';
   import { tokens } from '$lib/tokens';
@@ -35,25 +35,11 @@
   const visibleStart = $derived(Math.max(1, currentRound - visibleSpan + 1));
   const visibleEnd = $derived(Math.max(visibleSpan, currentRound));
 
-  // Earliest timestamp per round across all endpoints (index i = round i)
-  const sampleTimestamps = $derived.by((): readonly number[] => {
-    const endpoints = Object.values($measurementStore.endpoints);
-    // eslint-disable-next-line svelte/prefer-svelte-reactivity
-    const byRound = new Map<number, number>();
-    for (const ep of endpoints) {
-      for (const sample of ep.samples) {
-        const prev = byRound.get(sample.round);
-        if (prev === undefined || sample.timestamp < prev) {
-          byRound.set(sample.round, sample.timestamp);
-        }
-      }
-    }
-    const maxRound = currentRound;
-    const result: number[] = [];
-    for (let r = 0; r <= maxRound; r++) {
-      result.push(byRound.get(r) ?? 0);
-    }
-    return result;
+  // Earliest timestamp per round across all endpoints — O(1) read from incremental tracker.
+  // $measurementStore.roundCounter triggers reactive re-evaluation when new rounds arrive.
+  const sampleTimestamps: readonly number[] = $derived.by(() => {
+    void $measurementStore.roundCounter; // reactive subscription trigger
+    return incrementalTimestampTracker.timestamps;
   });
 
   onMount(() => {

--- a/src/lib/components/SettingsDrawer.svelte
+++ b/src/lib/components/SettingsDrawer.svelte
@@ -8,6 +8,8 @@
   import { settingsStore } from '$lib/stores/settings';
   import { measurementStore } from '$lib/stores/measurements';
   import { endpointStore } from '$lib/stores/endpoints';
+  import { clearPersistedSettings } from '$lib/utils/persistence';
+  import { DEFAULT_SETTINGS } from '$lib/types';
   import { tokens } from '$lib/tokens';
 
 
@@ -116,6 +118,7 @@
   }
 
   let showClearConfirm = $state(false);
+  let showResetConfirm = $state(false);
 
   function requestClear(): void {
     showClearConfirm = true;
@@ -134,6 +137,28 @@
 
   function cancelClear(): void {
     showClearConfirm = false;
+  }
+
+  function requestReset(): void {
+    showResetConfirm = true;
+  }
+
+  function confirmReset(): void {
+    if (isRunning) return;
+    showResetConfirm = false;
+    clearPersistedSettings();
+    endpointStore.reset();
+    settingsStore.set({ ...DEFAULT_SETTINGS });
+    measurementStore.reset();
+    // Re-init default endpoints in measurement store
+    const endpoints = get(endpointStore);
+    for (const ep of endpoints) {
+      measurementStore.initEndpoint(ep.id);
+    }
+  }
+
+  function cancelReset(): void {
+    showResetConfirm = false;
   }
 </script>
 
@@ -251,10 +276,28 @@
       <div class="danger-zone">
         <div class="danger-header">
           <span class="danger-label">Danger zone</span>
-          <span class="danger-desc">Clears all data, stats, and history</span>
         </div>
+
+        <!-- Reset to defaults -->
+        {#if !showResetConfirm}
+          <button type="button" class="btn-danger" disabled={isRunning} aria-disabled={isRunning} onclick={requestReset}>
+            Reset to defaults
+          </button>
+        {:else}
+          <div class="confirm-group" role="alert" aria-live="assertive">
+            <p class="confirm-text">Restores default endpoints and settings. Continue?</p>
+            <div class="confirm-actions">
+              <button type="button" class="btn-danger" disabled={isRunning} onclick={confirmReset}>Yes, reset</button>
+              <button type="button" class="btn-secondary" onclick={cancelReset}>Cancel</button>
+            </div>
+          </div>
+        {/if}
+
+        <!-- Clear results -->
         {#if !showClearConfirm}
-          <button type="button" class="btn-danger" disabled={isRunning} aria-disabled={isRunning} onclick={requestClear}>Clear all results</button>
+          <button type="button" class="btn-danger" disabled={isRunning} aria-disabled={isRunning} onclick={requestClear}>
+            Clear all results
+          </button>
         {:else}
           <div class="confirm-group" role="alert" aria-live="assertive">
             <p class="confirm-text">This cannot be undone. Continue?</p>

--- a/src/lib/components/TimelineCanvas.svelte
+++ b/src/lib/components/TimelineCanvas.svelte
@@ -149,7 +149,7 @@
       if (newCount > prevCount) {
         const latestSample = epState.samples.at(epState.samples.length - 1);
         const points = currentFrameData.pointsByEndpoint.get(ep.id);
-        const latestPoint = points?.[newCount - 1];
+        const latestPoint = points?.[points.length - 1];
         if (latestSample && latestPoint && timelineRenderer) {
           const { cx, cy } = timelineRenderer.toCanvasCoords(latestPoint);
           const ping: SonarPing = {

--- a/src/lib/components/TimelineCanvas.svelte
+++ b/src/lib/components/TimelineCanvas.svelte
@@ -39,7 +39,7 @@
     const ep = endpoints.find(e => e.id === pt.endpointId);
     const label = ep?.label || ep?.url || pt.endpointId;
     const latencyStr = pt.status === 'timeout' ? 'Timeout'
-      : pt.status === 'error' ? 'Error'
+      : pt.status === 'error' ? (pt.errorMessage ?? 'Error')
       : pt.latency >= 1000 ? `${(pt.latency / 1000).toFixed(2)}s`
       : `${Math.round(pt.latency)}ms`;
     tooltipText = `${label} · Round ${pt.round} · ${latencyStr}`;
@@ -144,10 +144,10 @@
       if (!epState || epState.samples.length === 0) continue;
 
       const prevCount = sampleCounts.get(ep.id) ?? 0;
-      const newCount = epState.samples.length;
+      const newCount = epState.samples.tailIndex;
 
       if (newCount > prevCount) {
-        const latestSample = epState.samples[newCount - 1];
+        const latestSample = epState.samples.at(epState.samples.length - 1);
         const points = currentFrameData.pointsByEndpoint.get(ep.id);
         const latestPoint = points?.[newCount - 1];
         if (latestSample && latestPoint && timelineRenderer) {

--- a/src/lib/engine/measurement-engine.ts
+++ b/src/lib/engine/measurement-engine.ts
@@ -31,6 +31,8 @@ export class MeasurementEngine {
   private expectedResponses: number = 0;
   private flushTimers: Map<number, ReturnType<typeof setTimeout>> = new Map();
   private lastFlushedRound = -1;
+  _paused = false;
+  private _visibilityHandler: (() => void) | null = null;
 
   constructor(workerFactory?: WorkerFactory) {
     this.workerFactory = workerFactory ?? defaultWorkerFactory;
@@ -73,6 +75,13 @@ export class MeasurementEngine {
       this._spawnWorkers(endpoints);
       measurementStore.setLifecycle('running');
       this.freezeDetector.start();
+
+      // Register visibility change handler to pause/resume when tab is hidden
+      if (typeof document !== 'undefined') {
+        this._visibilityHandler = () => this._handleVisibilityChange();
+        document.addEventListener('visibilitychange', this._visibilityHandler);
+      }
+
       // Dispatch the first round immediately (no delay for the very first round).
       this._dispatchRound();
     } catch (err: unknown) {
@@ -86,6 +95,13 @@ export class MeasurementEngine {
     if (lifecycle === 'idle') return;
 
     measurementStore.setLifecycle('stopping');
+
+    // Remove visibility change listener
+    if (this._visibilityHandler && typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', this._visibilityHandler);
+      this._visibilityHandler = null;
+    }
+    this._paused = false;
 
     if (this.roundTimer !== null) {
       clearTimeout(this.roundTimer);
@@ -215,6 +231,7 @@ export class MeasurementEngine {
             latency: 0,
             status: 'error' as const,
             timestamp,
+            errorMessage: msg.message || msg.errorType,
           };
       }
     });
@@ -225,6 +242,37 @@ export class MeasurementEngine {
     // This prevents round overlap and self-inflicted network contention.
     if (get(measurementStore).lifecycle === 'running') {
       this._scheduleNextRound();
+    }
+  }
+
+  // ── Visibility-aware pause/resume ─────────────────────────────────────────
+
+  _pause(): void {
+    if (this._paused) return;
+    this._paused = true;
+    if (this.roundTimer !== null) {
+      clearTimeout(this.roundTimer);
+      this.roundTimer = null;
+    }
+  }
+
+  _resume(): void {
+    if (!this._paused) return;
+    this._paused = false;
+    // Clear any orphaned roundTimer that _flushRound may have set during pause
+    if (this.roundTimer !== null) {
+      clearTimeout(this.roundTimer);
+      this.roundTimer = null;
+    }
+    this._scheduleNextRound();
+  }
+
+  _handleVisibilityChange(): void {
+    if (typeof document === 'undefined') return;
+    if (document.visibilityState === 'hidden') {
+      this._pause();
+    } else {
+      this._resume();
     }
   }
 
@@ -244,21 +292,40 @@ export class MeasurementEngine {
     });
   }
 
+  /** Number of rounds over which to ease from burst (0ms) to monitor delay. */
+  private static readonly TRANSITION_ROUNDS = 10;
+
   /**
-   * Two-phase cadence: burst (0ms delay) for the first N rounds, then
-   * monitor (configurable delay) for all subsequent rounds.
+   * Three-phase cadence: burst (0ms) → ease-in transition → monitor (full delay).
+   * The transition uses a quadratic ease-in so the rhythm feels smooth rather
+   * than snapping from rapid-fire to one-second gaps.
    */
   private _scheduleNextRound(): void {
     const { burstRounds, monitorDelay } = get(settingsStore);
     const { roundCounter } = get(measurementStore);
 
-    const isBurst = roundCounter < burstRounds;
-    const delay = isBurst ? 0 : monitorDelay;
+    let delay: number;
+    if (roundCounter < burstRounds) {
+      // Burst phase: no delay
+      delay = 0;
+    } else {
+      const roundsIntoCruise = roundCounter - burstRounds;
+      if (roundsIntoCruise < MeasurementEngine.TRANSITION_ROUNDS) {
+        // Transition: quadratic ease-in from 0 → monitorDelay
+        const t = (roundsIntoCruise + 1) / MeasurementEngine.TRANSITION_ROUNDS;
+        delay = Math.round(monitorDelay * t * t);
+      } else {
+        // Steady-state monitor
+        delay = monitorDelay;
+      }
+    }
 
     this.roundTimer = setTimeout(() => this._dispatchRound(), delay);
   }
 
-  private _dispatchRound(): void {
+  _dispatchRound(): void {
+    if (this._paused) return;
+
     const lifecycle = get(measurementStore).lifecycle;
     if (lifecycle !== 'running') return;
 

--- a/src/lib/renderers/color-map.ts
+++ b/src/lib/renderers/color-map.ts
@@ -13,16 +13,18 @@ export const STATUS_COLORS = {
 } as const;
 
 // ── Anchor points ──────────────────────────────────────────────────────────
+// Cyan-anchored thermal gradient with log-weighted thresholds.
+// Cool→warm sweep preserves brand identity while reading intuitively.
 // Each entry: [latency_ms, r, g, b]
 const ANCHORS: readonly [number, number, number, number][] = [
-  [0,    0x00, 0xb4, 0xd8], // #00b4d8 — excellent/cyan
-  [25,   0x00, 0x96, 0xc7], // #0096c7 — fast
-  [50,   0x00, 0x77, 0xb6], // #0077b6 — good/blue
-  [100,  0x90, 0xbe, 0x6d], // #90be6d — moderate/green
-  [200,  0xf9, 0xc7, 0x4f], // #f9c74f — elevated/yellow
-  [500,  0xf8, 0x96, 0x1e], // #f8961e — slow/orange
-  [1000, 0xf3, 0x72, 0x2c], // #f3722c — critical
-  [1500, 0xf9, 0x41, 0x44], // #f94144 — failing/red
+  [0,    0x67, 0xe8, 0xf9], // #67e8f9 — excellent / cyan (brand accent)
+  [10,   0x2d, 0xd4, 0xbf], // #2dd4bf — great / teal
+  [25,   0x22, 0xc5, 0x5e], // #22c55e — good / green
+  [50,   0xea, 0xb3, 0x08], // #eab308 — moderate / yellow
+  [100,  0xf9, 0x73, 0x16], // #f97316 — elevated / orange
+  [200,  0xef, 0x44, 0x44], // #ef4444 — degraded / red
+  [500,  0xdc, 0x26, 0x26], // #dc2626 — critical / deep red
+  [1500, 0xb9, 0x1c, 0x1c], // #b91c1c — failing / crimson
 ];
 
 // ── Interpolation helper ────────────────────────────────────────────────────

--- a/src/lib/renderers/render-scheduler.ts
+++ b/src/lib/renderers/render-scheduler.ts
@@ -15,6 +15,7 @@ type RendererFn = () => void;
 
 const OVERLOAD_THRESHOLD_MS = 12;  // frames above this count toward the streak
 const OVERLOAD_STREAK_LIMIT = 10;  // consecutive frames before effects are disabled
+const RECOVERY_STREAK_LIMIT = 60;  // consecutive under-budget frames to re-enable effects
 
 export class RenderScheduler {
   private readonly dataRenderers: RendererFn[] = [];
@@ -27,6 +28,7 @@ export class RenderScheduler {
 
   private overloadStreak = 0;
   private effectsDisabled = false;
+  private recoveryStreak = 0;
 
   // ── Registration ─────────────────────────────────────────────────────────
 
@@ -93,7 +95,20 @@ export class RenderScheduler {
   }
 
   private updateOverloadStreak(dataMs: number): void {
-    if (this.effectsDisabled) return;
+    if (this.effectsDisabled) {
+      // Recovery phase: accumulate under-budget frames
+      if (dataMs > OVERLOAD_THRESHOLD_MS) {
+        this.recoveryStreak = 0; // reset on any overload frame
+      } else {
+        this.recoveryStreak++;
+        if (this.recoveryStreak >= RECOVERY_STREAK_LIMIT) {
+          this.effectsDisabled = false;
+          this.recoveryStreak = 0;
+          this.overloadStreak = 0;
+        }
+      }
+      return;
+    }
 
     if (dataMs > OVERLOAD_THRESHOLD_MS) {
       this.overloadStreak++;

--- a/src/lib/renderers/timeline-data-pipeline.ts
+++ b/src/lib/renderers/timeline-data-pipeline.ts
@@ -3,6 +3,7 @@
 // No class, no mutable state. Entry point: prepareFrame().
 
 import { tokens } from '$lib/tokens';
+import { latencyToColor } from './color-map';
 import type {
   Endpoint,
   MeasurementState,
@@ -214,7 +215,7 @@ export function computeRibbons(
       // Fill buffer with ok latencies from the window, count them
       let okCount = 0;
       for (let j = i - WINDOW_SIZE + 1; j <= i; j++) {
-        const s = samples[j];
+        const s = samples.at(j);
         if (s && s.status === 'ok') {
           sortBuf[okCount++] = s.latency;
         }
@@ -238,7 +239,7 @@ export function computeRibbons(
       const i50 = Math.max(0, Math.ceil((50 / 100) * okCount) - 1);
       const i75 = Math.max(0, Math.ceil((75 / 100) * okCount) - 1);
 
-      const sample = samples[i];
+      const sample = samples.at(i);
       if (!sample) continue;
       const x = sample.round;
 
@@ -297,7 +298,7 @@ export function computeRibbonsPerLane(
     for (let i = WINDOW_SIZE - 1; i < samples.length; i++) {
       let okCount = 0;
       for (let j = i - WINDOW_SIZE + 1; j <= i; j++) {
-        const s = samples[j];
+        const s = samples.at(j);
         if (s && s.status === 'ok') {
           sortBuf[okCount++] = s.latency;
         }
@@ -318,7 +319,7 @@ export function computeRibbonsPerLane(
       const i50 = Math.max(0, Math.ceil((50 / 100) * okCount) - 1);
       const i75 = Math.max(0, Math.ceil((75 / 100) * okCount) - 1);
 
-      const sample = samples[i];
+      const sample = samples.at(i);
       if (!sample) continue;
       const x = sample.round;
 
@@ -365,7 +366,7 @@ export function formatElapsed(ms: number): string {
 const HEATMAP_MAX_CELLS = 200;
 
 export function computeHeatmapCells(
-  samples: readonly MeasurementSample[],
+  samples: { readonly length: number; at(index: number): MeasurementSample | undefined },
   stats: EndpointStatistics,
   startedAt: number | null,
 ): readonly HeatmapCellData[] {
@@ -388,21 +389,21 @@ export function computeHeatmapCells(
     let worstStatus: SampleStatus = 'ok';
 
     for (let i = startIdx; i <= endIdx; i++) {
-      const s = samples[i];
+      const s = samples.at(i);
       if (!s) continue;
       if (s.latency > worstLatency) worstLatency = s.latency;
       if (s.status === 'timeout' || s.status === 'error') worstStatus = s.status;
     }
 
-    const startSample = samples[startIdx];
-    const endSample = samples[endIdx];
+    const startSample = samples.at(startIdx);
+    const endSample = samples.at(endIdx);
     const startRound = startSample?.round ?? startIdx + 1;
     const endRound = endSample?.round ?? endIdx + 1;
     const base = startedAt ?? 0;
     const startElapsed = base > 0 ? Math.max(0, (startSample?.timestamp ?? 0) - base) : 0;
     const endElapsed = base > 0 ? Math.max(0, (endSample?.timestamp ?? 0) - base) : 0;
 
-    const color = heatmapColor(worstLatency, worstStatus, stats);
+    const color = heatmapColor(worstLatency, worstStatus);
     result.push({ startRound, endRound, worstLatency, worstStatus, startElapsed, endElapsed, color });
   }
 
@@ -410,13 +411,10 @@ export function computeHeatmapCells(
 }
 
 function heatmapColor(
-  latency: number, status: SampleStatus, stats: EndpointStatistics,
+  latency: number, status: SampleStatus,
 ): string {
   if (status === 'timeout' || status === 'error') return tokens.color.heatmap.timeout;
-  if (latency < stats.p25) return tokens.color.heatmap.fast;
-  if (latency <= stats.p75) return tokens.color.heatmap.normal;
-  if (latency <= stats.p95) return tokens.color.heatmap.elevated;
-  return tokens.color.heatmap.slow;
+  return latencyToColor(latency);
 }
 
 // ── Main entry point ───────────────────────────────────────────────────────
@@ -463,7 +461,7 @@ export function prepareFrame(
     const { samples } = epState;
     const epLatencies = new Float64Array(samples.length);
     for (let i = 0; i < samples.length; i++) {
-      epLatencies[i] = samples[i]?.latency ?? 0;
+      epLatencies[i] = samples.at(i)?.latency ?? 0;
     }
     epLatencies.sort();
     const epYRange = computeYRangeFromSorted(epLatencies);
@@ -480,7 +478,7 @@ export function prepareFrame(
     const epId = ep.id;
     const epColor = ep.color;
     for (let i = 0; i < n; i++) {
-      const s = samples[i];
+      const s = samples.at(i);
       if (!s) continue;
       const round = s.round;
       if (round > maxRound) maxRound = round;
@@ -492,6 +490,7 @@ export function prepareFrame(
         endpointId: epId,
         round,
         color: epColor,
+        ...(s.errorMessage !== undefined ? { errorMessage: s.errorMessage } : {}),
       };
     }
 

--- a/src/lib/share/hash-router.ts
+++ b/src/lib/share/hash-router.ts
@@ -62,9 +62,11 @@ export function applySharePayload(payload: SharePayload): string[] {
 
       endpointsRecord[id] = {
         endpointId: id,
-        samples,
+        // Plain array is converted to RingBuffer by loadSnapshot()
+        samples: samples as unknown as MeasurementState['endpoints'][string]['samples'],
         lastLatency: lastSample?.latency ?? null,
         lastStatus: lastSample?.status ?? null,
+        lastErrorMessage: null,
         tierLevel: 1,
       };
     });

--- a/src/lib/stores/measurements.ts
+++ b/src/lib/stores/measurements.ts
@@ -11,6 +11,30 @@ import type {
   TimingPayload,
   FreezeEvent,
 } from '../types';
+import { RingBuffer, DEFAULT_RING_CAPACITY, proxyRingBuffer } from '../utils/ring-buffer';
+import { IncrementalLossCounter } from '../utils/incremental-loss-counter';
+import { SortedInsertionBuffer } from '../utils/sorted-insertion-buffer';
+import { IncrementalTimestampTracker } from '../utils/incremental-timestamp-tracker';
+import { sessionHistoryStore } from './session-history';
+
+// ── Module-level singletons ────────────────────────────────────────────────
+export const incrementalLossCounter = new IncrementalLossCounter();
+export const incrementalTimestampTracker = new IncrementalTimestampTracker();
+const sortedBuffers = new Map<string, SortedInsertionBuffer>();
+
+function getSortedBuffer(endpointId: string): SortedInsertionBuffer {
+  let buf = sortedBuffers.get(endpointId);
+  if (!buf) {
+    buf = new SortedInsertionBuffer();
+    sortedBuffers.set(endpointId, buf);
+  }
+  return buf;
+}
+
+/** Public accessor for the sorted buffer of an endpoint. */
+export function getSortedBufferForEndpoint(endpointId: string): SortedInsertionBuffer {
+  return getSortedBuffer(endpointId);
+}
 
 const INITIAL_STATE: MeasurementState = {
   lifecycle: 'idle',
@@ -58,19 +82,28 @@ function createMeasurementStore() {
     },
 
     initEndpoint(endpointId: string): void {
-      update(s => ({
-        ...s,
-        endpoints: {
-          ...s.endpoints,
-          [endpointId]: {
-            endpointId,
-            samples: [],
-            lastLatency: null,
-            lastStatus: null,
-            tierLevel: 1,
+      update(s => {
+        const rawRb = new RingBuffer<MeasurementSample>({ capacity: DEFAULT_RING_CAPACITY });
+        rawRb.onEvict((evicted) => {
+          sessionHistoryStore.accumulate(endpointId, evicted);
+        });
+        const rb = proxyRingBuffer(rawRb);
+
+        return {
+          ...s,
+          endpoints: {
+            ...s.endpoints,
+            [endpointId]: {
+              endpointId,
+              samples: rb as unknown as import('../types').SampleBuffer,
+              lastLatency: null,
+              lastStatus: null,
+              lastErrorMessage: null,
+              tierLevel: 1,
+            },
           },
-        },
-      }));
+        };
+      });
     },
 
     removeEndpoint(endpointId: string): void {
@@ -78,6 +111,8 @@ function createMeasurementStore() {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { [endpointId]: _removed, ...rest } = s.endpoints;
         const { errorCount, timeoutCount } = recomputeCounts(rest);
+        sortedBuffers.delete(endpointId);
+        incrementalLossCounter.removeEndpoint(endpointId);
         return { ...s, endpoints: rest, errorCount, timeoutCount };
       });
     },
@@ -90,43 +125,14 @@ function createMeasurementStore() {
       timestamp: number,
       tier2?: TimingPayload
     ): void {
-      update(s => {
-        const existing = s.endpoints[endpointId];
-        if (!existing) return s;
-
-        const sample: MeasurementSample = {
-          round,
-          latency,
-          status,
-          timestamp,
-          ...(tier2 !== undefined ? { tier2 } : {}),
-        };
-
-        const tierLevel: 1 | 2 =
-          tier2 !== undefined && (tier2.dnsLookup !== 0 || tier2.tcpConnect !== 0 || tier2.ttfb !== 0)
-            ? 2
-            : existing.tierLevel;
-
-        // Mutable push — O(1) amortized instead of O(n) spread
-        existing.samples.push(sample);
-
-        const { errors, timeouts } = countDelta(status);
-
-        return {
-          ...s,
-          errorCount: s.errorCount + errors,
-          timeoutCount: s.timeoutCount + timeouts,
-          endpoints: {
-            ...s.endpoints,
-            [endpointId]: {
-              ...existing,
-              lastLatency: latency,
-              lastStatus: status,
-              tierLevel,
-            },
-          },
-        };
-      });
+      this.addSamples([{
+        endpointId,
+        round,
+        latency,
+        status,
+        timestamp,
+        tier2,
+      }]);
     },
 
     addSamples(entries: Array<{
@@ -136,6 +142,7 @@ function createMeasurementStore() {
       status: SampleStatus;
       timestamp: number;
       tier2?: TimingPayload;
+      errorMessage?: string;
     }>): void {
       update(s => {
         // Clone the top-level endpoints map once to trigger reactivity
@@ -153,6 +160,7 @@ function createMeasurementStore() {
             status: entry.status,
             timestamp: entry.timestamp,
             ...(entry.tier2 !== undefined ? { tier2: entry.tier2 } : {}),
+            ...(entry.errorMessage !== undefined ? { errorMessage: entry.errorMessage } : {}),
           };
 
           const tierLevel: 1 | 2 =
@@ -160,18 +168,27 @@ function createMeasurementStore() {
               ? 2
               : existing.tierLevel;
 
-          // Insert in round order — almost always appends (O(1) typical),
-          // but handles stragglers arriving after the next round flushed.
-          const samples = existing.samples;
-          const lastSample = samples[samples.length - 1];
-          if (samples.length === 0 || sample.round >= (lastSample?.round ?? 0)) {
-            samples.push(sample);
+          // Cast to RingBuffer for push/insertOrdered
+          const rb = existing.samples as unknown as RingBuffer<MeasurementSample>;
+
+          // Detect straggler: if sample round < newest round in buffer
+          const lastRound = rb.back?.round;
+          if (lastRound !== undefined && sample.round < lastRound) {
+            rb.insertOrdered(sample, (existing) => sample.round < existing.round);
           } else {
-            // Walk backward to find insertion point (usually 1-2 steps)
-            let i = samples.length - 1;
-            while (i > 0 && (samples[i - 1]?.round ?? 0) > sample.round) i--;
-            samples.splice(i, 0, sample);
+            rb.push(sample);
           }
+
+          // Update incremental loss counter
+          incrementalLossCounter.addSamples([{ endpointId: entry.endpointId, status: entry.status }]);
+
+          // Update sorted insertion buffer for ok samples
+          if (entry.status === 'ok') {
+            getSortedBuffer(entry.endpointId).insert(entry.latency);
+          }
+
+          // Update timestamp tracker
+          incrementalTimestampTracker.processNewSamples(entry.endpointId, rb, rb.tailIndex);
 
           const { errors, timeouts } = countDelta(entry.status);
           errorDelta += errors;
@@ -182,6 +199,7 @@ function createMeasurementStore() {
             ...existing,
             lastLatency: entry.latency,
             lastStatus: entry.status,
+            lastErrorMessage: entry.status === 'error' ? (entry.errorMessage ?? null) : null,
             tierLevel,
           };
         }
@@ -212,11 +230,59 @@ function createMeasurementStore() {
     },
 
     loadSnapshot(snapshot: MeasurementState): void {
-      const { errorCount, timeoutCount } = recomputeCounts(snapshot.endpoints);
-      set({ ...snapshot, errorCount, timeoutCount });
+      // Reset ALL incremental state first
+      incrementalLossCounter.reset();
+      incrementalTimestampTracker.reset();
+      sortedBuffers.clear();
+      sessionHistoryStore.reset();
+
+      // Rebuild endpoints with RingBuffers and incremental structures
+      const nextEndpoints: MeasurementState['endpoints'] = {};
+
+      for (const [endpointId, epState] of Object.entries(snapshot.endpoints)) {
+        const rawRb = new RingBuffer<MeasurementSample>({ capacity: DEFAULT_RING_CAPACITY });
+        rawRb.onEvict((evicted) => {
+          sessionHistoryStore.accumulate(endpointId, evicted);
+        });
+
+        // Convert samples to array if needed (snapshot may have plain arrays)
+        const samplesArray = Array.isArray(epState.samples)
+          ? epState.samples
+          : (epState.samples as unknown as RingBuffer<MeasurementSample>).toArray();
+
+        // Load samples into ring buffer
+        rawRb.loadFrom(samplesArray);
+        const rb = proxyRingBuffer(rawRb);
+
+        // Rebuild loss counter incrementally per endpoint (NOT loadFrom which clears on each call)
+        incrementalLossCounter.addSamples(
+          samplesArray.map(s => ({ endpointId, status: s.status }))
+        );
+
+        // Rebuild sorted buffer
+        const sortedBuf = getSortedBuffer(endpointId);
+        sortedBuf.loadFrom(
+          samplesArray.filter(s => s.status === 'ok').map(s => s.latency)
+        );
+
+        // Rebuild timestamp tracker
+        incrementalTimestampTracker.processNewSamples(endpointId, rawRb, rawRb.tailIndex);
+
+        nextEndpoints[endpointId] = {
+          ...epState,
+          samples: rb as unknown as import('../types').SampleBuffer,
+        };
+      }
+
+      const { errorCount, timeoutCount } = recomputeCounts(nextEndpoints);
+      set({ ...snapshot, endpoints: nextEndpoints, errorCount, timeoutCount });
     },
 
     reset(): void {
+      incrementalLossCounter.reset();
+      incrementalTimestampTracker.reset();
+      sortedBuffers.clear();
+      sessionHistoryStore.reset();
       set({ ...INITIAL_STATE });
     },
   };

--- a/src/lib/stores/session-history.ts
+++ b/src/lib/stores/session-history.ts
@@ -1,0 +1,178 @@
+// src/lib/stores/session-history.ts
+// Write-only per-hour eviction accumulator.
+// Plain class — NOT a Svelte store. Compacts measurement samples into hourly
+// buckets to bound memory during long sessions.
+
+import type { MeasurementSample } from '../types';
+import { percentileSorted } from '../utils/statistics';
+
+// ── Internal bucket shape ───────────────────────────────────────────────────
+
+interface HourBucket {
+  hourKey: string;
+  count: number;
+  errorCount: number;
+  timeoutCount: number;
+  min: number;
+  max: number;
+  sum: number;
+  sumSquares: number;
+  /** Sorted ascending latency array — only ok-sample latencies */
+  latencies: number[];
+}
+
+// ── Public summary shape ────────────────────────────────────────────────────
+
+export interface HourSummary {
+  readonly hourKey: string;
+  readonly count: number;
+  readonly errorCount: number;
+  readonly timeoutCount: number;
+  readonly min: number;
+  readonly max: number;
+  readonly mean: number;
+  readonly variance: number;
+  readonly p50: number;
+  readonly p95: number;
+  readonly p99: number;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function hourKeyFromTimestamp(timestamp: number): string {
+  return new Date(timestamp).toISOString().slice(0, 13);
+}
+
+/**
+ * Binary-search insertion into a sorted ascending array (in-place).
+ * Duplicate values are allowed — inserted after existing equal values.
+ */
+function sortedInsert(arr: number[], value: number): void {
+  let lo = 0;
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (arr[mid] <= value) lo = mid + 1;
+    else hi = mid;
+  }
+  arr.splice(lo, 0, value);
+}
+
+function bucketToSummary(b: HourBucket): HourSummary {
+  const okCount = b.latencies.length;
+  const mean = okCount > 0 ? b.sum / okCount : 0;
+  // Population variance: E[x²] - (E[x])²
+  const variance = okCount > 0 ? b.sumSquares / okCount - mean * mean : 0;
+  const p50 = percentileSorted(b.latencies, 50);
+  const p95 = percentileSorted(b.latencies, 95);
+  const p99 = percentileSorted(b.latencies, 99);
+
+  return {
+    hourKey: b.hourKey,
+    count: b.count,
+    errorCount: b.errorCount,
+    timeoutCount: b.timeoutCount,
+    min: b.min,
+    max: b.max,
+    mean,
+    variance: Math.max(0, variance),
+    p50,
+    p95,
+    p99,
+  };
+}
+
+// ── SessionHistoryStore ─────────────────────────────────────────────────────
+
+export class SessionHistoryStore {
+  /** endpointId → (hourKey → HourBucket) */
+  private readonly _data: Map<string, Map<string, HourBucket>> = new Map();
+
+  /**
+   * Derive the hour bucket from sample.timestamp and upsert.
+   * Only ok-samples contribute to latency statistics.
+   */
+  accumulate(endpointId: string, sample: MeasurementSample): void {
+    const hourKey = hourKeyFromTimestamp(sample.timestamp);
+
+    let endpointBuckets = this._data.get(endpointId);
+    if (!endpointBuckets) {
+      endpointBuckets = new Map();
+      this._data.set(endpointId, endpointBuckets);
+    }
+
+    let bucket = endpointBuckets.get(hourKey);
+    if (!bucket) {
+      bucket = {
+        hourKey,
+        count: 0,
+        errorCount: 0,
+        timeoutCount: 0,
+        min: 0,
+        max: 0,
+        sum: 0,
+        sumSquares: 0,
+        latencies: [],
+      };
+      endpointBuckets.set(hourKey, bucket);
+    }
+
+    bucket.count++;
+
+    if (sample.status === 'error') {
+      bucket.errorCount++;
+    } else if (sample.status === 'timeout') {
+      bucket.timeoutCount++;
+    } else {
+      // ok sample — update latency statistics
+      const lat = sample.latency;
+      sortedInsert(bucket.latencies, lat);
+      bucket.sum += lat;
+      bucket.sumSquares += lat * lat;
+      if (bucket.latencies.length === 1) {
+        bucket.min = lat;
+        bucket.max = lat;
+      } else {
+        if (lat < bucket.min) bucket.min = lat;
+        if (lat > bucket.max) bucket.max = lat;
+      }
+    }
+  }
+
+  /**
+   * Returns all hour summaries for an endpoint, sorted chronologically by
+   * hourKey (ISO string sort = chronological for this format).
+   */
+  getSummaries(endpointId: string): readonly HourSummary[] {
+    const endpointBuckets = this._data.get(endpointId);
+    if (!endpointBuckets) return [];
+
+    return Array.from(endpointBuckets.values())
+      .sort((a, b) => (a.hourKey < b.hourKey ? -1 : a.hourKey > b.hourKey ? 1 : 0))
+      .map(bucketToSummary);
+  }
+
+  /** Returns the summary for a single hour bucket, or undefined if not found. */
+  getSummary(endpointId: string, hourKey: string): HourSummary | undefined {
+    const bucket = this._data.get(endpointId)?.get(hourKey);
+    return bucket ? bucketToSummary(bucket) : undefined;
+  }
+
+  /** Remove all history for a single endpoint. */
+  removeEndpoint(id: string): void {
+    this._data.delete(id);
+  }
+
+  /** Clear all history. */
+  reset(): void {
+    this._data.clear();
+  }
+
+  /** True when at least one sample has been accumulated. */
+  get hasHistory(): boolean {
+    return this._data.size > 0;
+  }
+}
+
+// ── Singleton ───────────────────────────────────────────────────────────────
+export const sessionHistoryStore = new SessionHistoryStore();

--- a/src/lib/stores/statistics.ts
+++ b/src/lib/stores/statistics.ts
@@ -38,7 +38,7 @@ export const statisticsStore = derived<typeof measurementStore, StatisticsState>
             endpointId,
             sortedBuffer,
             lossCounts,
-            endpointState.samples.length,
+            lossCounts.totalSamples,
             endpointState.samples,
           );
         } else {

--- a/src/lib/stores/statistics.ts
+++ b/src/lib/stores/statistics.ts
@@ -3,32 +3,51 @@
 // the measurement store changes. Pure derived state — no side effects.
 
 import { derived } from 'svelte/store';
-import { measurementStore } from './measurements';
-import { computeEndpointStatistics } from '../utils/statistics';
+import { measurementStore, incrementalLossCounter, getSortedBufferForEndpoint } from './measurements';
+import { computeEndpointStatistics, computeEndpointStatisticsFromBuffer } from '../utils/statistics';
 import type { StatisticsState, EndpointStatistics } from '../types';
 
-// Per-endpoint memoization: only recompute when sample count changes
-let cache: Record<string, { sampleCount: number; stats: EndpointStatistics }> = {};
+// Per-endpoint memoization: compound cache key ${epoch}:${tailIndex}
+// tailIndex never stalls at capacity (THE BET), epoch resets after loadSnapshot (B3 fix)
+let cache: Record<string, { cacheKey: string; stats: EndpointStatistics }> = {};
 
 export const statisticsStore = derived<typeof measurementStore, StatisticsState>(
   measurementStore,
   ($measurements) => {
     const result: StatisticsState = {};
     const nextCache: typeof cache = {};
+    const epoch = $measurements.epoch;
 
     for (const [endpointId, endpointState] of Object.entries($measurements.endpoints)) {
-      const sampleCount = endpointState.samples.length;
+      const tailIndex = endpointState.samples.tailIndex;
+      const cacheKey = `${epoch}:${tailIndex}`;
       const cached = cache[endpointId];
 
-      if (cached && cached.sampleCount === sampleCount) {
-        // Sample count unchanged — reuse cached stats
+      if (cached && cached.cacheKey === cacheKey) {
+        // Cache key unchanged — reuse cached stats
         result[endpointId] = cached.stats;
         nextCache[endpointId] = cached;
       } else {
-        // Recompute
-        const stats = computeEndpointStatistics(endpointId, endpointState.samples);
+        // Recompute using buffer-based path when sorted buffer is available
+        const sortedBuffer = getSortedBufferForEndpoint(endpointId);
+        const lossCounts = incrementalLossCounter.getCounts(endpointId);
+        let stats: EndpointStatistics;
+
+        if (sortedBuffer.length > 0 || lossCounts.totalSamples > 0) {
+          stats = computeEndpointStatisticsFromBuffer(
+            endpointId,
+            sortedBuffer,
+            lossCounts,
+            endpointState.samples.length,
+            endpointState.samples,
+          );
+        } else {
+          // Fallback for empty state
+          stats = computeEndpointStatistics(endpointId, endpointState.samples.toArray());
+        }
+
         result[endpointId] = stats;
-        nextCache[endpointId] = { sampleCount, stats };
+        nextCache[endpointId] = { cacheKey, stats };
       }
     }
 

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -159,11 +159,11 @@ export const tokens = {
     },
 
     heatmap: {
-      fast:     'rgba(103,232,249,.6)',   // cyan — clearly good
-      normal:   'rgba(148,163,184,.3)',   // slate — quiet, unalarming
-      elevated: '#fbbf24',                // amber — attention
-      slow:     'rgba(249,168,212,.7)',   // pink — problem
-      timeout:  '#fbcfe8',                // bright pink — critical
+      fast:     'rgba(103,232,249,.6)',   // cyan — clearly good (brand accent)
+      normal:   'rgba(234,179,8,.4)',     // yellow — moderate
+      elevated: 'rgba(249,115,22,.7)',    // orange — attention
+      slow:     'rgba(239,68,68,.7)',     // red — problem
+      timeout:  'rgba(185,28,28,.85)',    // crimson — critical
     },
 
     orb: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -82,13 +82,31 @@ export interface MeasurementSample {
   readonly status: SampleStatus;
   readonly timestamp: number;
   readonly tier2?: TimingPayload;
+  readonly errorMessage?: string;
+}
+
+/** Array-like interface backed by RingBuffer. Consumers read through this. */
+export interface SampleBuffer {
+  readonly length: number;
+  readonly tailIndex: number;
+  at(index: number): MeasurementSample | undefined;
+  [index: number]: MeasurementSample | undefined;
+  [Symbol.iterator](): Iterator<MeasurementSample>;
+  filter(predicate: (value: MeasurementSample, index: number) => boolean): MeasurementSample[];
+  map<U>(callbackfn: (value: MeasurementSample, index: number) => U): U[];
+  find(predicate: (value: MeasurementSample, index: number) => boolean): MeasurementSample | undefined;
+  reduce<U>(callbackfn: (accumulator: U, value: MeasurementSample, index: number) => U, initialValue: U): U;
+  slice(start?: number, end?: number): MeasurementSample[];
+  forEach(callbackfn: (value: MeasurementSample, index: number) => void): void;
+  toArray(): MeasurementSample[];
 }
 
 export interface EndpointMeasurementState {
   readonly endpointId: string;
-  samples: MeasurementSample[];
+  samples: SampleBuffer;
   lastLatency: number | null;
   lastStatus: SampleStatus | null;
+  lastErrorMessage: string | null;
   tierLevel: 1 | 2;
 }
 
@@ -257,6 +275,7 @@ export interface ScatterPoint {
   readonly endpointId: string;
   readonly round: number;
   readonly color: string;
+  readonly errorMessage?: string;
 }
 
 export interface HeatmapCell {

--- a/src/lib/utils/incremental-loss-counter.ts
+++ b/src/lib/utils/incremental-loss-counter.ts
@@ -1,0 +1,88 @@
+// src/lib/utils/incremental-loss-counter.ts
+// Lifetime O(1) loss counters per endpoint.
+// Counts are never decremented — they accumulate monotonically.
+
+import type { SampleStatus, MeasurementSample } from '../types';
+
+export interface LossCounts {
+  readonly totalSamples: number;
+  readonly errorCount: number;
+  readonly timeoutCount: number;
+  readonly lossPercent: number;
+}
+
+interface MutableCounts {
+  totalSamples: number;
+  errorCount: number;
+  timeoutCount: number;
+}
+
+const ZERO_COUNTS: LossCounts = {
+  totalSamples: 0,
+  errorCount: 0,
+  timeoutCount: 0,
+  lossPercent: 0,
+};
+
+export class IncrementalLossCounter {
+  private readonly _counts: Map<string, MutableCounts> = new Map();
+
+  /**
+   * Increment counters for each sample entry. O(k) where k = entries.length.
+   */
+  addSamples(entries: ReadonlyArray<{ endpointId: string; status: SampleStatus }>): void {
+    for (const { endpointId, status } of entries) {
+      let bucket = this._counts.get(endpointId);
+      if (!bucket) {
+        bucket = { totalSamples: 0, errorCount: 0, timeoutCount: 0 };
+        this._counts.set(endpointId, bucket);
+      }
+      bucket.totalSamples++;
+      if (status === 'error') bucket.errorCount++;
+      else if (status === 'timeout') bucket.timeoutCount++;
+    }
+  }
+
+  /**
+   * O(1) lookup. Returns zero counts for unknown endpoints.
+   */
+  getCounts(endpointId: string): LossCounts {
+    const bucket = this._counts.get(endpointId);
+    if (!bucket) return ZERO_COUNTS;
+
+    const { totalSamples, errorCount, timeoutCount } = bucket;
+    const lossPercent =
+      totalSamples === 0
+        ? 0
+        : ((errorCount + timeoutCount) / totalSamples) * 100;
+
+    return { totalSamples, errorCount, timeoutCount, lossPercent };
+  }
+
+  /** Remove a single endpoint's counters. */
+  removeEndpoint(id: string): void {
+    this._counts.delete(id);
+  }
+
+  /** Clear all counters. */
+  reset(): void {
+    this._counts.clear();
+  }
+
+  /**
+   * Clear and repopulate from a full endpoint state snapshot.
+   * Iterates all samples to rebuild counters from scratch.
+   */
+  loadFrom(endpoints: Record<string, { samples: MeasurementSample[] }>): void {
+    this._counts.clear();
+    for (const [endpointId, state] of Object.entries(endpoints)) {
+      const bucket: MutableCounts = { totalSamples: 0, errorCount: 0, timeoutCount: 0 };
+      for (const sample of state.samples) {
+        bucket.totalSamples++;
+        if (sample.status === 'error') bucket.errorCount++;
+        else if (sample.status === 'timeout') bucket.timeoutCount++;
+      }
+      this._counts.set(endpointId, bucket);
+    }
+  }
+}

--- a/src/lib/utils/incremental-timestamp-tracker.ts
+++ b/src/lib/utils/incremental-timestamp-tracker.ts
@@ -1,0 +1,48 @@
+// src/lib/utils/incremental-timestamp-tracker.ts
+// Replaces O(n) sampleTimestamps scan with an O(k) incremental approach.
+// Tracks the per-round minimum timestamp across all endpoints using delta
+// reads from RingBuffer.sliceFromTail.
+
+import type { RingBuffer } from './ring-buffer';
+import type { MeasurementSample } from '../types';
+
+export class IncrementalTimestampTracker {
+  /** Sparse array: index = round, value = minimum timestamp seen for that round */
+  private readonly _timestamps: number[] = [];
+
+  /** Per-endpoint tail position for delta reads */
+  private readonly _lastProcessedTail: Map<string, number> = new Map();
+
+  /**
+   * Process only the new samples pushed since the last call for this endpoint.
+   * Updates _timestamps[round] with Math.min(existing, sample.timestamp).
+   */
+  processNewSamples(
+    endpointId: string,
+    ringBuffer: RingBuffer<MeasurementSample>,
+    currentTailIndex: number
+  ): void {
+    const lastTail = this._lastProcessedTail.get(endpointId) ?? 0;
+    const delta = ringBuffer.sliceFromTail(lastTail);
+
+    for (const sample of delta) {
+      const existing = this._timestamps[sample.round];
+      if (existing === undefined || sample.timestamp < existing) {
+        this._timestamps[sample.round] = sample.timestamp;
+      }
+    }
+
+    this._lastProcessedTail.set(endpointId, currentTailIndex);
+  }
+
+  /** Returns the internal array reference (readonly). Index = round. */
+  get timestamps(): readonly number[] {
+    return this._timestamps;
+  }
+
+  /** Clears all timestamp data and per-endpoint tail positions. */
+  reset(): void {
+    this._timestamps.length = 0;
+    this._lastProcessedTail.clear();
+  }
+}

--- a/src/lib/utils/persistence.ts
+++ b/src/lib/utils/persistence.ts
@@ -4,12 +4,23 @@
 import { DEFAULT_SETTINGS } from '../types';
 import type { PersistedSettings, ActiveView } from '../types';
 
-const STORAGE_KEY = 'chronoscope_v2_settings';
+const STORAGE_KEY = 'chronoscope_settings';
+const LEGACY_STORAGE_KEY = 'chronoscope_v2_settings';
 const CURRENT_VERSION = 3;
 
 export function loadPersistedSettings(): PersistedSettings | null {
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
+    let raw = localStorage.getItem(STORAGE_KEY);
+
+    // Migrate from legacy key name
+    if (raw === null) {
+      raw = localStorage.getItem(LEGACY_STORAGE_KEY);
+      if (raw !== null) {
+        localStorage.setItem(STORAGE_KEY, raw);
+        localStorage.removeItem(LEGACY_STORAGE_KEY);
+      }
+    }
+
     if (raw === null) return null;
     const parsed: unknown = JSON.parse(raw);
     return migrateSettings(parsed);
@@ -29,6 +40,7 @@ export function saveSettings(settings: PersistedSettings): void {
 
 export function clearPersistedSettings(): void {
   localStorage.removeItem(STORAGE_KEY);
+  localStorage.removeItem(LEGACY_STORAGE_KEY);
 }
 
 export function migrateSettings(data: unknown): PersistedSettings | null {

--- a/src/lib/utils/ring-buffer.ts
+++ b/src/lib/utils/ring-buffer.ts
@@ -11,6 +11,24 @@ interface RingBufferOptions {
 
 type EvictionCallback<T> = (evicted: T) => void;
 
+/**
+ * Wraps a RingBuffer in a Proxy so numeric bracket access (buf[i]) delegates to at(i).
+ * Returns a SampleBuffer-compatible object.
+ */
+export function proxyRingBuffer<T>(rb: RingBuffer<T>): RingBuffer<T> {
+  return new Proxy(rb, {
+    get(target, prop, receiver) {
+      if (typeof prop === 'string') {
+        const n = Number(prop);
+        if (Number.isInteger(n) && n >= 0) {
+          return target.at(n);
+        }
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+}
+
 export class RingBuffer<T> {
   private readonly _items: (T | undefined)[];
   private readonly _capacity: number;
@@ -170,6 +188,56 @@ export class RingBuffer<T> {
       result[i] = this._items[(this._head + i) % this._capacity] as T;
     }
     return result;
+  }
+
+  filter(predicate: (value: T, index: number) => boolean): T[] {
+    const result: T[] = [];
+    for (let i = 0; i < this._length; i++) {
+      const item = this._items[(this._head + i) % this._capacity] as T;
+      if (predicate(item, i)) result.push(item);
+    }
+    return result;
+  }
+
+  map<U>(callbackfn: (value: T, index: number) => U): U[] {
+    const result: U[] = new Array<U>(this._length);
+    for (let i = 0; i < this._length; i++) {
+      result[i] = callbackfn(this._items[(this._head + i) % this._capacity] as T, i);
+    }
+    return result;
+  }
+
+  find(predicate: (value: T, index: number) => boolean): T | undefined {
+    for (let i = 0; i < this._length; i++) {
+      const item = this._items[(this._head + i) % this._capacity] as T;
+      if (predicate(item, i)) return item;
+    }
+    return undefined;
+  }
+
+  reduce<U>(callbackfn: (accumulator: U, value: T, index: number) => U, initialValue: U): U {
+    let acc = initialValue;
+    for (let i = 0; i < this._length; i++) {
+      acc = callbackfn(acc, this._items[(this._head + i) % this._capacity] as T, i);
+    }
+    return acc;
+  }
+
+  slice(start?: number, end?: number): T[] {
+    const len = this._length;
+    const s = start === undefined ? 0 : start < 0 ? Math.max(len + start, 0) : Math.min(start, len);
+    const e = end === undefined ? len : end < 0 ? Math.max(len + end, 0) : Math.min(end, len);
+    const result: T[] = [];
+    for (let i = s; i < e; i++) {
+      result.push(this._items[(this._head + i) % this._capacity] as T);
+    }
+    return result;
+  }
+
+  forEach(callbackfn: (value: T, index: number) => void): void {
+    for (let i = 0; i < this._length; i++) {
+      callbackfn(this._items[(this._head + i) % this._capacity] as T, i);
+    }
   }
 
   /**

--- a/src/lib/utils/ring-buffer.ts
+++ b/src/lib/utils/ring-buffer.ts
@@ -1,0 +1,194 @@
+// src/lib/utils/ring-buffer.ts
+// Generic fixed-capacity circular buffer.
+// tailIndex is monotonically increasing and never stalls at capacity —
+// used by derived stores as a delta-tracking coordinate. (THE BET)
+
+export const DEFAULT_RING_CAPACITY = 28_800; // 8 hours at 1 Hz
+
+interface RingBufferOptions {
+  readonly capacity: number;
+}
+
+type EvictionCallback<T> = (evicted: T) => void;
+
+export class RingBuffer<T> {
+  private readonly _items: (T | undefined)[];
+  private readonly _capacity: number;
+  private _head: number = 0;   // index of oldest item in _items
+  private _length: number = 0; // current live item count
+  private _tailIndex: number = 0; // total items ever pushed (monotonic)
+  private _onEvict: EvictionCallback<T> | null = null;
+
+  constructor(options: RingBufferOptions) {
+    if (options.capacity < 1) {
+      throw new Error(`RingBuffer: capacity must be >= 1, got ${options.capacity}`);
+    }
+    this._capacity = options.capacity;
+    this._items = new Array<T | undefined>(options.capacity).fill(undefined);
+  }
+
+  get capacity(): number { return this._capacity; }
+  get length(): number { return this._length; }
+  get isEmpty(): boolean { return this._length === 0; }
+  get isFull(): boolean { return this._length === this._capacity; }
+  get tailIndex(): number { return this._tailIndex; }
+
+  get front(): T | undefined {
+    if (this._length === 0) return undefined;
+    return this._items[this._head];
+  }
+
+  get back(): T | undefined {
+    if (this._length === 0) return undefined;
+    const tailPos = (this._head + this._length - 1) % this._capacity;
+    return this._items[tailPos];
+  }
+
+  onEvict(cb: EvictionCallback<T>): void {
+    this._onEvict = cb;
+  }
+
+  push(item: T): T | undefined {
+    let evicted: T | undefined;
+
+    if (this._length === this._capacity) {
+      // Buffer full — evict oldest
+      evicted = this._items[this._head] as T;
+      this._onEvict?.(evicted);
+      this._items[this._head] = item;
+      this._head = (this._head + 1) % this._capacity;
+    } else {
+      // Space available — write at tail position
+      const writePos = (this._head + this._length) % this._capacity;
+      this._items[writePos] = item;
+      this._length++;
+    }
+
+    this._tailIndex++;
+    return evicted;
+  }
+
+  /**
+   * Insert item at a position determined by a comparator (for straggler insertion).
+   * Walks backward from newest to find the correct position using the provided predicate.
+   * `shouldInsertBefore(existingItem)` returns true when the new item should be placed before existingItem.
+   * O(k) where k = distance from tail to insertion point (typically 1-2 for stragglers).
+   */
+  insertOrdered(item: T, shouldInsertBefore: (existing: T) => boolean): T | undefined {
+    if (this._length === 0) {
+      return this.push(item);
+    }
+
+    // Find insertion point by walking backward from tail
+    let insertLogical = this._length; // default: append
+    for (let i = this._length - 1; i >= 0; i--) {
+      const existing = this._items[(this._head + i) % this._capacity] as T;
+      if (shouldInsertBefore(existing)) {
+        insertLogical = i;
+      } else {
+        break;
+      }
+    }
+
+    if (insertLogical === this._length) {
+      // Appending — normal push
+      return this.push(item);
+    }
+
+    // Need to shift items right from insertLogical to tail to make room
+    let evicted: T | undefined;
+
+    if (this._length === this._capacity) {
+      // Will evict the oldest item (head)
+      evicted = this._items[this._head] as T;
+      this._onEvict?.(evicted);
+      // Adjust insertion point since head moves
+      insertLogical = Math.max(0, insertLogical - 1);
+      this._head = (this._head + 1) % this._capacity;
+      this._length--;
+    }
+
+    // Shift items from insertLogical to end right by one
+    for (let i = this._length; i > insertLogical; i--) {
+      const srcPos = (this._head + i - 1) % this._capacity;
+      const dstPos = (this._head + i) % this._capacity;
+      this._items[dstPos] = this._items[srcPos];
+    }
+
+    const writePos = (this._head + insertLogical) % this._capacity;
+    this._items[writePos] = item;
+    this._length++;
+    this._tailIndex++;
+
+    return evicted;
+  }
+
+  at(index: number): T | undefined {
+    if (index < 0 || index >= this._length) return undefined;
+    return this._items[(this._head + index) % this._capacity];
+  }
+
+  [Symbol.iterator](): Iterator<T> {
+    let i = 0;
+    return {
+      next: (): IteratorResult<T> => {
+        if (i < this._length) {
+          const value = this._items[(this._head + i) % this._capacity] as T;
+          i++;
+          return { value, done: false };
+        }
+        return { value: undefined as unknown as T, done: true };
+      },
+    };
+  }
+
+  /**
+   * Return all items pushed since tailStart (inclusive).
+   * tailStart is an absolute tailIndex value.
+   * If tailStart is before the buffer's oldest live item, returns all live items.
+   */
+  sliceFromTail(tailStart: number): T[] {
+    if (this._length === 0) return [];
+
+    // The tailIndex of the oldest live item = _tailIndex - _length
+    const oldestTailIndex = this._tailIndex - this._length;
+
+    // Clamp tailStart so we don't go before the oldest item
+    const effectiveStart = Math.max(tailStart, oldestTailIndex);
+    const skipCount = effectiveStart - oldestTailIndex;
+
+    const result: T[] = [];
+    for (let i = skipCount; i < this._length; i++) {
+      result.push(this._items[(this._head + i) % this._capacity] as T);
+    }
+    return result;
+  }
+
+  toArray(): T[] {
+    const result: T[] = new Array<T>(this._length);
+    for (let i = 0; i < this._length; i++) {
+      result[i] = this._items[(this._head + i) % this._capacity] as T;
+    }
+    return result;
+  }
+
+  /**
+   * Bulk load from plain array. Clears existing contents.
+   * Items beyond capacity are truncated from the front (oldest discarded).
+   */
+  loadFrom(items: T[]): void {
+    this._head = 0;
+    this._length = 0;
+    this._tailIndex = 0;
+    this._items.fill(undefined);
+
+    // Truncate to last `capacity` items if over capacity
+    const start = Math.max(0, items.length - this._capacity);
+    for (let i = start; i < items.length; i++) {
+      const writePos = (this._head + this._length) % this._capacity;
+      this._items[writePos] = items[i];
+      this._length++;
+      this._tailIndex++;
+    }
+  }
+}

--- a/src/lib/utils/sorted-insertion-buffer.ts
+++ b/src/lib/utils/sorted-insertion-buffer.ts
@@ -11,6 +11,7 @@ export class SortedInsertionBuffer {
    * where sorted access is frequent.
    */
   insert(value: number): void {
+    if (!Number.isFinite(value)) return; // silently skip NaN/Infinity — don't corrupt sort order
     let lo = 0;
     let hi = this._data.length;
 

--- a/src/lib/utils/sorted-insertion-buffer.ts
+++ b/src/lib/utils/sorted-insertion-buffer.ts
@@ -1,0 +1,53 @@
+// src/lib/utils/sorted-insertion-buffer.ts
+// Persistent sorted array with O(log n) binary-search insertion.
+// Maintains ascending order at all times. No capacity limit.
+
+export class SortedInsertionBuffer {
+  private readonly _data: number[] = [];
+
+  /**
+   * Insert a value using binary search to locate the correct position, then
+   * splice. O(log n) search + O(n) shift — optimal for read-heavy workloads
+   * where sorted access is frequent.
+   */
+  insert(value: number): void {
+    let lo = 0;
+    let hi = this._data.length;
+
+    while (lo < hi) {
+      const mid = (lo + hi) >>> 1;
+      if (this._data[mid] <= value) {
+        lo = mid + 1;
+      } else {
+        hi = mid;
+      }
+    }
+
+    this._data.splice(lo, 0, value);
+  }
+
+  /** Returns the internal sorted array reference (readonly). */
+  get sorted(): readonly number[] {
+    return this._data;
+  }
+
+  /** Current number of elements. */
+  get length(): number {
+    return this._data.length;
+  }
+
+  /** Clear all values. */
+  reset(): void {
+    this._data.length = 0;
+  }
+
+  /**
+   * Replace contents with the provided values, sorted once.
+   * More efficient than inserting one-by-one when bulk loading.
+   */
+  loadFrom(values: number[]): void {
+    this._data.length = 0;
+    this._data.push(...values);
+    this._data.sort((a, b) => a - b);
+  }
+}

--- a/src/lib/utils/statistics.ts
+++ b/src/lib/utils/statistics.ts
@@ -7,7 +7,10 @@ import type {
   EndpointStatistics,
   ConfidenceInterval,
   TimingPayload,
+  SampleBuffer,
 } from '../types';
+import type { SortedInsertionBuffer } from './sorted-insertion-buffer';
+import type { LossCounts } from './incremental-loss-counter';
 
 // ── Percentile (nearest-rank method) ──────────────────────────────────────
 // Returns the value at the given percentile p (0–100) in the provided array.
@@ -144,6 +147,107 @@ export function computeEndpointStatistics(
   return {
     endpointId,
     sampleCount: samples.length,
+    p50, p95, p99, p25, p75, p90,
+    min, max,
+    stddev: sd,
+    ci95,
+    connectionReuseDelta,
+    tier2Averages,
+    ready,
+  };
+}
+
+/**
+ * Zero-allocation statistics from pre-sorted buffer + loss counter.
+ * Reads directly from sortedBuffer.sorted — no intermediate arrays.
+ */
+export function computeEndpointStatisticsFromBuffer(
+  endpointId: string,
+  sortedBuffer: SortedInsertionBuffer,
+  lossCounts: LossCounts,
+  totalSamples: number,
+  samples: SampleBuffer,
+): EndpointStatistics {
+  const sorted = sortedBuffer.sorted;
+  const count = sorted.length;
+  const ready = totalSamples >= READY_SAMPLE_GATE;
+
+  if (count === 0) {
+    return {
+      endpointId,
+      sampleCount: totalSamples,
+      p50: 0, p95: 0, p99: 0, p25: 0, p75: 0, p90: 0,
+      min: 0, max: 0, stddev: 0,
+      ci95: { lower: 0, upper: 0, margin: 0 },
+      connectionReuseDelta: null,
+      tier2Averages: undefined,
+      ready,
+    };
+  }
+
+  const p50 = percentileSorted(sorted as number[], 50);
+  const p95 = percentileSorted(sorted as number[], 95);
+  const p99 = percentileSorted(sorted as number[], 99);
+  const p25 = percentileSorted(sorted as number[], 25);
+  const p75 = percentileSorted(sorted as number[], 75);
+  const p90 = percentileSorted(sorted as number[], 90);
+  const min = sorted[0];
+  const max = sorted[sorted.length - 1];
+
+  // Stddev from sorted values
+  let sumVal = 0;
+  for (let i = 0; i < count; i++) sumVal += sorted[i];
+  const mean = sumVal / count;
+  let varianceSum = 0;
+  for (let i = 0; i < count; i++) varianceSum += (sorted[i] - mean) ** 2;
+  const sd = Math.sqrt(varianceSum / count);
+  const ci95 = confidenceInterval95(p50, sd, count);
+
+  // ── Connection reuse delta ────────────────────────────────────────────
+  type Tier2Sample = MeasurementSample & { tier2: TimingPayload };
+  const tier2Samples = samples.filter(
+    s => s.status === 'ok' && s.tier2 !== undefined
+  ) as Tier2Sample[];
+  let connectionReuseDelta: number | null = null;
+
+  if (tier2Samples.length >= 2) {
+    const first = tier2Samples[0];
+    const rest = tier2Samples.slice(1) as Tier2Sample[];
+
+    if (first?.tier2) {
+      const firstHasColdOverhead =
+        (first.tier2.tcpConnect > 0 || first.tier2.tlsHandshake > 0);
+
+      const warmSamples = rest.filter(
+        s => s.tier2 && s.tier2.tcpConnect === 0 && s.tier2.tlsHandshake === 0
+      );
+
+      if (firstHasColdOverhead && warmSamples.length > 0) {
+        const warmAvg =
+          warmSamples.reduce((accum, s) => accum + s.latency, 0) / warmSamples.length;
+        connectionReuseDelta = first.latency - warmAvg;
+      }
+    }
+  }
+
+  // ── Tier 2 averages ───────────────────────────────────────────────────
+  let tier2Averages: EndpointStatistics['tier2Averages'];
+  if (tier2Samples.length > 0) {
+    const avg = (field: 'dnsLookup' | 'tcpConnect' | 'tlsHandshake' | 'ttfb' | 'contentTransfer') =>
+      tier2Samples.reduce((accum, sample) => accum + (sample.tier2?.[field] ?? 0), 0) / tier2Samples.length;
+
+    tier2Averages = {
+      dnsLookup: avg('dnsLookup'),
+      tcpConnect: avg('tcpConnect'),
+      tlsHandshake: avg('tlsHandshake'),
+      ttfb: avg('ttfb'),
+      contentTransfer: avg('contentTransfer'),
+    };
+  }
+
+  return {
+    endpointId,
+    sampleCount: totalSamples,
     p50, p95, p99, p25, p75, p90,
     min, max,
     stddev: sd,

--- a/tests/unit/color-map.test.ts
+++ b/tests/unit/color-map.test.ts
@@ -14,77 +14,86 @@ describe('colorMap', () => {
     }
   });
 
-  it('0ms is the excellent cyan color', () => {
-    expect(colorMap[0]).toBe('#00b4d8');
+  it('0ms is the excellent cyan color (brand accent)', () => {
+    expect(colorMap[0]).toBe('#67e8f9');
   });
 
-  it('1500ms is the failing red color', () => {
-    expect(colorMap[1500]).toBe('#f94144');
+  it('1500ms is the failing crimson color', () => {
+    expect(colorMap[1500]).toBe('#b91c1c');
   });
 
-  it('25ms maps to the fast anchor color', () => {
-    expect(colorMap[25]).toBe('#0096c7');
+  it('10ms maps to the great teal anchor color', () => {
+    expect(colorMap[10]).toBe('#2dd4bf');
   });
 
-  it('50ms maps to the good blue anchor color', () => {
-    expect(colorMap[50]).toBe('#0077b6');
+  it('25ms maps to the good green anchor color', () => {
+    expect(colorMap[25]).toBe('#22c55e');
   });
 
-  it('100ms maps to the moderate green anchor color', () => {
-    expect(colorMap[100]).toBe('#90be6d');
+  it('50ms maps to the moderate yellow anchor color', () => {
+    expect(colorMap[50]).toBe('#eab308');
   });
 
-  it('200ms maps to the elevated yellow anchor color', () => {
-    expect(colorMap[200]).toBe('#f9c74f');
+  it('100ms maps to the elevated orange anchor color', () => {
+    expect(colorMap[100]).toBe('#f97316');
   });
 
-  it('500ms maps to the slow orange anchor color', () => {
-    expect(colorMap[500]).toBe('#f8961e');
+  it('200ms maps to the degraded red anchor color', () => {
+    expect(colorMap[200]).toBe('#ef4444');
   });
 
-  it('1000ms maps to the critical orange-red anchor color', () => {
-    expect(colorMap[1000]).toBe('#f3722c');
+  it('500ms maps to the critical deep red anchor color', () => {
+    expect(colorMap[500]).toBe('#dc2626');
   });
 });
 
 describe('latencyToColor', () => {
   it('returns correct color for exact anchors', () => {
-    expect(latencyToColor(0)).toBe('#00b4d8');
-    expect(latencyToColor(100)).toBe('#90be6d');
-    expect(latencyToColor(1500)).toBe('#f94144');
+    expect(latencyToColor(0)).toBe('#67e8f9');
+    expect(latencyToColor(50)).toBe('#eab308');
+    expect(latencyToColor(1500)).toBe('#b91c1c');
   });
 
   it('clamps below 0 to 0ms color', () => {
-    expect(latencyToColor(-50)).toBe('#00b4d8');
-    expect(latencyToColor(-1)).toBe('#00b4d8');
+    expect(latencyToColor(-50)).toBe('#67e8f9');
+    expect(latencyToColor(-1)).toBe('#67e8f9');
   });
 
   it('clamps above 1500 to 1500ms color', () => {
-    expect(latencyToColor(2000)).toBe('#f94144');
-    expect(latencyToColor(9999)).toBe('#f94144');
+    expect(latencyToColor(2000)).toBe('#b91c1c');
+    expect(latencyToColor(9999)).toBe('#b91c1c');
   });
 
-  it('interpolated value at 75ms is between good and moderate (blueish-green)', () => {
-    // Between 50ms (#0077b6 blue) and 100ms (#90be6d green)
-    // At 75ms (midpoint) the blue channel should be lower than 0077b6 and higher than 90be6d
-    const color = latencyToColor(75);
+  it('interpolated value at 5ms is between cyan and teal', () => {
+    const color = latencyToColor(5);
     expect(color).toMatch(/^#[0-9a-f]{6}$/);
-    // Not at either anchor
-    expect(color).not.toBe('#0077b6');
-    expect(color).not.toBe('#90be6d');
+    expect(color).not.toBe('#67e8f9');
+    expect(color).not.toBe('#2dd4bf');
   });
 
-  it('low latency values are in the blue/cyan family', () => {
-    // 0–50ms should be cyan/blue dominant (high blue channel)
+  it('low latency values are in the cyan/teal/green family (high green channel)', () => {
     const parseHex = (h: string) => ({
       r: parseInt(h.slice(1, 3), 16),
       g: parseInt(h.slice(3, 5), 16),
       b: parseInt(h.slice(5, 7), 16),
     });
-    for (let ms = 0; ms <= 50; ms += 5) {
-      const { r, b } = parseHex(latencyToColor(ms));
-      // Blue-dominant: blue channel >= red channel
-      expect(b, `at ${ms}ms`).toBeGreaterThanOrEqual(r);
+    for (let ms = 0; ms <= 25; ms += 5) {
+      const { r, g } = parseHex(latencyToColor(ms));
+      // Green channel dominant in the cool range
+      expect(g, `at ${ms}ms`).toBeGreaterThanOrEqual(r);
+    }
+  });
+
+  it('high latency values are in the red family', () => {
+    const parseHex = (h: string) => ({
+      r: parseInt(h.slice(1, 3), 16),
+      g: parseInt(h.slice(3, 5), 16),
+      b: parseInt(h.slice(5, 7), 16),
+    });
+    for (let ms = 200; ms <= 1500; ms += 100) {
+      const { r, g } = parseHex(latencyToColor(ms));
+      // Red-dominant in the warm range
+      expect(r, `at ${ms}ms`).toBeGreaterThan(g);
     }
   });
 

--- a/tests/unit/heatmap-renderer.test.ts
+++ b/tests/unit/heatmap-renderer.test.ts
@@ -10,11 +10,11 @@ function makeCanvas(): HTMLCanvasElement {
 }
 
 const SAMPLE_CELLS: HeatmapCell[] = [
-  { col: 0, row: 0, color: '#00b4d8', latency: 20,   status: 'ok',      endpointId: 'ep1', round: 1 },
-  { col: 1, row: 0, color: '#f9c74f', latency: 200,  status: 'ok',      endpointId: 'ep1', round: 2 },
+  { col: 0, row: 0, color: '#22c55e', latency: 20,   status: 'ok',      endpointId: 'ep1', round: 1 },
+  { col: 1, row: 0, color: '#ef4444', latency: 200,  status: 'ok',      endpointId: 'ep1', round: 2 },
   { col: 2, row: 0, color: '#9b5de5', latency: 5000, status: 'timeout', endpointId: 'ep1', round: 3 },
   { col: 3, row: 0, color: '#c77dff', latency: 0,    status: 'error',   endpointId: 'ep1', round: 4 },
-  { col: 0, row: 1, color: '#00b4d8', latency: 15,   status: 'ok',      endpointId: 'ep2', round: 1 },
+  { col: 0, row: 1, color: '#2dd4bf', latency: 15,   status: 'ok',      endpointId: 'ep2', round: 1 },
 ];
 
 describe('HeatmapRenderer', () => {

--- a/tests/unit/incremental-loss-counter.test.ts
+++ b/tests/unit/incremental-loss-counter.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import { IncrementalLossCounter } from '../../src/lib/utils/incremental-loss-counter';
+
+describe('IncrementalLossCounter', () => {
+  it('returns zero counts for unknown endpoint', () => {
+    const counter = new IncrementalLossCounter();
+    const counts = counter.getCounts('unknown');
+    expect(counts.totalSamples).toBe(0);
+    expect(counts.errorCount).toBe(0);
+    expect(counts.timeoutCount).toBe(0);
+    expect(counts.lossPercent).toBe(0);
+  });
+
+  it('addSamples increments ok sample count', () => {
+    const counter = new IncrementalLossCounter();
+    counter.addSamples([
+      { endpointId: 'ep1', status: 'ok' },
+      { endpointId: 'ep1', status: 'ok' },
+    ]);
+    const counts = counter.getCounts('ep1');
+    expect(counts.totalSamples).toBe(2);
+    expect(counts.errorCount).toBe(0);
+    expect(counts.timeoutCount).toBe(0);
+  });
+
+  it('addSamples increments error count', () => {
+    const counter = new IncrementalLossCounter();
+    counter.addSamples([
+      { endpointId: 'ep1', status: 'error' },
+    ]);
+    const counts = counter.getCounts('ep1');
+    expect(counts.totalSamples).toBe(1);
+    expect(counts.errorCount).toBe(1);
+  });
+
+  it('addSamples increments timeout count', () => {
+    const counter = new IncrementalLossCounter();
+    counter.addSamples([
+      { endpointId: 'ep1', status: 'timeout' },
+      { endpointId: 'ep1', status: 'timeout' },
+    ]);
+    const counts = counter.getCounts('ep1');
+    expect(counts.totalSamples).toBe(2);
+    expect(counts.timeoutCount).toBe(2);
+  });
+
+  it('lossPercent is computed correctly', () => {
+    const counter = new IncrementalLossCounter();
+    counter.addSamples([
+      { endpointId: 'ep1', status: 'ok' },
+      { endpointId: 'ep1', status: 'ok' },
+      { endpointId: 'ep1', status: 'error' },
+      { endpointId: 'ep1', status: 'timeout' },
+    ]);
+    const counts = counter.getCounts('ep1');
+    expect(counts.totalSamples).toBe(4);
+    expect(counts.errorCount).toBe(1);
+    expect(counts.timeoutCount).toBe(1);
+    expect(counts.lossPercent).toBeCloseTo(50, 5);
+  });
+
+  it('lossPercent is 0 when no samples', () => {
+    const counter = new IncrementalLossCounter();
+    expect(counter.getCounts('ep1').lossPercent).toBe(0);
+  });
+
+  it('counts accumulate as lifetime totals — not decremented by subsequent calls', () => {
+    const counter = new IncrementalLossCounter();
+    counter.addSamples([{ endpointId: 'ep1', status: 'ok' }]);
+    counter.addSamples([{ endpointId: 'ep1', status: 'ok' }]);
+    counter.addSamples([{ endpointId: 'ep1', status: 'ok' }]);
+    expect(counter.getCounts('ep1').totalSamples).toBe(3);
+  });
+
+  it('tracks multiple endpoints independently', () => {
+    const counter = new IncrementalLossCounter();
+    counter.addSamples([
+      { endpointId: 'ep1', status: 'ok' },
+      { endpointId: 'ep2', status: 'error' },
+      { endpointId: 'ep2', status: 'error' },
+    ]);
+    expect(counter.getCounts('ep1').totalSamples).toBe(1);
+    expect(counter.getCounts('ep1').errorCount).toBe(0);
+    expect(counter.getCounts('ep2').totalSamples).toBe(2);
+    expect(counter.getCounts('ep2').errorCount).toBe(2);
+  });
+
+  it('removeEndpoint removes only the specified endpoint', () => {
+    const counter = new IncrementalLossCounter();
+    counter.addSamples([
+      { endpointId: 'ep1', status: 'ok' },
+      { endpointId: 'ep2', status: 'ok' },
+    ]);
+    counter.removeEndpoint('ep1');
+    expect(counter.getCounts('ep1').totalSamples).toBe(0);
+    expect(counter.getCounts('ep2').totalSamples).toBe(1);
+  });
+
+  it('reset clears all counters', () => {
+    const counter = new IncrementalLossCounter();
+    counter.addSamples([
+      { endpointId: 'ep1', status: 'ok' },
+      { endpointId: 'ep2', status: 'error' },
+    ]);
+    counter.reset();
+    expect(counter.getCounts('ep1').totalSamples).toBe(0);
+    expect(counter.getCounts('ep2').totalSamples).toBe(0);
+  });
+
+  it('loadFrom clears existing state and repopulates from endpoint samples', () => {
+    const counter = new IncrementalLossCounter();
+    counter.addSamples([{ endpointId: 'ep1', status: 'ok' }]);
+
+    counter.loadFrom({
+      ep1: {
+        samples: [
+          { round: 0, latency: 10, status: 'ok', timestamp: 1000 },
+          { round: 1, latency: 0, status: 'error', timestamp: 2000 },
+          { round: 2, latency: 0, status: 'timeout', timestamp: 3000 },
+        ],
+      },
+      ep2: {
+        samples: [
+          { round: 0, latency: 20, status: 'ok', timestamp: 1000 },
+        ],
+      },
+    });
+
+    const ep1 = counter.getCounts('ep1');
+    expect(ep1.totalSamples).toBe(3);
+    expect(ep1.errorCount).toBe(1);
+    expect(ep1.timeoutCount).toBe(1);
+
+    const ep2 = counter.getCounts('ep2');
+    expect(ep2.totalSamples).toBe(1);
+    expect(ep2.errorCount).toBe(0);
+  });
+
+  it('getCounts is O(1) — returns immediately without iteration', () => {
+    const counter = new IncrementalLossCounter();
+    counter.addSamples([{ endpointId: 'ep1', status: 'ok' }]);
+    // Simply verify it returns in constant time by checking the result is correct
+    const counts = counter.getCounts('ep1');
+    expect(counts.totalSamples).toBe(1);
+  });
+});

--- a/tests/unit/incremental-timestamp-tracker.test.ts
+++ b/tests/unit/incremental-timestamp-tracker.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { IncrementalTimestampTracker } from '../../src/lib/utils/incremental-timestamp-tracker';
+import { RingBuffer } from '../../src/lib/utils/ring-buffer';
+import type { MeasurementSample } from '../../src/lib/types';
+
+function makeSample(round: number, timestamp: number): MeasurementSample {
+  return { round, timestamp, latency: 10, status: 'ok' };
+}
+
+describe('IncrementalTimestampTracker', () => {
+  it('starts empty — timestamps is an empty array', () => {
+    const tracker = new IncrementalTimestampTracker();
+    expect(tracker.timestamps).toEqual([]);
+  });
+
+  it('populates timestamps for rounds from a single endpoint', () => {
+    const tracker = new IncrementalTimestampTracker();
+    const rb = new RingBuffer<MeasurementSample>({ capacity: 10 });
+    rb.push(makeSample(0, 1000));
+    rb.push(makeSample(1, 2000));
+    rb.push(makeSample(2, 3000));
+
+    tracker.processNewSamples('ep1', rb, 0);
+
+    expect(tracker.timestamps[0]).toBe(1000);
+    expect(tracker.timestamps[1]).toBe(2000);
+    expect(tracker.timestamps[2]).toBe(3000);
+  });
+
+  it('uses min timestamp across endpoints for the same round', () => {
+    const tracker = new IncrementalTimestampTracker();
+    const rb1 = new RingBuffer<MeasurementSample>({ capacity: 10 });
+    const rb2 = new RingBuffer<MeasurementSample>({ capacity: 10 });
+
+    rb1.push(makeSample(0, 5000));
+    rb2.push(makeSample(0, 3000));
+
+    tracker.processNewSamples('ep1', rb1, 0);
+    tracker.processNewSamples('ep2', rb2, 0);
+
+    expect(tracker.timestamps[0]).toBe(3000);
+  });
+
+  it('min wins when second endpoint has lower timestamp', () => {
+    const tracker = new IncrementalTimestampTracker();
+    const rb1 = new RingBuffer<MeasurementSample>({ capacity: 10 });
+    const rb2 = new RingBuffer<MeasurementSample>({ capacity: 10 });
+
+    rb1.push(makeSample(0, 2000));
+    rb2.push(makeSample(0, 9999));
+
+    tracker.processNewSamples('ep1', rb1, 0);
+    tracker.processNewSamples('ep2', rb2, 0);
+
+    expect(tracker.timestamps[0]).toBe(2000);
+  });
+
+  it('only processes delta — does not re-process already-seen items', () => {
+    const tracker = new IncrementalTimestampTracker();
+    const rb = new RingBuffer<MeasurementSample>({ capacity: 10 });
+
+    rb.push(makeSample(0, 1000));
+    rb.push(makeSample(1, 2000));
+    tracker.processNewSamples('ep1', rb, 0);
+
+    const tailAfterFirst = rb.tailIndex;
+
+    // Change round 0 timestamp via a second endpoint to a lower value
+    // then process ep1 again — it should NOT re-process old items
+    rb.push(makeSample(2, 3000));
+    tracker.processNewSamples('ep1', rb, tailAfterFirst);
+
+    expect(tracker.timestamps[2]).toBe(3000);
+    // round 0 and 1 should still have their original values
+    expect(tracker.timestamps[0]).toBe(1000);
+    expect(tracker.timestamps[1]).toBe(2000);
+  });
+
+  it('reset clears all state', () => {
+    const tracker = new IncrementalTimestampTracker();
+    const rb = new RingBuffer<MeasurementSample>({ capacity: 10 });
+    rb.push(makeSample(0, 1000));
+    tracker.processNewSamples('ep1', rb, 0);
+
+    tracker.reset();
+
+    expect(tracker.timestamps).toEqual([]);
+  });
+
+  it('after reset processes all samples as new', () => {
+    const tracker = new IncrementalTimestampTracker();
+    const rb = new RingBuffer<MeasurementSample>({ capacity: 10 });
+    rb.push(makeSample(0, 500));
+    tracker.processNewSamples('ep1', rb, 0);
+    tracker.reset();
+
+    // After reset the tail tracking is cleared — processing from tailIndex 0 again
+    tracker.processNewSamples('ep1', rb, 0);
+    expect(tracker.timestamps[0]).toBe(500);
+  });
+
+  it('timestamps getter returns the same array reference on repeated calls', () => {
+    const tracker = new IncrementalTimestampTracker();
+    const ref1 = tracker.timestamps;
+    const ref2 = tracker.timestamps;
+    expect(ref1).toBe(ref2);
+  });
+
+  it('handles empty ring buffer gracefully', () => {
+    const tracker = new IncrementalTimestampTracker();
+    const rb = new RingBuffer<MeasurementSample>({ capacity: 10 });
+    expect(() => tracker.processNewSamples('ep1', rb, 0)).not.toThrow();
+    expect(tracker.timestamps).toEqual([]);
+  });
+});

--- a/tests/unit/measurement-engine.test.ts
+++ b/tests/unit/measurement-engine.test.ts
@@ -125,6 +125,62 @@ describe('MeasurementEngine', () => {
     unsub();
   });
 
+  // ── Visibility-aware pause/resume ─────────────────────────────────────────
+
+  it('pause is idempotent', () => {
+    endpointStore.addEndpoint('https://example.com');
+    engine.start();
+    engine._pause();
+    expect(engine._paused).toBe(true);
+    engine._pause(); // second call is no-op
+    expect(engine._paused).toBe(true);
+  });
+
+  it('resume is idempotent', () => {
+    endpointStore.addEndpoint('https://example.com');
+    engine.start();
+    engine._pause();
+    engine._resume();
+    expect(engine._paused).toBe(false);
+    engine._resume(); // second call is no-op
+    expect(engine._paused).toBe(false);
+  });
+
+  it('pause+resume leaves no orphan timers', () => {
+    endpointStore.addEndpoint('https://example.com');
+    engine.start();
+    // Pause clears the round timer
+    engine._pause();
+    const timerAfterPause = (engine as unknown as { roundTimer: ReturnType<typeof setTimeout> | null }).roundTimer;
+    expect(timerAfterPause).toBeNull();
+
+    // Resume schedules a new round
+    engine._resume();
+    const timerAfterResume = (engine as unknown as { roundTimer: ReturnType<typeof setTimeout> | null }).roundTimer;
+    expect(timerAfterResume).not.toBeNull();
+  });
+
+  it('_dispatchRound is a no-op while paused', () => {
+    endpointStore.addEndpoint('https://example.com');
+    engine.start();
+
+    const roundBefore = get(measurementStore).roundCounter;
+    engine._pause();
+    engine._dispatchRound();
+    const roundAfter = get(measurementStore).roundCounter;
+    // roundCounter should not have incremented because _dispatchRound bailed
+    expect(roundAfter).toBe(roundBefore);
+  });
+
+  it('resume reschedules next round', () => {
+    endpointStore.addEndpoint('https://example.com');
+    engine.start();
+    engine._pause();
+    expect((engine as unknown as { roundTimer: ReturnType<typeof setTimeout> | null }).roundTimer).toBeNull();
+    engine._resume();
+    expect((engine as unknown as { roundTimer: ReturnType<typeof setTimeout> | null }).roundTimer).not.toBeNull();
+  });
+
   it('flushes partial batch via timeout for stragglers', async () => {
     const testId = endpointStore.addEndpoint('https://a.example.com');
     endpointStore.addEndpoint('https://b.example.com');

--- a/tests/unit/persistence.test.ts
+++ b/tests/unit/persistence.test.ts
@@ -36,9 +36,24 @@ describe('persistence', () => {
   });
 
   it('returns null for corrupt data', () => {
-    localStorageMock.setItem('chronoscope_v2_settings', 'not-json{{{}}}');
+    localStorageMock.setItem('chronoscope_settings', 'not-json{{{}}}');
     expect(() => loadPersistedSettings()).not.toThrow();
     expect(loadPersistedSettings()).toBeNull();
+  });
+
+  it('migrates legacy storage key to new key', () => {
+    const settings: PersistedSettings = {
+      version: 3,
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors' },
+      ui: { expandedCards: [], activeView: 'timeline' },
+    };
+    localStorageMock.setItem('chronoscope_v2_settings', JSON.stringify(settings));
+    const loaded = loadPersistedSettings();
+    expect(loaded?.version).toBe(3);
+    // Legacy key should be removed, new key should exist
+    expect(localStorageMock.getItem('chronoscope_v2_settings')).toBeNull();
+    expect(localStorageMock.getItem('chronoscope_settings')).not.toBeNull();
   });
 
   it('migrates v1 data to v3', () => {

--- a/tests/unit/render-scheduler.test.ts
+++ b/tests/unit/render-scheduler.test.ts
@@ -120,4 +120,114 @@ describe('RenderScheduler', () => {
     scheduler.registerDataRenderer(dataRenderer);
     expect(dataRenderer).not.toHaveBeenCalled();
   });
+
+  // ── Hysteresis recovery tests ─────────────────────────────────────────────
+
+  it('re-enables effects after 60 consecutive under-budget frames', () => {
+    const effectsRenderer = vi.fn();
+    scheduler.registerEffectsRenderer(effectsRenderer);
+
+    // Trigger overload disable (10 consecutive frames >12ms)
+    for (let i = 0; i < 10; i++) {
+      simulateDirtyFrame(scheduler, 15);
+    }
+    effectsRenderer.mockClear();
+    simulateDirtyFrame(scheduler, 1);
+    expect(effectsRenderer).not.toHaveBeenCalled(); // still disabled
+
+    // Run 60 under-budget dirty frames for recovery
+    for (let i = 0; i < 60; i++) {
+      simulateDirtyFrame(scheduler, 5);
+    }
+
+    // Effects should now be re-enabled
+    effectsRenderer.mockClear();
+    simulateDirtyFrame(scheduler, 1);
+    expect(effectsRenderer).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets recovery streak on any overload frame during recovery', () => {
+    const effectsRenderer = vi.fn();
+    scheduler.registerEffectsRenderer(effectsRenderer);
+
+    // Trigger overload disable
+    for (let i = 0; i < 10; i++) {
+      simulateDirtyFrame(scheduler, 15);
+    }
+
+    // Accumulate 50 under-budget frames (not enough to recover)
+    for (let i = 0; i < 50; i++) {
+      simulateDirtyFrame(scheduler, 5);
+    }
+
+    // One overload frame resets recovery streak
+    simulateDirtyFrame(scheduler, 15);
+
+    // Another 59 under-budget frames (total since reset = 59, not 60)
+    for (let i = 0; i < 59; i++) {
+      simulateDirtyFrame(scheduler, 5);
+    }
+
+    // Still disabled
+    effectsRenderer.mockClear();
+    simulateDirtyFrame(scheduler, 1);
+    expect(effectsRenderer).not.toHaveBeenCalled();
+
+    // One more makes 60 since last reset → re-enables
+    simulateDirtyFrame(scheduler, 5);
+    effectsRenderer.mockClear();
+    simulateDirtyFrame(scheduler, 1);
+    expect(effectsRenderer).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not accumulate recovery streak while effects are enabled', () => {
+    const effectsRenderer = vi.fn();
+    scheduler.registerEffectsRenderer(effectsRenderer);
+
+    // Run 60 under-budget frames while effects are still enabled
+    for (let i = 0; i < 60; i++) {
+      simulateDirtyFrame(scheduler, 5);
+    }
+
+    // Effects are enabled, should still work
+    effectsRenderer.mockClear();
+    simulateDirtyFrame(scheduler, 1);
+    expect(effectsRenderer).toHaveBeenCalledTimes(1);
+
+    // Now trigger overload disable — recovery should start from 0
+    for (let i = 0; i < 10; i++) {
+      simulateDirtyFrame(scheduler, 15);
+    }
+
+    // Only 10 under-budget frames (not 60) — effects still disabled
+    for (let i = 0; i < 10; i++) {
+      simulateDirtyFrame(scheduler, 5);
+    }
+    effectsRenderer.mockClear();
+    simulateDirtyFrame(scheduler, 1);
+    expect(effectsRenderer).not.toHaveBeenCalled();
+  });
+
+  it('handles multiple disable/recover cycles', () => {
+    const effectsRenderer = vi.fn();
+    scheduler.registerEffectsRenderer(effectsRenderer);
+
+    for (let cycle = 0; cycle < 3; cycle++) {
+      // Disable effects
+      for (let i = 0; i < 10; i++) {
+        simulateDirtyFrame(scheduler, 15);
+      }
+      effectsRenderer.mockClear();
+      simulateDirtyFrame(scheduler, 1);
+      expect(effectsRenderer).not.toHaveBeenCalled();
+
+      // Recover effects
+      for (let i = 0; i < 60; i++) {
+        simulateDirtyFrame(scheduler, 5);
+      }
+      effectsRenderer.mockClear();
+      simulateDirtyFrame(scheduler, 1);
+      expect(effectsRenderer).toHaveBeenCalledTimes(1);
+    }
+  });
 });

--- a/tests/unit/ring-buffer.test.ts
+++ b/tests/unit/ring-buffer.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi } from 'vitest';
+import { RingBuffer, DEFAULT_RING_CAPACITY } from '../../src/lib/utils/ring-buffer';
+
+describe('RingBuffer — AC1: fixed-capacity prevents unbounded growth', () => {
+  it('DEFAULT_RING_CAPACITY equals 28800', () => {
+    expect(DEFAULT_RING_CAPACITY).toBe(28_800);
+  });
+
+  it('constructor throws if capacity < 1', () => {
+    expect(() => new RingBuffer<number>({ capacity: 0 })).toThrow();
+  });
+
+  it('starts empty', () => {
+    const rb = new RingBuffer<number>({ capacity: 4 });
+    expect(rb.length).toBe(0);
+    expect(rb.isEmpty).toBe(true);
+    expect(rb.isFull).toBe(false);
+  });
+
+  it('push increases length up to capacity', () => {
+    const rb = new RingBuffer<number>({ capacity: 3 });
+    rb.push(1); expect(rb.length).toBe(1);
+    rb.push(2); expect(rb.length).toBe(2);
+    rb.push(3); expect(rb.length).toBe(3);
+    expect(rb.isFull).toBe(true);
+  });
+
+  it('push beyond capacity does not increase length', () => {
+    const rb = new RingBuffer<number>({ capacity: 3 });
+    for (let i = 0; i < 10; i++) rb.push(i);
+    expect(rb.length).toBe(3);
+  });
+
+  it('push evicts oldest item when full', () => {
+    const rb = new RingBuffer<number>({ capacity: 3 });
+    rb.push(1); rb.push(2); rb.push(3);
+    rb.push(4); // evicts 1
+    expect(rb.toArray()).toEqual([2, 3, 4]);
+  });
+
+  it('push returns evicted item when full', () => {
+    const rb = new RingBuffer<number>({ capacity: 3 });
+    rb.push(1); rb.push(2); rb.push(3);
+    const evicted = rb.push(4);
+    expect(evicted).toBe(1);
+  });
+
+  it('push returns undefined when not full', () => {
+    const rb = new RingBuffer<number>({ capacity: 3 });
+    const evicted = rb.push(1);
+    expect(evicted).toBeUndefined();
+  });
+
+  it('onEvict callback fires with evicted item', () => {
+    const rb = new RingBuffer<number>({ capacity: 3 });
+    const onEvict = vi.fn();
+    rb.onEvict(onEvict);
+    rb.push(1); rb.push(2); rb.push(3);
+    rb.push(4);
+    expect(onEvict).toHaveBeenCalledTimes(1);
+    expect(onEvict).toHaveBeenCalledWith(1);
+  });
+
+  it('onEvict fires before item is overwritten (synchronous)', () => {
+    const rb = new RingBuffer<number>({ capacity: 2 });
+    const evictions: number[] = [];
+    rb.onEvict(v => evictions.push(v));
+    rb.push(10); rb.push(20);
+    rb.push(30); // evicts 10
+    rb.push(40); // evicts 20
+    expect(evictions).toEqual([10, 20]);
+  });
+
+  it('at(0) returns oldest item', () => {
+    const rb = new RingBuffer<number>({ capacity: 3 });
+    rb.push(10); rb.push(20); rb.push(30);
+    expect(rb.at(0)).toBe(10);
+  });
+
+  it('at(length-1) returns newest item', () => {
+    const rb = new RingBuffer<number>({ capacity: 3 });
+    rb.push(10); rb.push(20); rb.push(30);
+    expect(rb.at(2)).toBe(30);
+  });
+
+  it('at() wraps correctly after eviction', () => {
+    const rb = new RingBuffer<number>({ capacity: 3 });
+    rb.push(1); rb.push(2); rb.push(3); rb.push(4); // evicts 1
+    expect(rb.at(0)).toBe(2);
+    expect(rb.at(1)).toBe(3);
+    expect(rb.at(2)).toBe(4);
+  });
+
+  it('Symbol.iterator yields oldest to newest', () => {
+    const rb = new RingBuffer<number>({ capacity: 4 });
+    rb.push(1); rb.push(2); rb.push(3); rb.push(4); rb.push(5); // evicts 1
+    expect([...rb]).toEqual([2, 3, 4, 5]);
+  });
+
+  it('toArray returns new plain array each call', () => {
+    const rb = new RingBuffer<number>({ capacity: 3 });
+    rb.push(1); rb.push(2);
+    const a = rb.toArray();
+    const b = rb.toArray();
+    expect(a).toEqual([1, 2]);
+    expect(a).not.toBe(b);
+  });
+
+  it('loadFrom clears and bulk-inserts', () => {
+    const rb = new RingBuffer<number>({ capacity: 5 });
+    rb.push(99);
+    rb.loadFrom([1, 2, 3]);
+    expect(rb.toArray()).toEqual([1, 2, 3]);
+  });
+
+  it('loadFrom truncates items beyond capacity (oldest discarded)', () => {
+    const rb = new RingBuffer<number>({ capacity: 3 });
+    rb.loadFrom([1, 2, 3, 4, 5]);
+    expect(rb.toArray()).toEqual([3, 4, 5]);
+  });
+
+  it('tailIndex starts at 0', () => {
+    const rb = new RingBuffer<number>({ capacity: 4 });
+    expect(rb.tailIndex).toBe(0);
+  });
+
+  it('tailIndex increments monotonically on every push', () => {
+    const rb = new RingBuffer<number>({ capacity: 3 });
+    rb.push(1); expect(rb.tailIndex).toBe(1);
+    rb.push(2); expect(rb.tailIndex).toBe(2);
+    rb.push(3); expect(rb.tailIndex).toBe(3);
+    rb.push(4); // evicts 1
+    expect(rb.tailIndex).toBe(4);
+  });
+
+  it('tailIndex does not stall at capacity — THE BET', () => {
+    const rb = new RingBuffer<number>({ capacity: 3 });
+    for (let i = 0; i < 100; i++) rb.push(i);
+    expect(rb.tailIndex).toBe(100);
+    expect(rb.length).toBe(3);
+  });
+
+  it('sliceFromTail(0) returns all items', () => {
+    const rb = new RingBuffer<number>({ capacity: 4 });
+    rb.push(10); rb.push(20); rb.push(30);
+    expect(rb.sliceFromTail(0)).toEqual([10, 20, 30]);
+  });
+
+  it('sliceFromTail returns only new items since last call', () => {
+    const rb = new RingBuffer<number>({ capacity: 4 });
+    rb.push(10); rb.push(20);
+    const tail1 = rb.tailIndex;
+    rb.push(30); rb.push(40);
+    expect(rb.sliceFromTail(tail1)).toEqual([30, 40]);
+  });
+
+  it('sliceFromTail returns all live items when tailStart is before oldest', () => {
+    const rb = new RingBuffer<number>({ capacity: 3 });
+    rb.push(1); rb.push(2); rb.push(3); rb.push(4); // evicts 1, oldest now at index 1
+    expect(rb.sliceFromTail(0)).toEqual([2, 3, 4]); // 0 is before oldest — returns all live
+  });
+
+  it('front returns oldest item', () => {
+    const rb = new RingBuffer<number>({ capacity: 3 });
+    rb.push(5); rb.push(6); rb.push(7);
+    expect(rb.front).toBe(5);
+  });
+
+  it('back returns newest item', () => {
+    const rb = new RingBuffer<number>({ capacity: 3 });
+    rb.push(5); rb.push(6); rb.push(7);
+    expect(rb.back).toBe(7);
+  });
+
+  it('front and back are undefined when empty', () => {
+    const rb = new RingBuffer<number>({ capacity: 3 });
+    expect(rb.front).toBeUndefined();
+    expect(rb.back).toBeUndefined();
+  });
+
+  it('insertOrdered inserts in correct position', () => {
+    const rb = new RingBuffer<number>({ capacity: 5 });
+    rb.push(1); rb.push(3); rb.push(5);
+    rb.insertOrdered(2, (existing) => existing > 2);
+    expect(rb.toArray()).toEqual([1, 2, 3, 5]);
+  });
+
+  it('insertOrdered appends when item is newest', () => {
+    const rb = new RingBuffer<number>({ capacity: 5 });
+    rb.push(1); rb.push(2);
+    rb.insertOrdered(3, (existing) => existing > 3);
+    expect(rb.toArray()).toEqual([1, 2, 3]);
+  });
+
+  it('capacity getter returns construction value', () => {
+    const rb = new RingBuffer<number>({ capacity: 42 });
+    expect(rb.capacity).toBe(42);
+  });
+});

--- a/tests/unit/session-history.test.ts
+++ b/tests/unit/session-history.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SessionHistoryStore } from '../../src/lib/stores/session-history';
+import type { MeasurementSample } from '../../src/lib/types';
+
+function makeSample(
+  overrides: Partial<MeasurementSample> & { timestamp: number }
+): MeasurementSample {
+  return {
+    round: 0,
+    latency: 100,
+    status: 'ok',
+    ...overrides,
+  };
+}
+
+// 2024-01-15T10:xx:xx.xxxZ → hourKey = "2024-01-15T10"
+const BASE_TS = new Date('2024-01-15T10:30:00.000Z').getTime();
+const HOUR_KEY = '2024-01-15T10';
+
+// Different hour
+const NEXT_HOUR_TS = new Date('2024-01-15T11:30:00.000Z').getTime();
+const NEXT_HOUR_KEY = '2024-01-15T11';
+
+describe('SessionHistoryStore', () => {
+  let store: SessionHistoryStore;
+
+  beforeEach(() => {
+    store = new SessionHistoryStore();
+  });
+
+  it('getSummaries returns empty array for unknown endpoint', () => {
+    expect(store.getSummaries('ep1')).toEqual([]);
+  });
+
+  it('hasHistory is false when no data accumulated', () => {
+    expect(store.hasHistory).toBe(false);
+  });
+
+  it('hasHistory is true after accumulating a sample', () => {
+    store.accumulate('ep1', makeSample({ timestamp: BASE_TS }));
+    expect(store.hasHistory).toBe(true);
+  });
+
+  it('accumulate stores sample in the correct hour bucket', () => {
+    store.accumulate('ep1', makeSample({ timestamp: BASE_TS, latency: 100 }));
+    const summaries = store.getSummaries('ep1');
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0].hourKey).toBe(HOUR_KEY);
+    expect(summaries[0].count).toBe(1);
+  });
+
+  it('ok samples update latency stats (min, max, sum)', () => {
+    store.accumulate('ep1', makeSample({ timestamp: BASE_TS, latency: 100, status: 'ok' }));
+    store.accumulate('ep1', makeSample({ timestamp: BASE_TS + 1000, latency: 200, status: 'ok' }));
+    const s = store.getSummaries('ep1')[0];
+    expect(s.min).toBe(100);
+    expect(s.max).toBe(200);
+    expect(s.mean).toBeCloseTo(150, 5);
+  });
+
+  it('error samples do not affect latency stats', () => {
+    store.accumulate('ep1', makeSample({ timestamp: BASE_TS, latency: 100, status: 'ok' }));
+    store.accumulate('ep1', makeSample({ timestamp: BASE_TS + 1000, latency: 9999, status: 'error' }));
+    const s = store.getSummaries('ep1')[0];
+    expect(s.min).toBe(100);
+    expect(s.max).toBe(100);
+    expect(s.mean).toBeCloseTo(100, 5);
+  });
+
+  it('timeout samples do not affect latency stats', () => {
+    store.accumulate('ep1', makeSample({ timestamp: BASE_TS, latency: 100, status: 'ok' }));
+    store.accumulate('ep1', makeSample({ timestamp: BASE_TS + 1000, latency: 9999, status: 'timeout' }));
+    const s = store.getSummaries('ep1')[0];
+    expect(s.min).toBe(100);
+    expect(s.max).toBe(100);
+  });
+
+  it('error samples are counted separately', () => {
+    store.accumulate('ep1', makeSample({ timestamp: BASE_TS, status: 'ok', latency: 50 }));
+    store.accumulate('ep1', makeSample({ timestamp: BASE_TS + 100, status: 'error', latency: 0 }));
+    store.accumulate('ep1', makeSample({ timestamp: BASE_TS + 200, status: 'error', latency: 0 }));
+    const s = store.getSummaries('ep1')[0];
+    expect(s.count).toBe(3);
+    expect(s.errorCount).toBe(2);
+  });
+
+  it('timeout samples are counted separately', () => {
+    store.accumulate('ep1', makeSample({ timestamp: BASE_TS, status: 'ok', latency: 50 }));
+    store.accumulate('ep1', makeSample({ timestamp: BASE_TS + 100, status: 'timeout', latency: 0 }));
+    const s = store.getSummaries('ep1')[0];
+    expect(s.timeoutCount).toBe(1);
+  });
+
+  it('samples in separate hours create separate buckets', () => {
+    store.accumulate('ep1', makeSample({ timestamp: BASE_TS, latency: 100 }));
+    store.accumulate('ep1', makeSample({ timestamp: NEXT_HOUR_TS, latency: 200 }));
+    const summaries = store.getSummaries('ep1');
+    expect(summaries).toHaveLength(2);
+  });
+
+  it('getSummaries returns buckets in chronological order', () => {
+    // Accumulate out of order
+    store.accumulate('ep1', makeSample({ timestamp: NEXT_HOUR_TS, latency: 200 }));
+    store.accumulate('ep1', makeSample({ timestamp: BASE_TS, latency: 100 }));
+    const summaries = store.getSummaries('ep1');
+    expect(summaries[0].hourKey).toBe(HOUR_KEY);
+    expect(summaries[1].hourKey).toBe(NEXT_HOUR_KEY);
+  });
+
+  it('p50 computation works correctly', () => {
+    for (let i = 1; i <= 10; i++) {
+      store.accumulate(
+        'ep1',
+        makeSample({ timestamp: BASE_TS + i * 100, latency: i * 10, status: 'ok' })
+      );
+    }
+    const s = store.getSummaries('ep1')[0];
+    // sorted: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100] — p50 at ceil(0.5*10)=5 → index 4 = 50
+    expect(s.p50).toBe(50);
+  });
+
+  it('p95 computation works correctly', () => {
+    for (let i = 1; i <= 20; i++) {
+      store.accumulate(
+        'ep1',
+        makeSample({ timestamp: BASE_TS + i * 100, latency: i * 10, status: 'ok' })
+      );
+    }
+    const s = store.getSummaries('ep1')[0];
+    // sorted: [10..200], p95 at ceil(0.95*20)=19 → index 18 → 190
+    expect(s.p95).toBe(190);
+  });
+
+  it('p99 is clamped to max for small samples', () => {
+    store.accumulate('ep1', makeSample({ timestamp: BASE_TS, latency: 50, status: 'ok' }));
+    const s = store.getSummaries('ep1')[0];
+    expect(s.p99).toBe(50);
+  });
+
+  it('getSummary returns single bucket by hourKey', () => {
+    store.accumulate('ep1', makeSample({ timestamp: BASE_TS, latency: 100 }));
+    const s = store.getSummary('ep1', HOUR_KEY);
+    expect(s).toBeDefined();
+    expect(s?.hourKey).toBe(HOUR_KEY);
+  });
+
+  it('getSummary returns undefined for unknown hourKey', () => {
+    expect(store.getSummary('ep1', '2024-01-01T00')).toBeUndefined();
+  });
+
+  it('removeEndpoint removes only the specified endpoint', () => {
+    store.accumulate('ep1', makeSample({ timestamp: BASE_TS, latency: 100 }));
+    store.accumulate('ep2', makeSample({ timestamp: BASE_TS, latency: 200 }));
+    store.removeEndpoint('ep1');
+    expect(store.getSummaries('ep1')).toEqual([]);
+    expect(store.getSummaries('ep2')).toHaveLength(1);
+  });
+
+  it('reset clears all data', () => {
+    store.accumulate('ep1', makeSample({ timestamp: BASE_TS, latency: 100 }));
+    store.accumulate('ep2', makeSample({ timestamp: BASE_TS, latency: 200 }));
+    store.reset();
+    expect(store.hasHistory).toBe(false);
+    expect(store.getSummaries('ep1')).toEqual([]);
+    expect(store.getSummaries('ep2')).toEqual([]);
+  });
+
+  it('jitter (variance) is non-negative', () => {
+    store.accumulate('ep1', makeSample({ timestamp: BASE_TS, latency: 100, status: 'ok' }));
+    store.accumulate('ep1', makeSample({ timestamp: BASE_TS + 1000, latency: 200, status: 'ok' }));
+    const s = store.getSummaries('ep1')[0];
+    expect(s.variance).toBeGreaterThanOrEqual(0);
+  });
+
+  it('min and max are 0 when all samples are errors', () => {
+    store.accumulate('ep1', makeSample({ timestamp: BASE_TS, latency: 0, status: 'error' }));
+    store.accumulate('ep1', makeSample({ timestamp: BASE_TS + 100, latency: 0, status: 'error' }));
+    const s = store.getSummaries('ep1')[0];
+    expect(s.min).toBe(0);
+    expect(s.max).toBe(0);
+  });
+
+  it('different endpoints have independent history', () => {
+    store.accumulate('ep1', makeSample({ timestamp: BASE_TS, latency: 100 }));
+    store.accumulate('ep2', makeSample({ timestamp: BASE_TS, latency: 200 }));
+    store.accumulate('ep2', makeSample({ timestamp: BASE_TS + 500, latency: 300 }));
+    expect(store.getSummaries('ep1')[0].count).toBe(1);
+    expect(store.getSummaries('ep2')[0].count).toBe(2);
+  });
+});

--- a/tests/unit/sorted-insertion-buffer.test.ts
+++ b/tests/unit/sorted-insertion-buffer.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { SortedInsertionBuffer } from '../../src/lib/utils/sorted-insertion-buffer';
+
+describe('SortedInsertionBuffer', () => {
+  it('starts empty', () => {
+    const buf = new SortedInsertionBuffer();
+    expect(buf.sorted).toEqual([]);
+    expect(buf.length).toBe(0);
+  });
+
+  it('maintains ascending order after arbitrary insertions', () => {
+    const buf = new SortedInsertionBuffer();
+    buf.insert(50);
+    buf.insert(10);
+    buf.insert(30);
+    buf.insert(20);
+    buf.insert(40);
+    expect(buf.sorted).toEqual([10, 20, 30, 40, 50]);
+  });
+
+  it('handles duplicate values', () => {
+    const buf = new SortedInsertionBuffer();
+    buf.insert(5);
+    buf.insert(5);
+    buf.insert(5);
+    expect(buf.sorted).toEqual([5, 5, 5]);
+    expect(buf.length).toBe(3);
+  });
+
+  it('inserts at head correctly', () => {
+    const buf = new SortedInsertionBuffer();
+    buf.insert(10);
+    buf.insert(20);
+    buf.insert(5);
+    expect(buf.sorted[0]).toBe(5);
+  });
+
+  it('handles already-sorted insertion efficiently', () => {
+    const buf = new SortedInsertionBuffer();
+    buf.insert(1);
+    buf.insert(2);
+    buf.insert(3);
+    buf.insert(4);
+    expect(buf.sorted).toEqual([1, 2, 3, 4]);
+  });
+
+  it('handles reverse-sorted insertion', () => {
+    const buf = new SortedInsertionBuffer();
+    buf.insert(4);
+    buf.insert(3);
+    buf.insert(2);
+    buf.insert(1);
+    expect(buf.sorted).toEqual([1, 2, 3, 4]);
+  });
+
+  it('sorted getter returns the same array reference on repeated calls', () => {
+    const buf = new SortedInsertionBuffer();
+    buf.insert(1);
+    const ref1 = buf.sorted;
+    const ref2 = buf.sorted;
+    expect(ref1).toBe(ref2);
+  });
+
+  it('length grows without bound', () => {
+    const buf = new SortedInsertionBuffer();
+    for (let i = 0; i < 1000; i++) buf.insert(Math.random() * 1000);
+    expect(buf.length).toBe(1000);
+  });
+
+  it('sorted array is always ascending after bulk random inserts', () => {
+    const buf = new SortedInsertionBuffer();
+    for (let i = 0; i < 100; i++) buf.insert(Math.floor(Math.random() * 200));
+    const arr = buf.sorted;
+    for (let i = 1; i < arr.length; i++) {
+      expect(arr[i]).toBeGreaterThanOrEqual(arr[i - 1]);
+    }
+  });
+
+  it('reset clears all values and resets length', () => {
+    const buf = new SortedInsertionBuffer();
+    buf.insert(1);
+    buf.insert(2);
+    buf.reset();
+    expect(buf.sorted).toEqual([]);
+    expect(buf.length).toBe(0);
+  });
+
+  it('loadFrom sorts the provided values once', () => {
+    const buf = new SortedInsertionBuffer();
+    buf.loadFrom([30, 10, 20, 50, 40]);
+    expect(buf.sorted).toEqual([10, 20, 30, 40, 50]);
+    expect(buf.length).toBe(5);
+  });
+
+  it('loadFrom replaces any existing values', () => {
+    const buf = new SortedInsertionBuffer();
+    buf.insert(999);
+    buf.loadFrom([3, 1, 2]);
+    expect(buf.sorted).toEqual([1, 2, 3]);
+    expect(buf.length).toBe(3);
+  });
+
+  it('loadFrom with already-sorted input stays sorted', () => {
+    const buf = new SortedInsertionBuffer();
+    buf.loadFrom([1, 2, 3, 4, 5]);
+    expect(buf.sorted).toEqual([1, 2, 3, 4, 5]);
+  });
+});


### PR DESCRIPTION
## Summary

Batch of fixes from friend-testing the app. Addresses error handling, cadence perception, color legibility, and guard rails.

- **Error pipeline**: Worker `errorType`/`message` now flows through engine → store → UI. Tooltips and endpoint rows show actual error text (e.g. "Failed to fetch") instead of misleading 0ms
- **Cadence easing**: Quadratic ease-in over 10 transition rounds from burst (0ms) to monitor delay, eliminating the perceived "lag" when switching phases
- **Endpoint guards**: Can't disable the last enabled endpoint; Start button disabled when no endpoints are enabled
- **Reset to defaults**: New button in Settings danger zone — restores default endpoints, settings, and clears localStorage
- **localStorage key migration**: Renamed from `chronoscope_v2_settings` to `chronoscope_settings` with transparent legacy key migration
- **Color ramp overhaul**: Cyan-anchored thermal gradient (cyan → teal → green → yellow → orange → red → crimson) with log-weighted breakpoints at 0/10/25/50/100/200/500/1500ms. Heatmap now uses continuous ramp instead of 5 discrete opacity buckets (fixes the "brown on dark background" problem)
- **Latency legend**: Minimal gradient bar in footer — "Fast [gradient] Slow"
- **Smooth lane scroll**: CSS-transitioned SVG group translate (300ms deceleration curve) with `prefers-reduced-motion` support

## Test plan

- [ ] Type a bogus URL (e.g. `https://asdfasdf.fake`) → should show error text in tooltip and endpoint row, not 0ms
- [ ] Run a test past 50 rounds → burst→monitor transition should feel gradual, not a hard stop
- [ ] Disable all endpoints except one → last toggle should be locked; Start button disabled if all disabled
- [ ] Settings → Reset to defaults → should restore Google + Cloudflare DNS endpoints
- [ ] Verify heatmap colors: fast endpoints show cyan/green cells, slow show orange/red, no brown
- [ ] Footer legend visible: "Fast [gradient bar] Slow"
- [ ] Lane charts scroll smoothly when window slides (no sharp jumps)
- [ ] Test with `prefers-reduced-motion: reduce` → scroll transition disabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added latency color legend (Fast → Slow scale) to footer
  * Enabled settings reset with confirmation workflow
  * Added tab visibility awareness to pause measurements when browser tab is hidden

* **Improvements**
  * Enhanced error message display in tooltips and measurement details
  * Protected against accidentally disabling all endpoints
  * Refreshed heatmap color palette for improved clarity
  * Optimized measurement processing and rendering performance
  * Improved statistical accuracy and caching

<!-- end of auto-generated comment: release notes by coderabbit.ai -->