### PR TITLE
fix: switch measurement probe from HEAD to GET /favicon.ico

### DIFF
--- a/src/lib/engine/worker.ts
+++ b/src/lib/engine/worker.ts
@@ -80,6 +80,27 @@ export function classifyLatencyTier(
   return 'slow';
 }
 
+// ── Probe URL resolution ──────────────────────────────────────────────────
+
+/**
+ * Resolve the actual probe URL from the user-configured endpoint URL.
+ * - Bare origins (no path or just "/") → append /favicon.ico for stable,
+ *   CDN-edge-cached measurement with minimal server processing.
+ * - URLs with an explicit path → respect the user's intent, fetch as-is.
+ */
+export function resolveProbeUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (parsed.pathname === '/' || parsed.pathname === '') {
+      parsed.pathname = '/favicon.ico';
+      return parsed.href;
+    }
+    return url;
+  } catch {
+    return url;
+  }
+}
+
 // ── Resource Timing extraction helpers ─────────────────────────────────────
 
 const hasPerformanceObserver = typeof PerformanceObserver !== 'undefined';
@@ -196,13 +217,15 @@ if (typeof (globalThis as any).WorkerGlobalScope !== 'undefined' && self instanc
 
       const timeoutId = setTimeout(() => abortController?.abort(), timeout);
 
+      const probeUrl = resolveProbeUrl(url);
       const startMark = performance.now();
 
       try {
-        await fetch(url, {
-          method: 'HEAD',
+        await fetch(probeUrl, {
+          method: 'GET',
           mode: corsMode,
           cache: 'no-store',
+          credentials: 'omit',
           signal,
         });
 
@@ -214,7 +237,7 @@ if (typeof (globalThis as any).WorkerGlobalScope !== 'undefined' && self instanc
         clearTimeout(timeoutId);
 
         // Use PerformanceObserver to get the Resource Timing entry (push-based).
-        const entry = await waitForResourceEntry(url, signal);
+        const entry = await waitForResourceEntry(probeUrl, signal);
 
         const timing: TimingPayload = entry
           ? extractTimingPayload(entry)

--- a/tests/unit/worker.test.ts
+++ b/tests/unit/worker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extractTimingPayload, classifyLatencyTier } from '../../src/lib/engine/worker';
+import { extractTimingPayload, classifyLatencyTier, resolveProbeUrl } from '../../src/lib/engine/worker';
 
 describe('worker — extractTimingPayload', () => {
   it('returns tier 1 data (zeros) when TAO is absent', () => {
@@ -29,6 +29,40 @@ describe('worker — extractTimingPayload', () => {
     expect(result.tlsHandshake).toBe(13);
     expect(result.ttfb).toBe(85);
     expect(result.contentTransfer).toBe(30);
+  });
+});
+
+describe('worker — resolveProbeUrl', () => {
+  it('appends /favicon.ico to bare origin', () => {
+    expect(resolveProbeUrl('https://www.google.com')).toBe('https://www.google.com/favicon.ico');
+  });
+
+  it('appends /favicon.ico when path is just /', () => {
+    expect(resolveProbeUrl('https://www.google.com/')).toBe('https://www.google.com/favicon.ico');
+  });
+
+  it('preserves explicit path (user intent)', () => {
+    expect(resolveProbeUrl('https://api.example.com/health')).toBe('https://api.example.com/health');
+  });
+
+  it('preserves path with trailing slash', () => {
+    expect(resolveProbeUrl('https://example.com/api/')).toBe('https://example.com/api/');
+  });
+
+  it('handles IP addresses', () => {
+    expect(resolveProbeUrl('https://1.1.1.1')).toBe('https://1.1.1.1/favicon.ico');
+  });
+
+  it('handles ports', () => {
+    expect(resolveProbeUrl('https://example.com:8080')).toBe('https://example.com:8080/favicon.ico');
+  });
+
+  it('handles port with explicit path', () => {
+    expect(resolveProbeUrl('https://example.com:8080/status')).toBe('https://example.com:8080/status');
+  });
+
+  it('returns original URL for invalid input', () => {
+    expect(resolveProbeUrl('not-a-url')).toBe('not-a-url');
   });
 });
 


### PR DESCRIPTION
## Summary

Switches the latency measurement approach from `HEAD /` to `GET /favicon.ico` for more accurate, stable network latency readings.

**Why:** HEAD requests to root URLs include unpredictable server-side processing (middleware chains, dynamic page generation) and suffer from CDN cache-key fragmentation (CDNs treat HEAD and GET as separate cache entries). favicon.ico is a static asset served directly from CDN edge with near-zero server processing — the measurement captures network latency, not application overhead.

**What changed in the worker:**
- `resolveProbeUrl(url)` — bare origins (`https://google.com`) probe `/favicon.ico`; URLs with explicit paths (`https://api.example.com/health`) are fetched as-is (respects user intent)
- Method switched from `HEAD` to `GET` (consistent CDN caching, no cache-key fragmentation)
- Added `credentials: 'omit'` (no cross-origin cookies — reduces request size, avoids WAF triggers)

**What didn't change:**
- UI shows the user's configured URL, never the probe path
- `no-cors` mode, `cache: 'no-store'`, `performance.now()` bracketing, Resource Timing extraction — all unchanged
- 404 responses are valid measurements (server responded = network round-trip completed)

## Test plan

- [ ] Configure `https://www.google.com` → worker probes `https://www.google.com/favicon.ico`
- [ ] Configure `https://api.example.com/health` → worker probes the exact URL (path preserved)
- [ ] Configure `https://1.1.1.1` → worker probes `https://1.1.1.1/favicon.ico`
- [ ] Verify latency readings are stable and comparable to S80
- [ ] `npm run typecheck && npm run lint && npm test` — 485 tests pass