### PR TITLE
feat: surface tier2 TTFB timing decomposition in Lane UI

### DIFF
--- a/src/lib/components/Lane.svelte
+++ b/src/lib/components/Lane.svelte
@@ -1,6 +1,7 @@
 <!-- src/lib/components/Lane.svelte -->
 <script lang="ts">
   import { tokens } from '$lib/tokens';
+  import LaneHeaderWaterfall from './LaneHeaderWaterfall.svelte';
 
   let {
     endpointId,
@@ -20,6 +21,7 @@
     noTransition = false,
     translateY = 0,
     onGripPointerDown = undefined,
+    tier2Averages = undefined,
     onGripKeyDown = undefined,
     children,
   }: {
@@ -39,6 +41,13 @@
     settling?: boolean;
     noTransition?: boolean;
     translateY?: number;
+    tier2Averages?: {
+      dnsLookup: number;
+      tcpConnect: number;
+      tlsHandshake: number;
+      ttfb: number;
+      contentTransfer: number;
+    };
     onGripPointerDown?: (e: PointerEvent) => void;
     onGripKeyDown?: (e: KeyboardEvent) => void;
     children?: import('svelte').Snippet;
@@ -61,6 +70,7 @@
 
 <article
   id="lane-{endpointId}"
+  data-endpoint-id={endpointId}
   class="lane"
   class:compact={compact}
   class:is-dragging={dragging}
@@ -118,6 +128,9 @@
         <div class="ls"><div class="ls-label">Loss</div><div class="ls-val">{fmtLoss(lossPercent)}</div></div>
       </div>
       </div>
+      {#if !compact && tier2Averages !== undefined}
+        <LaneHeaderWaterfall {tier2Averages} />
+      {/if}
     {:else}
       <div class="collecting-note">Collecting data…</div>
     {/if}

--- a/src/lib/components/LaneHeaderWaterfall.svelte
+++ b/src/lib/components/LaneHeaderWaterfall.svelte
@@ -1,0 +1,107 @@
+<!-- src/lib/components/LaneHeaderWaterfall.svelte -->
+<!-- 6px-tall horizontal stacked bar showing 5 timing phases as proportional flex segments. -->
+<script lang="ts">
+  import { tokens } from '$lib/tokens';
+
+  // ── Props ────────────────────────────────────────────────────────────────────
+  let {
+    tier2Averages,
+  }: {
+    tier2Averages: {
+      dnsLookup: number;
+      tcpConnect: number;
+      tlsHandshake: number;
+      ttfb: number;
+      contentTransfer: number;
+    };
+  } = $props();
+
+  // ── Phase definitions ────────────────────────────────────────────────────────
+  const phases = $derived([
+    { key: 'dns',      label: 'DNS',      value: tier2Averages.dnsLookup,      color: tokens.color.tier2.dns },
+    { key: 'tcp',      label: 'TCP',      value: tier2Averages.tcpConnect,     color: tokens.color.tier2.tcp },
+    { key: 'tls',      label: 'TLS',      value: tier2Averages.tlsHandshake,   color: tokens.color.tier2.tls },
+    { key: 'ttfb',     label: 'TTFB',     value: tier2Averages.ttfb,           color: tokens.color.tier2.ttfb },
+    { key: 'transfer', label: 'Transfer', value: tier2Averages.contentTransfer, color: tokens.color.tier2.transfer },
+  ]);
+
+  const tier2Total = $derived(phases.reduce((sum, p) => sum + p.value, 0));
+
+  // When total is 0, distribute equally (20% each) to avoid division by zero
+  function flexBasis(value: number): string {
+    if (tier2Total === 0) return '20%';
+    return `${(value / tier2Total) * 100}%`;
+  }
+
+  const ariaLabel = $derived(
+    phases.map((p) => `${p.label}: ${p.value}ms`).join(', ')
+  );
+</script>
+
+<div
+  class="wf-root"
+  style:--wf-label-color={tokens.color.tier2.labelText}
+>
+  <!-- Stacked timing bar -->
+  <div
+    class="waterfall-bar"
+    role="img"
+    aria-label={ariaLabel}
+  >
+    {#each phases as phase (phase.key)}
+      <div
+        class="wf-segment"
+        style:flex-basis={flexBasis(phase.value)}
+        style:min-width="2px"
+        style:background={phase.color}
+      ></div>
+    {/each}
+  </div>
+
+  <!-- Phase labels — only show phases with value > 0 -->
+  <div class="wf-labels" aria-hidden="true">
+    {#each phases as phase (phase.key)}
+      {#if phase.value > 0}
+        <span class="wf-label">{phase.label} {phase.value}ms</span>
+      {/if}
+    {/each}
+  </div>
+</div>
+
+<style>
+  .wf-root {
+    margin-top: 12px;
+  }
+
+  .waterfall-bar {
+    display: flex;
+    height: 6px;
+    border-radius: 3px;
+    overflow: hidden;
+    gap: 0.5px;
+  }
+
+  .wf-segment {
+    transition: flex-basis 400ms ease;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .wf-segment {
+      transition: none;
+    }
+  }
+
+  .wf-labels {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 8px;
+    margin-top: 4px;
+  }
+
+  .wf-label {
+    font-size: 6px;
+    font-family: 'Martian Mono', monospace;
+    color: var(--wf-label-color);
+    white-space: nowrap;
+  }
+</style>

--- a/src/lib/components/LaneSvgChart.svelte
+++ b/src/lib/components/LaneSvgChart.svelte
@@ -15,6 +15,7 @@
     yRange,
     heatmapCells = [],
     timeoutMs = 5000,
+    ttfbPoints = undefined,
   }: {
     color: string;
     colorRgba06: string;
@@ -25,6 +26,7 @@
     yRange: YRange;
     heatmapCells?: readonly HeatmapCellData[];
     timeoutMs?: number;
+    ttfbPoints?: readonly { round: number; ttfb: number }[];
   } = $props();
 
   // ── ViewBox dimensions ───────────────────────────────────────────────────
@@ -92,6 +94,33 @@
     return ribbon.p50Path.map(([round, ny], i) =>
       `${i === 0 ? 'M' : 'L'}${toX(round)},${toY(ny)}`
     ).join(' ');
+  });
+
+  // ── TTFB overlay ─────────────────────────────────────────────────────────
+  interface TtfbDot { cx: number; cy: number; }
+
+  const ttfbDots: TtfbDot[] = $derived.by(() => {
+    if (!ttfbPoints || ttfbPoints.length < 2) return [];
+    return ttfbPoints.map(pt => ({
+      cx: toX(pt.round),
+      cy: toY(normalizeLatency(pt.ttfb, yRange)),
+    }));
+  });
+
+  const ttfbOverlayPath: string = $derived.by(() => {
+    if (ttfbDots.length < 2) return '';
+    return ttfbDots.map((d, i) => `${i === 0 ? 'M' : 'L'}${d.cx},${d.cy}`).join(' ');
+  });
+
+  // Area fill between total-latency dots and TTFB dots
+  const ttfbAreaPath: string = $derived.by(() => {
+    if (ttfbDots.length < 2 || dots.length < 2) return '';
+    const ttfbMap = new Map(ttfbDots.map((d, i) => [ttfbPoints![i]!.round, d.cy]));
+    const sharedDots = dots.filter(d => ttfbMap.has(d.round));
+    if (sharedDots.length < 2) return '';
+    const topEdge = sharedDots.map((d, i) => `${i === 0 ? 'M' : 'L'}${d.cx},${d.cy}`).join(' ');
+    const botEdge = [...sharedDots].reverse().map(d => `L${d.cx},${ttfbMap.get(d.round)!}`).join(' ');
+    return `${topEdge} ${botEdge} Z`;
   });
 
   const gridlineYs: number[] = [
@@ -182,6 +211,8 @@
   aria-label="Latency scatter chart"
   style:--ep-color={color}
   style:--ribbon-fill={colorRgba06}
+  style:--ttfb-stroke="color-mix(in srgb, var(--ep-color) 40%, transparent)"
+  style:--ttfb-fill="color-mix(in srgb, var(--ep-color) 4%, transparent)"
   style:--empty-fill={tokens.color.text.emptyFill}
   style:--grid-line={tokens.color.svg.gridLine}
   style:--future-zone={tokens.color.svg.futureZone}
@@ -278,6 +309,18 @@
     </g>
   {/if}
 
+  <!-- TTFB overlay (independent of scatter data) -->
+  {#if ttfbAreaPath || ttfbOverlayPath}
+    <g class="slide-group" transform="translate({slideX}, 0)">
+      {#if ttfbAreaPath}
+        <path class="ttfb-area" d={ttfbAreaPath} />
+      {/if}
+      {#if ttfbOverlayPath}
+        <path class="ttfb-overlay" d={ttfbOverlayPath} stroke-dasharray="3 4" />
+      {/if}
+    </g>
+  {/if}
+
   <!-- Heatmap strip -->
   {#each cellRects as rect (rect.x)}
     <rect
@@ -314,6 +357,18 @@
   /* Timeout line */
   .timeout-line { stroke: var(--timeout-stroke); stroke-width: 0.8; stroke-dasharray: 6 4; opacity: 0.4; }
   .timeout-label { font-family: 'Martian Mono', monospace; font-size: 5px; font-weight: 400; fill: var(--timeout-stroke); opacity: 0.5; }
+  /* TTFB overlay */
+  .ttfb-overlay {
+    fill: none;
+    stroke: var(--ttfb-stroke);
+    stroke-width: 1.2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+  .ttfb-area {
+    fill: var(--ttfb-fill);
+    stroke: none;
+  }
   /* Heatmap */
   .heatmap-cell { cursor: default; }
   @media (prefers-reduced-motion: reduce) {

--- a/src/lib/components/LaneSvgChart.svelte
+++ b/src/lib/components/LaneSvgChart.svelte
@@ -115,11 +115,15 @@
   // Area fill between total-latency dots and TTFB dots
   const ttfbAreaPath: string = $derived.by(() => {
     if (ttfbDots.length < 2 || dots.length < 2) return '';
-    const ttfbMap = new Map(ttfbDots.map((d, i) => [ttfbPoints![i]!.round, d.cy]));
+    if (!ttfbPoints) return '';
+    const ttfbMap = new Map(ttfbDots.map((d, i) => {
+      const pt = ttfbPoints[i];
+      return [pt ? pt.round : -1, d.cy];
+    }));
     const sharedDots = dots.filter(d => ttfbMap.has(d.round));
     if (sharedDots.length < 2) return '';
     const topEdge = sharedDots.map((d, i) => `${i === 0 ? 'M' : 'L'}${d.cx},${d.cy}`).join(' ');
-    const botEdge = [...sharedDots].reverse().map(d => `L${d.cx},${ttfbMap.get(d.round)!}`).join(' ');
+    const botEdge = [...sharedDots].reverse().map(d => `L${d.cx},${ttfbMap.get(d.round) ?? 0}`).join(' ');
     return `${topEdge} ${botEdge} Z`;
   });
 

--- a/src/lib/components/LaneTimingTooltip.svelte
+++ b/src/lib/components/LaneTimingTooltip.svelte
@@ -1,0 +1,206 @@
+<!-- src/lib/components/LaneTimingTooltip.svelte -->
+<!-- Floating tooltip showing tier2 timing decomposition for a scatter dot hover. -->
+<script lang="ts">
+  import { tokens } from '$lib/tokens';
+  import type { MeasurementSample } from '$lib/types';
+
+  let { sample, x, y, color }: {
+    sample: MeasurementSample;
+    x: number;
+    y: number;
+    color: string;
+  } = $props();
+
+  // CRITICAL: tier2Total must be defined BEFORE hasTier2
+  const tier2Total = $derived.by(() => {
+    if (!sample.tier2) return 0;
+    const t = sample.tier2;
+    return (t.dnsLookup ?? 0) + (t.tcpConnect ?? 0) + (t.tlsHandshake ?? 0) + (t.ttfb ?? 0) + (t.contentTransfer ?? 0);
+  });
+
+  const hasTier2 = $derived(sample.tier2 !== undefined && tier2Total > 0);
+
+  interface Phase {
+    key: string;
+    label: string;
+    value: number;
+    color: string;
+  }
+
+  const phases: Phase[] = $derived.by(() => {
+    if (!hasTier2 || !sample.tier2) return [];
+    const t = sample.tier2;
+    return [
+      { key: 'dns',      label: 'DNS',      value: t.dnsLookup ?? 0,      color: tokens.color.tier2.dns },
+      { key: 'tcp',      label: 'TCP',      value: t.tcpConnect ?? 0,     color: tokens.color.tier2.tcp },
+      { key: 'tls',      label: 'TLS',      value: t.tlsHandshake ?? 0,   color: tokens.color.tier2.tls },
+      { key: 'ttfb',     label: 'TTFB',     value: t.ttfb ?? 0,           color: tokens.color.tier2.ttfb },
+      { key: 'transfer', label: 'Transfer', value: t.contentTransfer ?? 0, color: tokens.color.tier2.transfer },
+    ].filter(p => p.value > 0);
+  });
+
+  // All 5 segments for mini waterfall (including zero-value ones for proportional display)
+  const allSegments: Phase[] = $derived.by(() => {
+    if (!hasTier2 || !sample.tier2) return [];
+    const t = sample.tier2;
+    return [
+      { key: 'dns',      label: 'DNS',      value: t.dnsLookup ?? 0,      color: tokens.color.tier2.dns },
+      { key: 'tcp',      label: 'TCP',      value: t.tcpConnect ?? 0,     color: tokens.color.tier2.tcp },
+      { key: 'tls',      label: 'TLS',      value: t.tlsHandshake ?? 0,   color: tokens.color.tier2.tls },
+      { key: 'ttfb',     label: 'TTFB',     value: t.ttfb ?? 0,           color: tokens.color.tier2.ttfb },
+      { key: 'transfer', label: 'Transfer', value: t.contentTransfer ?? 0, color: tokens.color.tier2.transfer },
+    ];
+  });
+
+  function segmentBasis(value: number): string {
+    if (tier2Total <= 0) return '20%';
+    return `${(value / tier2Total) * 100}%`;
+  }
+</script>
+
+<div
+  class="lt-tooltip"
+  style:left="{x}px"
+  style:top="{y}px"
+  style:--tooltip-bg={tokens.color.tooltip.bg}
+  style:--shadow-low={tokens.shadow.low}
+  style:--radius-sm="{tokens.radius.sm}px"
+  style:--radius-md="{tokens.radius.md}px"
+  style:--protocol-bg={tokens.color.glass.bgHover}
+  style:--t2={tokens.color.text.t2}
+  style:--t4={tokens.color.tier2.labelText}
+  style:--mono={tokens.typography.mono.fontFamily}
+  style:--ep-color={color}
+  aria-live="polite"
+>
+  <div class="lt-total">{Math.round(sample.latency)}ms</div>
+
+  {#if hasTier2}
+    <div class="lt-mini-bar" role="img" aria-label="Timing breakdown waterfall">
+      {#each allSegments as seg (seg.key)}
+        <div
+          class="lt-bar-seg"
+          style:flex-basis={segmentBasis(seg.value)}
+          style:min-width="2px"
+          style:background={seg.color}
+        ></div>
+      {/each}
+    </div>
+
+    <div class="lt-phases">
+      {#each phases as phase (phase.key)}
+        <div class="lt-phase-row">
+          <span class="lt-phase-dot" style:background={phase.color}></span>
+          <span class="lt-phase-label">{phase.label}</span>
+          <span class="lt-phase-value">{Math.round(phase.value)}ms</span>
+        </div>
+      {/each}
+    </div>
+
+    {#if sample.tier2?.protocol}
+      <div class="lt-protocol">{sample.tier2.protocol}</div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .lt-tooltip {
+    position: fixed;
+    pointer-events: none;
+    z-index: 100;
+    background: var(--tooltip-bg);
+    box-shadow: var(--shadow-low);
+    border-radius: var(--radius-sm);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    padding: 10px 12px;
+    max-width: 220px;
+  }
+
+  .lt-total {
+    font-family: var(--mono);
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--ep-color);
+    margin-bottom: 6px;
+  }
+
+  .lt-mini-bar {
+    display: flex;
+    height: 4px;
+    border-radius: 2px;
+    overflow: hidden;
+    margin-bottom: 8px;
+    gap: 1px;
+  }
+
+  .lt-bar-seg {
+    height: 100%;
+    border-radius: 1px;
+  }
+
+  .lt-phases {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  .lt-phase-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .lt-phase-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .lt-phase-label {
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 400;
+    color: var(--t4);
+    flex: 1;
+  }
+
+  .lt-phase-value {
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--t2);
+  }
+
+  .lt-protocol {
+    display: inline-block;
+    margin-top: 8px;
+    padding: 2px 6px;
+    border-radius: 4px;
+    background: var(--protocol-bg);
+    font-family: var(--mono);
+    font-size: 9px;
+    font-weight: 400;
+    color: var(--t4);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  @media (max-width: 767px) {
+    .lt-tooltip {
+      position: fixed;
+      left: 0 !important;
+      right: 0 !important;
+      bottom: 0 !important;
+      top: auto !important;
+      max-width: none;
+      border-radius: var(--radius-md) var(--radius-md) 0 0;
+    }
+
+    .lt-phases {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+</style>

--- a/src/lib/components/LanesView.svelte
+++ b/src/lib/components/LanesView.svelte
@@ -10,9 +10,10 @@
   import { tokens } from '$lib/tokens';
   import { deriveLayoutMode } from '$lib/layout';
   import type { LayoutMode } from '$lib/layout';
-  import type { HeatmapCellData, RibbonData } from '$lib/types';
+  import type { HeatmapCellData, RibbonData, MeasurementSample } from '$lib/types';
   import Lane from './Lane.svelte';
   import LaneSvgChart from './LaneSvgChart.svelte';
+  import LaneTimingTooltip from './LaneTimingTooltip.svelte';
 
   let {
     visibleStart = 1,
@@ -109,6 +110,42 @@
     cachedHeatmapCells = map;
     return map;
   });
+
+  // Round-indexed lookup for tooltip: Map<endpointId, Map<round, MeasurementSample>>
+  const roundMapsByEndpoint = $derived.by(() => {
+    const outer = new SvelteMap<string, ReadonlyMap<number, MeasurementSample>>();
+    for (const ep of endpoints) {
+      const epState = $measurementStore.endpoints[ep.id];
+      if (!epState) { outer.set(ep.id, new SvelteMap()); continue; }
+      const inner = new SvelteMap<number, MeasurementSample>();
+      epState.samples.forEach(s => inner.set(s.round, s));
+      outer.set(ep.id, inner);
+    }
+    return outer;
+  });
+
+  // TTFB points for chart overlay: Map<endpointId, array of {round, ttfb}>
+  const ttfbPointsByEndpoint = $derived.by(() => {
+    const map = new SvelteMap<string, readonly { round: number; ttfb: number }[]>();
+    for (const ep of endpoints) {
+      const epState = $measurementStore.endpoints[ep.id];
+      if (!epState) { map.set(ep.id, []); continue; }
+      const pts: { round: number; ttfb: number }[] = [];
+      epState.samples.forEach(s => {
+        if (s.tier2 !== undefined && s.tier2.ttfb > 0) {
+          pts.push({ round: s.round, ttfb: s.tier2.ttfb });
+        }
+      });
+      map.set(ep.id, pts);
+    }
+    return map;
+  });
+
+  // Hover tracking for tooltip
+  let hoverEndpointId: string | null = $state(null);
+  const laneHoverRound = $derived($uiStore.laneHoverRound);
+  const laneHoverX = $derived($uiStore.laneHoverX);
+  const laneHoverY = $derived($uiStore.laneHoverY);
 
   function colorToRgba06(hex: string): string {
     if (!/^#[0-9a-fA-F]{6}$/.test(hex)) {
@@ -294,6 +331,9 @@
   }
 
   function handleMouseMove(e: MouseEvent): void {
+    const laneEl = (e.target as HTMLElement).closest('[data-endpoint-id]');
+    hoverEndpointId = laneEl?.getAttribute('data-endpoint-id') ?? null;
+
     const lane = (e.target as HTMLElement).closest('.lane');
     const chartEl = lane?.querySelector('.lane-chart') as HTMLElement | null;
     if (!chartEl) {
@@ -319,6 +359,7 @@
   }
 
   function handleMouseLeave(): void {
+    hoverEndpointId = null;
     uiStore.clearLaneHover();
   }
 
@@ -327,10 +368,10 @@
     const epState = $measurementStore.endpoints[endpointId];
     if (!stats || !stats.ready) {
       const lastLatency = epState?.lastLatency ?? 0;
-      return { p50: lastLatency, p95: lastLatency, p99: lastLatency, jitter: 0, lossPercent: 0, ready: false };
+      return { p50: lastLatency, p95: lastLatency, p99: lastLatency, jitter: 0, lossPercent: 0, ready: false, tier2Averages: undefined };
     }
     const lossPercent = incrementalLossCounter.getCounts(endpointId).lossPercent;
-    return { p50: stats.p50, p95: stats.p95, p99: stats.p99, jitter: stats.stddev, lossPercent, ready: true };
+    return { p50: stats.p50, p95: stats.p95, p99: stats.p99, jitter: stats.stddev, lossPercent, ready: true, tier2Averages: stats.tier2Averages };
   }
 </script>
 
@@ -371,6 +412,7 @@
         jitter={laneProps.jitter}
         lossPercent={laneProps.lossPercent}
         ready={laneProps.ready}
+        tier2Averages={laneProps.tier2Averages}
         {lastLatency}
         compact={isCompact}
         showGrip={endpoints.length > 1 && layoutMode !== 'compact-2col'}
@@ -383,6 +425,8 @@
       >
           {@const allPoints = frameData.pointsByEndpoint.get(ep.id) ?? []}
           {@const windowedPoints = allPoints.filter(p => p.round >= visibleStart && p.round <= visibleEnd)}
+          {@const allTtfbPts = ttfbPointsByEndpoint.get(ep.id) ?? []}
+          {@const ttfbPts = allTtfbPts.filter(p => p.round >= visibleStart && p.round <= visibleEnd)}
           <LaneSvgChart
             color={ep.color}
             colorRgba06={colorToRgba06(ep.color)}
@@ -393,9 +437,25 @@
             yRange={frameData.yRangesByEndpoint.get(ep.id) ?? frameData.yRange}
             heatmapCells={heatmapCellsByEndpoint.get(ep.id) ?? []}
             timeoutMs={$settingsStore.timeout}
+            ttfbPoints={ttfbPts}
           />
       </Lane>
     {/each}
+  {/if}
+
+  {#if laneHoverRound !== null && laneHoverX !== null && laneHoverY !== null && hoverEndpointId}
+    {@const hoveredSample = roundMapsByEndpoint.get(hoverEndpointId)?.get(laneHoverRound)}
+    {#if hoveredSample}
+      {@const hoveredEp = endpoints.find(e => e.id === hoverEndpointId)}
+      {#if hoveredEp}
+        <LaneTimingTooltip
+          sample={hoveredSample}
+          x={laneHoverX + 12}
+          y={laneHoverY - 8}
+          color={hoveredEp.color}
+        />
+      {/if}
+    {/if}
   {/if}
 </div>
 

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -42,6 +42,14 @@ const primitive = {
   green:     '#86efac',
   greenGlow: 'rgba(134,239,172,.5)',
 
+  // Tier2 phase palette (opacity-attenuated primitives for waterfall segments)
+  tier2Dns:      'rgba(134,239,172,.7)',   // green   — DNS resolution
+  tier2Tcp:      'rgba(103,232,249,.7)',   // cyan    — TCP connect
+  tier2Tls:      'rgba(196,181,253,.7)',   // violet  — TLS handshake
+  tier2Ttfb:     'rgba(251,191,36,.7)',    // amber   — server processing (TTFB)
+  tier2Transfer: 'rgba(249,168,212,.7)',   // pink    — content transfer
+  tier2LabelText: 'rgba(255,255,255,.40)', // bumped from t4 (.32) to .40 for WCAG AA
+
   // Glass surfaces
   glassBg:        'rgba(255,255,255,.03)',
   glassBorder:    'rgba(255,255,255,.07)',
@@ -189,6 +197,15 @@ export const tokens = {
       violet: primitive.orbViolet,
     },
 
+    tier2: {
+      dns:       primitive.tier2Dns,
+      tcp:       primitive.tier2Tcp,
+      tls:       primitive.tier2Tls,
+      ttfb:      primitive.tier2Ttfb,
+      transfer:  primitive.tier2Transfer,
+      labelText: primitive.tier2LabelText,
+    },
+
     endpoint: [
       primitive.ep0, primitive.ep1, primitive.ep2, primitive.ep3, primitive.ep4,
       primitive.ep5, primitive.ep6, primitive.ep7, primitive.ep8, primitive.ep9,
@@ -254,6 +271,7 @@ export const tokens = {
     nowRing:        2000,
     hoverLine:        80,
     hoverTip:        100,
+    tooltipDelay:     50,    // faster than hoverTip — tier2 tooltip needs snappier response
     // Generic
     fadeIn:          200,
     btnHover:        200,

--- a/tests/unit/components/lane-header-waterfall.test.ts
+++ b/tests/unit/components/lane-header-waterfall.test.ts
@@ -1,0 +1,88 @@
+// tests/unit/components/lane-header-waterfall.test.ts
+// Tests for LaneHeaderWaterfall component — 6px stacked timing-phase bar.
+
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import LaneHeaderWaterfall from '../../../src/lib/components/LaneHeaderWaterfall.svelte';
+
+const tier2Averages = {
+  dnsLookup: 10,
+  tcpConnect: 20,
+  tlsHandshake: 15,
+  ttfb: 80,
+  contentTransfer: 25,
+};
+
+const allZero = {
+  dnsLookup: 0,
+  tcpConnect: 0,
+  tlsHandshake: 0,
+  ttfb: 0,
+  contentTransfer: 0,
+};
+
+describe('LaneHeaderWaterfall', () => {
+  it('renders .waterfall-bar container', () => {
+    const { container } = render(LaneHeaderWaterfall, { props: { tier2Averages } });
+    expect(container.querySelector('.waterfall-bar')).not.toBeNull();
+  });
+
+  it('renders exactly 5 .wf-segment elements', () => {
+    const { container } = render(LaneHeaderWaterfall, { props: { tier2Averages } });
+    const segments = container.querySelectorAll('.wf-segment');
+    expect(segments.length).toBe(5);
+  });
+
+  it('renders .wf-labels row', () => {
+    const { container } = render(LaneHeaderWaterfall, { props: { tier2Averages } });
+    expect(container.querySelector('.wf-labels')).not.toBeNull();
+  });
+
+  it('has role="img" with aria-label containing DNS, TCP, TLS, TTFB, Transfer', () => {
+    const { container } = render(LaneHeaderWaterfall, { props: { tier2Averages } });
+    const bar = container.querySelector('[role="img"]');
+    expect(bar).not.toBeNull();
+    const label = bar?.getAttribute('aria-label') ?? '';
+    expect(label).toContain('DNS');
+    expect(label).toContain('TCP');
+    expect(label).toContain('TLS');
+    expect(label).toContain('TTFB');
+    expect(label).toContain('Transfer');
+  });
+
+  it('gracefully renders when all phases are 0 (no crash, no division by zero)', () => {
+    expect(() =>
+      render(LaneHeaderWaterfall, { props: { tier2Averages: allZero } })
+    ).not.toThrow();
+    const { container } = render(LaneHeaderWaterfall, { props: { tier2Averages: allZero } });
+    const segments = container.querySelectorAll('.wf-segment');
+    expect(segments.length).toBe(5);
+  });
+
+  it('TTFB segment has highest flex-basis when ttfb dominates (80ms out of 150ms total)', () => {
+    const { container } = render(LaneHeaderWaterfall, { props: { tier2Averages } });
+    const segments = container.querySelectorAll('.wf-segment');
+    // total = 10+20+15+80+25 = 150; ttfb index = 3 → 80/150 ≈ 53.33%
+    const ttfbSegment = segments[3] as HTMLElement;
+    const style = ttfbSegment.getAttribute('style') ?? '';
+    // flex-basis should be ~53.33%
+    expect(style).toContain('flex-basis');
+    // Extract the value and confirm it's the largest
+    const bases = Array.from(segments).map((seg) => {
+      const s = (seg as HTMLElement).getAttribute('style') ?? '';
+      const match = s.match(/flex-basis:\s*([\d.]+)%/);
+      return match ? parseFloat(match[1]) : 0;
+    });
+    const maxIdx = bases.indexOf(Math.max(...bases));
+    expect(maxIdx).toBe(3); // ttfb is index 3
+  });
+
+  it('each segment has min-width of 2px via inline style', () => {
+    const { container } = render(LaneHeaderWaterfall, { props: { tier2Averages } });
+    const segments = container.querySelectorAll('.wf-segment');
+    segments.forEach((seg) => {
+      const style = (seg as HTMLElement).getAttribute('style') ?? '';
+      expect(style).toContain('min-width: 2px');
+    });
+  });
+});

--- a/tests/unit/components/lane-timing-tooltip.test.ts
+++ b/tests/unit/components/lane-timing-tooltip.test.ts
@@ -1,0 +1,134 @@
+// tests/unit/components/lane-timing-tooltip.test.ts
+// Tests for LaneTimingTooltip component — floating tier2 timing decomposition tooltip.
+
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import LaneTimingTooltip from '../../../src/lib/components/LaneTimingTooltip.svelte';
+import type { MeasurementSample, TimingPayload } from '../../../src/lib/types';
+
+function makeSample(latency: number, tier2?: Partial<TimingPayload>): MeasurementSample {
+  const base: MeasurementSample = { round: 1, latency, status: 'ok', timestamp: Date.now() };
+  if (tier2) {
+    const full: TimingPayload = {
+      total: latency,
+      dnsLookup: 0,
+      tcpConnect: 0,
+      tlsHandshake: 0,
+      ttfb: latency,
+      contentTransfer: 0,
+      connectionReused: false,
+      protocol: undefined,
+      ...tier2,
+    };
+    return { ...base, tier2: full };
+  }
+  return base;
+}
+
+const defaultProps = {
+  x: 100,
+  y: 200,
+  color: '#67e8f9',
+};
+
+describe('LaneTimingTooltip', () => {
+  it('renders .lt-tooltip container', () => {
+    const sample = makeSample(120);
+    const { container } = render(LaneTimingTooltip, { props: { sample, ...defaultProps } });
+    expect(container.querySelector('.lt-tooltip')).not.toBeNull();
+  });
+
+  it('shows total latency text rounded to nearest ms', () => {
+    const sample = makeSample(120.4);
+    const { container } = render(LaneTimingTooltip, { props: { sample, ...defaultProps } });
+    const total = container.querySelector('.lt-total');
+    expect(total).not.toBeNull();
+    expect(total?.textContent).toContain('120ms');
+  });
+
+  it('shows only total when no tier2 data — no .lt-phases, no .lt-mini-bar', () => {
+    const sample = makeSample(120);
+    const { container } = render(LaneTimingTooltip, { props: { sample, ...defaultProps } });
+    expect(container.querySelector('.lt-phases')).toBeNull();
+    expect(container.querySelector('.lt-mini-bar')).toBeNull();
+  });
+
+  it('shows only total when tier2 exists but all phases are 0', () => {
+    const sample = makeSample(0, {
+      total: 0,
+      dnsLookup: 0,
+      tcpConnect: 0,
+      tlsHandshake: 0,
+      ttfb: 0,
+      contentTransfer: 0,
+    });
+    const { container } = render(LaneTimingTooltip, { props: { sample, ...defaultProps } });
+    expect(container.querySelector('.lt-phases')).toBeNull();
+    expect(container.querySelector('.lt-mini-bar')).toBeNull();
+  });
+
+  it('renders phase breakdown when tier2 present with non-zero phases', () => {
+    const sample = makeSample(150, {
+      dnsLookup: 10,
+      tcpConnect: 20,
+      tlsHandshake: 15,
+      ttfb: 80,
+      contentTransfer: 25,
+    });
+    const { container } = render(LaneTimingTooltip, { props: { sample, ...defaultProps } });
+    expect(container.querySelector('.lt-phases')).not.toBeNull();
+  });
+
+  it('renders mini waterfall when tier2 present with non-zero phases', () => {
+    const sample = makeSample(150, {
+      dnsLookup: 10,
+      tcpConnect: 20,
+      tlsHandshake: 15,
+      ttfb: 80,
+      contentTransfer: 25,
+    });
+    const { container } = render(LaneTimingTooltip, { props: { sample, ...defaultProps } });
+    expect(container.querySelector('.lt-mini-bar')).not.toBeNull();
+  });
+
+  it('skips zero-value phases in phase list', () => {
+    // dnsLookup=0, tcpConnect=0, tlsHandshake=0 → only ttfb and contentTransfer rows
+    const sample = makeSample(105, {
+      dnsLookup: 0,
+      tcpConnect: 0,
+      tlsHandshake: 0,
+      ttfb: 80,
+      contentTransfer: 25,
+    });
+    const { container } = render(LaneTimingTooltip, { props: { sample, ...defaultProps } });
+    const rows = container.querySelectorAll('.lt-phase-row');
+    expect(rows.length).toBe(2);
+  });
+
+  it('shows protocol badge when protocol present', () => {
+    const sample = makeSample(120, {
+      ttfb: 120,
+      protocol: 'h2',
+    });
+    const { container } = render(LaneTimingTooltip, { props: { sample, ...defaultProps } });
+    const badge = container.querySelector('.lt-protocol');
+    expect(badge).not.toBeNull();
+    expect(badge?.textContent).toContain('h2');
+  });
+
+  it('no protocol badge when protocol absent', () => {
+    const sample = makeSample(120, {
+      ttfb: 120,
+      protocol: undefined,
+    });
+    const { container } = render(LaneTimingTooltip, { props: { sample, ...defaultProps } });
+    expect(container.querySelector('.lt-protocol')).toBeNull();
+  });
+
+  it('has aria-live="polite"', () => {
+    const sample = makeSample(120);
+    const { container } = render(LaneTimingTooltip, { props: { sample, ...defaultProps } });
+    const tooltip = container.querySelector('.lt-tooltip');
+    expect(tooltip?.getAttribute('aria-live')).toBe('polite');
+  });
+});

--- a/tests/unit/components/lane.test.ts
+++ b/tests/unit/components/lane.test.ts
@@ -128,4 +128,27 @@ describe('Lane', () => {
     const grip = container.querySelector('.lane-grip');
     expect(grip).toBeNull();
   });
+
+  // ── LaneHeaderWaterfall integration ─────────────────────────────────────────
+
+  it('does not render .waterfall-bar when tier2Averages is undefined (AC-4)', () => {
+    const { container } = render(Lane, { props });
+    expect(container.querySelector('.waterfall-bar')).toBeNull();
+  });
+
+  it('renders .waterfall-bar when tier2Averages provided and ready=true (AC-2)', () => {
+    const tier2Averages = { dnsLookup: 10, tcpConnect: 15, tlsHandshake: 10, ttfb: 80, contentTransfer: 15 };
+    const { container } = render(Lane, {
+      props: { ...props, tier2Averages, ready: true },
+    });
+    expect(container.querySelector('.waterfall-bar')).not.toBeNull();
+  });
+
+  it('does not render .waterfall-bar in compact mode even with tier2Averages (AC-3)', () => {
+    const tier2Averages = { dnsLookup: 10, tcpConnect: 15, tlsHandshake: 10, ttfb: 80, contentTransfer: 15 };
+    const { container } = render(Lane, {
+      props: { ...props, tier2Averages, ready: true, compact: true },
+    });
+    expect(container.querySelector('.waterfall-bar')).toBeNull();
+  });
 });

--- a/tests/unit/lane-svg-chart.test.ts
+++ b/tests/unit/lane-svg-chart.test.ts
@@ -132,4 +132,58 @@ describe('LaneSvgChart', () => {
     const ring = container.querySelector('.empty-ring');
     expect(ring).toBeNull();
   });
+
+  // ── TTFB overlay tests ──────────────────────────────────────────────────
+
+  it('does not render .ttfb-overlay when ttfbPoints is undefined (AC-4)', () => {
+    const { container } = render(LaneSvgChart, { props: baseProps });
+    expect(container.querySelector('.ttfb-overlay')).toBeNull();
+  });
+
+  it('does not render .ttfb-overlay when ttfbPoints is empty', () => {
+    const { container } = render(LaneSvgChart, { props: { ...baseProps, ttfbPoints: [] } });
+    expect(container.querySelector('.ttfb-overlay')).toBeNull();
+  });
+
+  it('does not render .ttfb-overlay when fewer than 2 ttfbPoints', () => {
+    const { container } = render(LaneSvgChart, {
+      props: { ...baseProps, ttfbPoints: [{ round: 1, ttfb: 50 }] },
+    });
+    expect(container.querySelector('.ttfb-overlay')).toBeNull();
+  });
+
+  it('renders .ttfb-overlay when 2+ ttfbPoints provided (AC-3)', () => {
+    const { container } = render(LaneSvgChart, {
+      props: {
+        ...baseProps,
+        ttfbPoints: [{ round: 1, ttfb: 60 }, { round: 2, ttfb: 70 }],
+      },
+    });
+    expect(container.querySelector('.ttfb-overlay')).not.toBeNull();
+  });
+
+  it('.ttfb-overlay has stroke-dasharray (AC-3)', () => {
+    const { container } = render(LaneSvgChart, {
+      props: {
+        ...baseProps,
+        ttfbPoints: [{ round: 1, ttfb: 60 }, { round: 2, ttfb: 70 }],
+      },
+    });
+    const overlay = container.querySelector('.ttfb-overlay');
+    expect(overlay?.getAttribute('stroke-dasharray')).toBeTruthy();
+  });
+
+  it('renders .ttfb-area when 2+ ttfbPoints provided', () => {
+    const { container } = render(LaneSvgChart, {
+      props: {
+        ...baseProps,
+        points: [
+          { round: 1, y: 0.5, latency: 100, status: 'ok', endpointId: 'ep-1', x: 1, color: '#67e8f9' },
+          { round: 2, y: 0.6, latency: 120, status: 'ok', endpointId: 'ep-1', x: 2, color: '#67e8f9' },
+        ],
+        ttfbPoints: [{ round: 1, ttfb: 60 }, { round: 2, ttfb: 70 }],
+      },
+    });
+    expect(container.querySelector('.ttfb-area')).not.toBeNull();
+  });
 });

--- a/tests/unit/tokens.test.ts
+++ b/tests/unit/tokens.test.ts
@@ -181,3 +181,22 @@ describe('ux-polish tokens', () => {
     expect(tokens.color.text.emptyFill).toBe('rgba(255,255,255,.1)');
   });
 });
+
+describe('tier2 visualization tokens', () => {
+  it('exports tokens.color.tier2 group with all 5 phase colors (AC-6)', () => {
+    expect(tokens.color.tier2).toBeDefined();
+    expect(tokens.color.tier2.dns).toBe('rgba(134,239,172,.7)');
+    expect(tokens.color.tier2.tcp).toBe('rgba(103,232,249,.7)');
+    expect(tokens.color.tier2.tls).toBe('rgba(196,181,253,.7)');
+    expect(tokens.color.tier2.ttfb).toBe('rgba(251,191,36,.7)');
+    expect(tokens.color.tier2.transfer).toBe('rgba(249,168,212,.7)');
+  });
+
+  it('exports tokens.timing.tooltipDelay as 50 (faster than hoverTip at 100)', () => {
+    expect(tokens.timing.tooltipDelay).toBe(50);
+  });
+
+  it('exports tokens.color.tier2.labelText at opacity .40 for WCAG AA (AC-6)', () => {
+    expect(tokens.color.tier2.labelText).toBe('rgba(255,255,255,.40)');
+  });
+});


### PR DESCRIPTION
## Summary
- **LaneHeaderWaterfall**: 6px stacked bar showing DNS/TCP/TLS/TTFB/Transfer averages below the stats grid, with proportional flex segments, WCAG AA labels, and reduced-motion support
- **LaneTimingTooltip**: Floating tooltip on scatter dot hover showing per-sample timing decomposition with mini waterfall, phase breakdown (non-zero phases only), protocol badge, and mobile fixed-position layout
- **TTFB overlay line**: Dashed SVG path in LaneSvgChart showing TTFB trend below the total-latency trace, with a subtle area fill between the two lines
- **Design tokens**: 5 tier2 phase colors (DNS=green, TCP=cyan, TLS=violet, TTFB=amber, Transfer=pink), labelText at .40 opacity for WCAG AA, tooltipDelay timing token
- **Zero data pipeline changes** — all data already flows through `tier2?: TimingPayload` on `MeasurementSample`; this is pure rendering

## Test plan
- [x] 547 unit tests pass (29 new)
- [x] TypeScript strict mode — zero errors
- [x] ESLint — zero errors
- [ ] Visual: start monitoring an endpoint with TAO headers — lane header shows waterfall bar, hover shows tooltip with phase breakdown, chart shows dashed TTFB line below scatter dots
- [ ] Visual: endpoint without TAO headers — no waterfall, no tooltip decomposition, no TTFB line (graceful degradation)
- [ ] Visual: 375px viewport — waterfall hidden in compact mode, tooltip fixed to bottom
- [ ] Accessibility: waterfall has `role="img"` with aria-label, tooltip has `aria-live="polite"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TTFB and tier2 timing visualization with waterfall bars showing DNS, TCP, TLS, TTFB, and Transfer phases.
  * Interactive hover tooltips display detailed per-phase timing metrics.
  * Enhanced charts with TTFB trend line overlays for request lifecycle visibility.

* **Tests**
  * Added comprehensive unit test coverage for new timing visualization components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->