### PR TITLE
fix: dot exit animation and timestamp tracker cleanup

### DIFF
--- a/src/lib/components/Topbar.svelte
+++ b/src/lib/components/Topbar.svelte
@@ -115,9 +115,12 @@
 
   {#if showRunStatus}
     <div class="run-status">
-      {#if isRunning}
-        <div class="pulse-dot" class:dot-enter={isRunning} aria-hidden="true"></div>
-      {/if}
+      <div
+        class="pulse-dot"
+        class:dot-enter={isRunning}
+        class:dot-exit={!isRunning}
+        aria-hidden="true"
+      ></div>
       <span class="run-label" aria-hidden="true">{runLabel}</span>
     </div>
   {/if}
@@ -231,9 +234,16 @@
   .dot-enter {
     animation: dot-entrance var(--timing-dot-enter) var(--easing-spring) forwards, pulse 2s ease-in-out infinite var(--timing-dot-enter);
   }
+  .dot-exit {
+    animation: dot-exit-anim var(--timing-dot-exit) ease-out forwards;
+  }
   @keyframes dot-entrance {
     from { transform: scale(0); }
     to { transform: scale(1); }
+  }
+  @keyframes dot-exit-anim {
+    from { transform: scale(1); opacity: 1; }
+    to { transform: scale(0); opacity: 0; }
   }
   @keyframes pulse {
     0%, 100% { opacity: 1; transform: scale(1); }

--- a/src/lib/stores/measurements.ts
+++ b/src/lib/stores/measurements.ts
@@ -114,6 +114,7 @@ function createMeasurementStore() {
         const { errorCount, timeoutCount } = recomputeCounts(rest);
         sortedBuffers.delete(endpointId);
         incrementalLossCounter.removeEndpoint(endpointId);
+        incrementalTimestampTracker.removeEndpoint(endpointId);
         return { ...s, endpoints: rest, errorCount, timeoutCount };
       });
     },

--- a/src/lib/utils/incremental-timestamp-tracker.ts
+++ b/src/lib/utils/incremental-timestamp-tracker.ts
@@ -40,6 +40,11 @@ export class IncrementalTimestampTracker {
     return this._timestamps;
   }
 
+  /** Removes the tail-tracking state for a single endpoint. */
+  removeEndpoint(endpointId: string): void {
+    this._lastProcessedTail.delete(endpointId);
+  }
+
   /** Clears all timestamp data and per-endpoint tail positions. */
   reset(): void {
     this._timestamps.length = 0;

--- a/tests/unit/incremental-timestamp-tracker.test.ts
+++ b/tests/unit/incremental-timestamp-tracker.test.ts
@@ -112,4 +112,31 @@ describe('IncrementalTimestampTracker', () => {
     expect(() => tracker.processNewSamples('ep1', rb, 0)).not.toThrow();
     expect(tracker.timestamps).toEqual([]);
   });
+
+  it('removeEndpoint clears tail tracking for that endpoint only', () => {
+    const tracker = new IncrementalTimestampTracker();
+    const rb1 = new RingBuffer<MeasurementSample>({ capacity: 10 });
+    const rb2 = new RingBuffer<MeasurementSample>({ capacity: 10 });
+
+    rb1.push(makeSample(0, 1000));
+    rb2.push(makeSample(0, 2000));
+    tracker.processNewSamples('ep1', rb1, 0);
+    tracker.processNewSamples('ep2', rb2, 0);
+
+    tracker.removeEndpoint('ep1');
+
+    // ep1 re-processes from scratch (tail reset), ep2 still has its tail
+    rb1.push(makeSample(1, 3000));
+    rb2.push(makeSample(1, 4000));
+    const tail2 = rb2.tailIndex;
+    tracker.processNewSamples('ep1', rb1, 0);
+    tracker.processNewSamples('ep2', rb2, tail2);
+
+    expect(tracker.timestamps[1]).toBe(3000);
+  });
+
+  it('removeEndpoint on unknown id does not throw', () => {
+    const tracker = new IncrementalTimestampTracker();
+    expect(() => tracker.removeEndpoint('nonexistent')).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
- **Dot exit animation**: Pulse dot now animates out (scale + fade, 150ms) when monitoring stops, instead of unmounting instantly. Uses the existing `dotExit` timing token that was defined but never wired up.
- **Timestamp tracker cleanup**: Adds `removeEndpoint()` to `IncrementalTimestampTracker` and calls it from `measurementStore.removeEndpoint()`, preventing orphaned tail-tracking state when endpoints are removed. Matches the existing `IncrementalLossCounter` pattern.

Both were CodeRabbit findings from earlier PRs.

## Test plan
- [x] Typecheck passes
- [x] Lint passes  
- [x] 518 unit tests pass (including 2 new tests for `removeEndpoint`)
- [ ] Visual: start monitoring, stop — dot should scale/fade out over ~150ms instead of vanishing
- [ ] Functional: add endpoint, start monitoring, remove endpoint, verify no console errors