### PR TITLE
fix: TTFB overlay layering, waterfall rounding, DeepSource config

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -8,23 +8,23 @@ enabled = true
   environment = ["browser"]
   dialect = "typescript"
   plugins = ["svelte"]
-
-  [analyzers.meta.skip_rules]
-  # Module-level const exports are not "global scope" — false positive for ES modules
-  "JS-0067" = true
-  # Short variable names (i, r, s) are appropriate in math-heavy renderers
-  "JS-C1002" = true
-  # Cyclomatic complexity threshold is too aggressive for data pipelines
-  "JS-R1005" = true
-  # Explicit type declarations are often required in TypeScript
-  "JS-0331" = true
-  # Non-null assertions in test files are intentional
-  "JS-0339" = true
-  # Switch exhaustiveness is enforced by TypeScript's type narrowing
-  "JS-0047" = true
-  # Array .map() callbacks with switch returns — TypeScript validates all paths
-  "JS-0042" = true
-  "JS-0045" = true
+  skip_rules = [
+    # Module-level const exports are not "global scope" — false positive for ES modules
+    "JS-0067",
+    # Short variable names (i, r, s) are appropriate in math-heavy renderers
+    "JS-C1002",
+    # Cyclomatic complexity threshold is too aggressive for data pipelines
+    "JS-R1005",
+    # Explicit type declarations are often required in TypeScript
+    "JS-0331",
+    # Non-null assertions in test files are intentional
+    "JS-0339",
+    # Switch exhaustiveness is enforced by TypeScript's type narrowing
+    "JS-0047",
+    # Array .map() callbacks with switch returns — TypeScript validates all paths
+    "JS-0042",
+    "JS-0045",
+  ]
 
 [[analyzers]]
 name = "secrets"

--- a/src/lib/components/LaneHeaderWaterfall.svelte
+++ b/src/lib/components/LaneHeaderWaterfall.svelte
@@ -34,7 +34,7 @@
   }
 
   const ariaLabel = $derived(
-    phases.map((p) => `${p.label}: ${p.value}ms`).join(', ')
+    phases.map((p) => `${p.label}: ${Math.round(p.value)}ms`).join(', ')
   );
 </script>
 
@@ -62,7 +62,7 @@
   <div class="wf-labels" aria-hidden="true">
     {#each phases as phase (phase.key)}
       {#if phase.value > 0}
-        <span class="wf-label">{phase.label} {phase.value}ms</span>
+        <span class="wf-label">{phase.label} {Math.round(phase.value)}ms</span>
       {/if}
     {/each}
   </div>

--- a/src/lib/components/LaneSvgChart.svelte
+++ b/src/lib/components/LaneSvgChart.svelte
@@ -253,6 +253,12 @@
     {#if ribbonPath}
       <path class="ribbon" d={ribbonPath} />
     {/if}
+    {#if ttfbAreaPath}
+      <path class="ttfb-area" d={ttfbAreaPath} />
+    {/if}
+    {#if ttfbOverlayPath}
+      <path class="ttfb-overlay" d={ttfbOverlayPath} stroke-dasharray="3 4" />
+    {/if}
     {#if medianPath}
       <path class="median" d={medianPath} />
     {/if}
@@ -310,18 +316,6 @@
         text-anchor="middle"
         dominant-baseline="middle"
       >Waiting for data</text>
-    </g>
-  {/if}
-
-  <!-- TTFB overlay (independent of scatter data) -->
-  {#if ttfbAreaPath || ttfbOverlayPath}
-    <g class="slide-group" transform="translate({slideX}, 0)">
-      {#if ttfbAreaPath}
-        <path class="ttfb-area" d={ttfbAreaPath} />
-      {/if}
-      {#if ttfbOverlayPath}
-        <path class="ttfb-overlay" d={ttfbOverlayPath} stroke-dasharray="3 4" />
-      {/if}
     </g>
   {/if}
 

--- a/tests/unit/lane-svg-chart.test.ts
+++ b/tests/unit/lane-svg-chart.test.ts
@@ -156,6 +156,10 @@ describe('LaneSvgChart', () => {
     const { container } = render(LaneSvgChart, {
       props: {
         ...baseProps,
+        points: [
+          { round: 1, y: 0.5, latency: 100, status: 'ok', endpointId: 'ep-1', x: 1, color: '#67e8f9' },
+          { round: 2, y: 0.6, latency: 120, status: 'ok', endpointId: 'ep-1', x: 2, color: '#67e8f9' },
+        ],
         ttfbPoints: [{ round: 1, ttfb: 60 }, { round: 2, ttfb: 70 }],
       },
     });
@@ -166,6 +170,10 @@ describe('LaneSvgChart', () => {
     const { container } = render(LaneSvgChart, {
       props: {
         ...baseProps,
+        points: [
+          { round: 1, y: 0.5, latency: 100, status: 'ok', endpointId: 'ep-1', x: 1, color: '#67e8f9' },
+          { round: 2, y: 0.6, latency: 120, status: 'ok', endpointId: 'ep-1', x: 2, color: '#67e8f9' },
+        ],
         ttfbPoints: [{ round: 1, ttfb: 60 }, { round: 2, ttfb: 70 }],
       },
     });


### PR DESCRIPTION
## Summary
Follow-up to #21 (merged before this fix landed).

- **TTFB overlay layering**: Moved TTFB area fill + dashed path inside the existing `slide-group` `<g>` (after ribbon, before median) instead of a separate `<g>` that rendered on top of scatter data
- **Waterfall label rounding**: `Math.round()` on aria-label and visible label text to prevent long decimals from averaged floats
- **DeepSource skip_rules format**: Changed from TOML table format (`[analyzers.meta.skip_rules]` with `"JS-0067" = true`) to the documented array format (`skip_rules = [...]`) — the table format was silently ignored, causing JS-0067 to fire on every PR

## Test plan
- [x] 547 tests pass
- [x] TypeScript + ESLint clean
- [ ] DeepSource JS analyzer should now show PASSED (not FAILED) on this PR