### PR TITLE
fix(tooltip): clamp LaneTimingTooltip to viewport edges

### DIFF
--- a/src/lib/components/LaneTimingTooltip.svelte
+++ b/src/lib/components/LaneTimingTooltip.svelte
@@ -56,12 +56,37 @@
     if (tier2Total <= 0) return '20%';
     return `${(value / tier2Total) * 100}%`;
   }
+
+  const VIEWPORT_MARGIN = 8;
+
+  let tooltipEl: HTMLDivElement | undefined = $state();
+
+  function clamp(pos: number, size: number, viewportSize: number): number {
+    if (pos + size > viewportSize - VIEWPORT_MARGIN) {
+      pos = viewportSize - size - VIEWPORT_MARGIN;
+    }
+    if (pos < VIEWPORT_MARGIN) {
+      pos = VIEWPORT_MARGIN;
+    }
+    return pos;
+  }
+
+  let clampedX = $derived.by(() => {
+    if (!tooltipEl) return x;
+    return clamp(x, tooltipEl.offsetWidth, window.innerWidth);
+  });
+
+  let clampedY = $derived.by(() => {
+    if (!tooltipEl) return y;
+    return clamp(y, tooltipEl.offsetHeight, window.innerHeight);
+  });
 </script>
 
 <div
   class="lt-tooltip"
-  style:left="{x}px"
-  style:top="{y}px"
+  bind:this={tooltipEl}
+  style:left="{clampedX}px"
+  style:top="{clampedY}px"
   style:--tooltip-bg={tokens.color.tooltip.bg}
   style:--shadow-low={tokens.shadow.low}
   style:--radius-sm="{tokens.radius.sm}px"


### PR DESCRIPTION
## Summary

- Adds viewport-aware clamping to `LaneTimingTooltip` so it no longer clips when hovering dots near the right or bottom edges
- Binds the tooltip element and uses `$derived` to clamp `x`/`y` against `window.innerWidth`/`innerHeight` with an 8px margin
- Mobile bottom-sheet behavior (existing `@media` rule) is unchanged

## Test plan

- [x] Typecheck, lint, 586 tests pass
- [x] Visually verified in Chrome: right-edge clamp confirmed (`left=1385 = viewport(1512) - width(119) - margin(8)`)
- [x] Visually verified in Chrome: bottom-edge clamp confirmed (`top=595 = viewport(707) - height(104) - margin(8)`)
- [ ] Verify tooltip still appears correctly when hovering dots in the middle of the chart (no regression)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tooltip positioning to remain visible within viewport boundaries with proper margins from screen edges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->