### PR TITLE
feat: Apple polish v3 — ambient + chrome (subtractive reduce)

### DIFF
--- a/src/lib/components/Lane.svelte
+++ b/src/lib/components/Lane.svelte
@@ -93,7 +93,7 @@
   style:--t5={tokens.color.text.t5}
   style:--stats-border={tokens.color.glass.statsBorder}
   style:--lane-bg={tokens.color.lane.bg}
-  style:--lane-border={tokens.color.lane.border}
+  style:--border-mid={tokens.color.surface.border.mid}
   style:--glass-highlight={tokens.color.glass.highlight}
   style:--mono={tokens.typography.mono.fontFamily}
   style:--sans={tokens.typography.sans.fontFamily}
@@ -190,7 +190,7 @@
     position: relative; overflow: hidden;
     border-radius: var(--radius-lg);
     background: var(--lane-bg);
-    border: 1px solid var(--lane-border);
+    border: 1px solid var(--border-mid);
     backdrop-filter: blur(20px) saturate(1.2);
     -webkit-backdrop-filter: blur(20px) saturate(1.2);
     transform: translateY(var(--drag-translate, 0px));

--- a/src/lib/components/LaneTimingTooltip.svelte
+++ b/src/lib/components/LaneTimingTooltip.svelte
@@ -116,6 +116,7 @@
   style:--t4={tokens.color.tier2.labelText}
   style:--mono={tokens.typography.mono.fontFamily}
   style:--ep-color={color}
+  style:--border-dim={tokens.color.surface.border.dim}
   aria-live="polite"
 >
   <div class="lt-total">{Math.round(sample.latency)}ms</div>
@@ -154,6 +155,7 @@
     pointer-events: none;
     z-index: 100;
     background: var(--tooltip-bg);
+    border: 1px solid var(--border-dim);
     box-shadow: var(--shadow-low);
     border-radius: var(--radius-sm);
     backdrop-filter: blur(12px);

--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -63,7 +63,7 @@
 
 <a href="#lanes" class="skip-link">Skip to lanes</a>
 
-<div class="bg" aria-hidden="true"></div>
+<div class="bg" aria-hidden="true" style:--bg-accent={tokens.color.bg.accent}></div>
 <div class="orb orb-1" aria-hidden="true"></div>
 <div class="orb orb-2" aria-hidden="true"></div>
 <div class="orb orb-3" aria-hidden="true"></div>
@@ -104,9 +104,7 @@
   .bg {
     position: fixed; inset: 0; z-index: 0;
     background:
-      radial-gradient(ellipse 80% 60% at 20% 10%, rgba(103,232,249,.07) 0%, transparent 60%),
-      radial-gradient(ellipse 60% 80% at 85% 90%, rgba(249,168,212,.06) 0%, transparent 50%),
-      radial-gradient(ellipse 50% 50% at 50% 50%, rgba(139,92,246,.04) 0%, transparent 60%),
+      radial-gradient(ellipse 60% 80% at 85% 90%, var(--bg-accent, rgba(249,168,212,.03)) 0%, transparent 50%),
       linear-gradient(160deg, #0c0a14 0%, #100e1e 40%, #0e0c18 100%);
     animation: bgShift 20s ease-in-out infinite alternate;
   }

--- a/src/lib/components/Topbar.svelte
+++ b/src/lib/components/Topbar.svelte
@@ -4,7 +4,6 @@
   import { uiStore } from '$lib/stores/ui';
   import { tokens } from '$lib/tokens';
   import type { TestLifecycleState } from '$lib/types';
-  import { onMount, onDestroy } from 'svelte';
 
   let { onStart, onStop }: {
     onStart?: () => void;
@@ -41,23 +40,6 @@
     lifecycle === 'idle' || lifecycle === 'stopped' || lifecycle === 'completed'
   );
 
-  let isMobile: boolean = $state(false);
-  let mql: MediaQueryList | null = null;
-
-  function handleMqlChange(e: MediaQueryListEvent | MediaQueryList): void {
-    isMobile = e.matches;
-  }
-
-  onMount(() => {
-    mql = window.matchMedia('(max-width: 767px)');
-    isMobile = mql.matches;
-    mql.addEventListener('change', handleMqlChange as EventListener);
-  });
-
-  onDestroy(() => {
-    mql?.removeEventListener('change', handleMqlChange as EventListener);
-  });
-
   function handleStartStop(): void {
     if (lifecycle === 'running') {
       onStop?.();
@@ -79,7 +61,7 @@
 <header
   class="topbar"
   style:--topbar-bg={tokens.color.topbar.bg}
-  style:--topbar-border={tokens.color.topbar.border}
+  style:--border-bright={tokens.color.surface.border.bright}
   style:--t1={tokens.color.text.t1}
   style:--t2={tokens.color.text.t2}
   style:--t3={tokens.color.text.t3}
@@ -130,46 +112,30 @@
   <nav class="actions" aria-label="Test controls">
     {#if isSharedView}
       <button type="button" class="btn btn-ghost" aria-label="Share results" aria-expanded={$uiStore.showShare} aria-controls="share-popover" onclick={handleShare}>
-        {#if isMobile}
-          <svg class="btn-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-            <path d="M4 10V12.5C4 13.052 4.448 13.5 5 13.5H11C11.552 13.5 12 13.052 12 12.5V10" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
-            <path d="M8 2.5V10M8 2.5L5.5 5M8 2.5L10.5 5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-        {:else}
-          Share
-        {/if}
+        <svg class="btn-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <path d="M4 10V12.5C4 13.052 4.448 13.5 5 13.5H11C11.552 13.5 12 13.052 12 12.5V10" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+          <path d="M8 2.5V10M8 2.5L5.5 5M8 2.5L10.5 5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
       </button>
       <button type="button" class="btn btn-start-stop start" aria-label="Run your own test" onclick={handleRunOwn}>Run Your Own Test</button>
     {:else}
       <button type="button" class="btn btn-ghost" aria-label="Add or remove endpoints" aria-expanded={$uiStore.showEndpoints} aria-controls="endpoint-drawer" onclick={handleEndpoints}>
-        {#if isMobile}
-          <svg class="btn-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-            <circle cx="8" cy="8" r="6.5" stroke="currentColor" stroke-width="1.3"/>
-            <path d="M8 5V11M5 8H11" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
-          </svg>
-        {:else}
-          + Endpoint
-        {/if}
+        <svg class="btn-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <circle cx="8" cy="8" r="6.5" stroke="currentColor" stroke-width="1.3"/>
+          <path d="M8 5V11M5 8H11" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
+        </svg>
       </button>
       <button type="button" class="btn btn-ghost" aria-label="Open settings" aria-expanded={$uiStore.showSettings} aria-controls="settings-drawer" onclick={handleSettings}>
-        {#if isMobile}
-          <svg class="btn-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-            <circle cx="8" cy="8" r="2" stroke="currentColor" stroke-width="1.3"/>
-            <path d="M8 1.5V3M8 13V14.5M14.5 8H13M3 8H1.5M12.6 3.4L11.5 4.5M4.5 11.5L3.4 12.6M12.6 12.6L11.5 11.5M4.5 4.5L3.4 3.4" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
-          </svg>
-        {:else}
-          Settings
-        {/if}
+        <svg class="btn-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <circle cx="8" cy="8" r="2" stroke="currentColor" stroke-width="1.3"/>
+          <path d="M8 1.5V3M8 13V14.5M14.5 8H13M3 8H1.5M12.6 3.4L11.5 4.5M4.5 11.5L3.4 12.6M12.6 12.6L11.5 11.5M4.5 4.5L3.4 3.4" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
+        </svg>
       </button>
       <button type="button" class="btn btn-ghost" aria-label="Share results" aria-expanded={$uiStore.showShare} aria-controls="share-popover" onclick={handleShare}>
-        {#if isMobile}
-          <svg class="btn-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-            <path d="M4 10V12.5C4 13.052 4.448 13.5 5 13.5H11C11.552 13.5 12 13.052 12 12.5V10" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
-            <path d="M8 2.5V10M8 2.5L5.5 5M8 2.5L10.5 5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
-        {:else}
-          Share
-        {/if}
+        <svg class="btn-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <path d="M4 10V12.5C4 13.052 4.448 13.5 5 13.5H11C11.552 13.5 12 13.052 12 12.5V10" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+          <path d="M8 2.5V10M8 2.5L5.5 5M8 2.5L10.5 5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
       </button>
       <button
         type="button"
@@ -194,7 +160,7 @@
     gap: 14px;
     flex-shrink: 0;
     background: var(--topbar-bg);
-    border-bottom: 1px solid var(--topbar-border);
+    border-bottom: 1px solid var(--border-bright);
     backdrop-filter: blur(30px) saturate(1.3);
     -webkit-backdrop-filter: blur(30px) saturate(1.3);
     position: relative;
@@ -323,6 +289,10 @@
   @media (max-width: 767px) {
     .topbar { padding: 0 12px; gap: 8px; }
     .btn-ghost { padding: 7px; min-width: 44px; }
+  }
+
+  @media (min-width: 768px) {
+    .btn-ghost { min-width: 44px; }
   }
 
   @media (max-width: 479px) {

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -56,12 +56,10 @@ const primitive = {
   glassHighlight: 'rgba(255,255,255,.12)',
 
   // Lane surface (slightly darker glass)
-  laneBg:     'rgba(255,255,255,.025)',
-  laneBorder: 'rgba(255,255,255,.06)',
+  laneBg: 'rgba(255,255,255,.025)',
 
   // Topbar
-  topbarBg:     'rgba(255,255,255,.025)',
-  topbarBorder: 'rgba(255,255,255,.07)',
+  topbarBg: 'rgba(255,255,255,.025)',
 
   // Footer
   footerBg: 'rgba(255,255,255,.02)',
@@ -178,13 +176,11 @@ export const tokens = {
     },
 
     lane: {
-      bg:     primitive.laneBg,
-      border: primitive.laneBorder,
+      bg: primitive.laneBg,
     },
 
     topbar: {
-      bg:     primitive.topbarBg,
-      border: primitive.topbarBorder,
+      bg: primitive.topbarBg,
     },
 
     footer: {

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -92,6 +92,14 @@ const primitive = {
   orbCyan:   'rgba(103,232,249,.045)',
   orbPink:   'rgba(249,168,212,.04)',
   orbViolet: 'rgba(139,92,246,.03)',
+
+  // Ambient background accent (tokenized from Layout.svelte's .bg pink radial)
+  bgAccent: 'rgba(249,168,212,.03)',
+
+  // Elevation-aware surface border hierarchy (dim → mid → bright, ≥ .04 delta per tier)
+  borderDim:    'rgba(255,255,255,.04)',
+  borderMid:    'rgba(255,255,255,.08)',
+  borderBright: 'rgba(255,255,255,.14)',
 } as const;
 
 // ── Semantic tokens ────────────────────────────────────────────────────────
@@ -104,6 +112,15 @@ export const tokens = {
       raised:   primitive.bgMid,
       elevated: primitive.bgDeep,
       overlay:  'rgba(0, 0, 0, 0.6)',
+      border: {
+        dim:    primitive.borderDim,
+        mid:    primitive.borderMid,
+        bright: primitive.borderBright,
+      },
+    },
+
+    bg: {
+      accent: primitive.bgAccent,
     },
 
     text: {

--- a/tests/unit/components/lane-timing-tooltip.test.ts
+++ b/tests/unit/components/lane-timing-tooltip.test.ts
@@ -132,3 +132,13 @@ describe('LaneTimingTooltip', () => {
     expect(tooltip?.getAttribute('aria-live')).toBe('polite');
   });
 });
+
+describe('LaneTimingTooltip — AC2 dim border', () => {
+  it('injects --border-dim from tokens.color.surface.border.dim', () => {
+    const sample = makeSample(120);
+    const { container } = render(LaneTimingTooltip, { props: { sample, ...defaultProps } });
+    const tooltip = container.querySelector('.lt-tooltip') as HTMLElement;
+    expect(tooltip).not.toBeNull();
+    expect(tooltip.style.getPropertyValue('--border-dim')).toBe('rgba(255,255,255,.04)');
+  });
+});

--- a/tests/unit/tokens.test.ts
+++ b/tests/unit/tokens.test.ts
@@ -200,3 +200,47 @@ describe('tier2 visualization tokens', () => {
     expect(tokens.color.tier2.labelText).toBe('rgba(255,255,255,.40)');
   });
 });
+
+describe('apple-polish-v3 tokens (AC1 + AC2)', () => {
+  const parseAlpha = (s: string): number => {
+    const m = s.match(/,\s*([\d.]+)\s*\)/);
+    return m ? parseFloat(m[1]) : 0;
+  };
+
+  it('color.bg.accent has alpha ≤ .04 (AC1)', () => {
+    const val: string = tokens.color.bg.accent;
+    expect(parseAlpha(val)).toBeLessThanOrEqual(0.04);
+  });
+
+  it('color.orb.cyan has alpha ≤ .045 (AC1 orb baseline)', () => {
+    expect(parseAlpha(tokens.color.orb.cyan)).toBeLessThanOrEqual(0.045);
+  });
+
+  it('color.orb.pink has alpha ≤ .045 (AC1 orb baseline)', () => {
+    expect(parseAlpha(tokens.color.orb.pink)).toBeLessThanOrEqual(0.045);
+  });
+
+  it('color.orb.violet has alpha ≤ .045 (AC1 orb baseline)', () => {
+    expect(parseAlpha(tokens.color.orb.violet)).toBeLessThanOrEqual(0.045);
+  });
+
+  it('color.surface.border.dim is rgba(255,255,255,.04) (AC2)', () => {
+    expect(tokens.color.surface.border.dim).toBe('rgba(255,255,255,.04)');
+  });
+
+  it('color.surface.border.mid is rgba(255,255,255,.08) (AC2)', () => {
+    expect(tokens.color.surface.border.mid).toBe('rgba(255,255,255,.08)');
+  });
+
+  it('color.surface.border.bright is rgba(255,255,255,.14) (AC2)', () => {
+    expect(tokens.color.surface.border.bright).toBe('rgba(255,255,255,.14)');
+  });
+
+  it('border tiers have ≥ .04 alpha delta between adjacent tiers (AC2)', () => {
+    const dim    = parseAlpha(tokens.color.surface.border.dim);
+    const mid    = parseAlpha(tokens.color.surface.border.mid);
+    const bright = parseAlpha(tokens.color.surface.border.bright);
+    expect(mid - dim).toBeGreaterThanOrEqual(0.04);
+    expect(bright - mid).toBeGreaterThanOrEqual(0.04);
+  });
+});

--- a/tests/unit/tokens.test.ts
+++ b/tests/unit/tokens.test.ts
@@ -203,8 +203,8 @@ describe('tier2 visualization tokens', () => {
 
 describe('apple-polish-v3 tokens (AC1 + AC2)', () => {
   const parseAlpha = (s: string): number => {
-    const m = s.match(/,\s*([\d.]+)\s*\)/);
-    return m ? parseFloat(m[1]) : 0;
+    const match = s.match(/,\s*([\d.]+)\s*\)/);
+    return match ? parseFloat(match[1]) : 0;
   };
 
   it('color.bg.accent has alpha ≤ .04 (AC1)', () => {

--- a/tests/visual/apple-polish-v3.spec.ts
+++ b/tests/visual/apple-polish-v3.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Apple polish v3 — Topbar icons (AC3) + touch targets (AC5)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/');
+    await page.waitForSelector('#chronoscope-root');
+  });
+
+  test('AC3: +Endpoint ghost button renders an SVG icon at 1440px', async ({ page }) => {
+    const btn = page.getByRole('button', { name: /add or remove endpoints/i });
+    await expect(btn).toBeVisible();
+    await expect(btn.locator('svg')).toBeVisible();
+    await expect(btn.locator('svg')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  test('AC3: Settings ghost button renders an SVG icon at 1440px', async ({ page }) => {
+    const btn = page.getByRole('button', { name: /open settings/i });
+    await expect(btn).toBeVisible();
+    await expect(btn.locator('svg')).toBeVisible();
+    await expect(btn.locator('svg')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  test('AC3: Share ghost button renders an SVG icon at 1440px', async ({ page }) => {
+    const btn = page.getByRole('button', { name: /share results/i });
+    await expect(btn).toBeVisible();
+    await expect(btn.locator('svg')).toBeVisible();
+    await expect(btn.locator('svg')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  test('AC5: desktop ghost buttons have min-width 44px at 1440px', async ({ page }) => {
+    const btn = page.getByRole('button', { name: /open settings/i });
+    await expect(btn).toHaveCSS('min-width', '44px');
+    await expect(btn).toHaveCSS('min-height', '44px');
+  });
+});
+
+test.describe('Apple polish v3 — Lane + Topbar elevation borders (AC2)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/');
+    await page.waitForSelector('#chronoscope-root');
+  });
+
+  test('AC2: Lane border is rgba(255,255,255,.08) (surface.border.mid)', async ({ page }) => {
+    const lane = page.locator('article.lane').first();
+    await expect(lane).toBeVisible();
+    await expect(lane).toHaveCSS('border-top-color', 'rgba(255, 255, 255, 0.08)');
+  });
+
+  test('AC2: Topbar border is rgba(255,255,255,.14) (surface.border.bright)', async ({ page }) => {
+    const topbar = page.locator('header.topbar');
+    await expect(topbar).toBeVisible();
+    await expect(topbar).toHaveCSS('border-bottom-color', 'rgba(255, 255, 255, 0.14)');
+  });
+});
+
+test.describe('Apple polish v3 — Mobile a11y (AC5)', () => {
+  test('AC5: no horizontal overflow at 375px', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto('/');
+    await page.waitForSelector('#chronoscope-root');
+    const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    const clientWidth = await page.evaluate(() => document.documentElement.clientWidth);
+    expect(scrollWidth).toBeLessThanOrEqual(clientWidth);
+  });
+
+  test('AC5: ghost buttons have 44x44 touch targets at 375px', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto('/');
+    await page.waitForSelector('#chronoscope-root');
+    const btn = page.getByRole('button', { name: /open settings/i });
+    await expect(btn).toHaveCSS('min-width', '44px');
+    await expect(btn).toHaveCSS('min-height', '44px');
+  });
+});


### PR DESCRIPTION
## Summary

Apple polish v3 bundles three visual-chrome items following PR #25's subtractive thesis ("reduce, don't add"):

- **Ambient subtlety** — `.bg` collapsed from 3 untokenized radials (`.07/.06/.04`) to a single token-driven pink radial at `.03` alpha. `color.bg.accent` added.
- **3-tier elevation border hierarchy** — new `color.surface.border.{dim .04, mid .08, bright .14}` tokens wired to `LaneTimingTooltip` (was no border), `Lane` (was `.06`), and `Topbar` (was `.07`). `laneBorder`/`topbarBorder` primitives + their semantic keys deleted entirely.
- **Icon-only desktop topbar** — removed `isMobile` guard so all four ghost buttons (`+ Endpoint`, `Settings`, `Share`, shared-view Share) render their existing 16×16 monoline SVG at every breakpoint. Removed the dead `isMobile`/`mql`/`handleMqlChange`/`onMount`/`onDestroy` lifecycle. Added `min-width: 44px` to `.btn-ghost` at ≥768px to preserve touch target parity.

## Acceptance criteria

| AC | Mechanism |
|---|---|
| AC1 — ambient ≤ `.04` dominant-hue alpha | Vitest unit test on `tokens.ts` asserting alpha ceilings |
| AC2 — 3-tier border hierarchy, ≥ `.04` delta | Playwright `toHaveCSS` assertions on Lane + Topbar; Vitest render-style assertion on tooltip |
| AC3 — desktop topbar SVG icons | Playwright `btn.locator('svg')` visibility + `aria-hidden` on all 3 non-shared ghost buttons |
| AC4 — no PR #25 regressions | `npm run typecheck && lint && test` all exit 0; 595 unit + 86 Playwright tests pass |
| AC5 — 375px + a11y preserved | Playwright `min-width/min-height` at 1440 + 375; scroll-overflow check at 375 |

THE BET: users can identify `+ Endpoint` / `Settings` / `Share` from their monoline icons alone (same icons already shipping on mobile; `aria-label` retains accessible names).

## Test plan

- [x] `npm run typecheck` exits 0
- [x] `npm run lint` exits 0 (zero `no-unused-vars` after `isMobile` lifecycle removal)
- [x] `npm test` exits 0 — 595 tests pass (including 8 new AC1+AC2 token assertions and 1 new AC2 tooltip-border assertion)
- [x] `npx playwright test` exits 0 — 86 visual tests pass across chromium + mobile-chrome (including 9 new AC2/AC3/AC5 assertions in `tests/visual/apple-polish-v3.spec.ts`)
- [x] Grep audit: zero residual references to `laneBorder` / `topbarBorder` / `color.lane.border` / `color.topbar.border`
- [x] Shared-view paranoia: Share SVG markup count = 2 (both branches render identical SVG)
- [ ] Manual: side-by-side screenshot vs `main @ 7514b94` — post-change frame visibly dimmer in pink/orange quadrant (AC1 visual gate)
- [ ] Manual: animation regression check (drag-lift, drawer slide, button press, SharePopover, `prefers-reduced-motion`)

## Non-goals

- `glass.border` / `chrome.border` legacy tokens untouched (16 consumers between them)
- No animation/timing/spacing changes — all PR #25 values locked
- No icon library or icon-name registry — each SVG stays inline in `Topbar.svelte`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded color system with layered border tiers for improved visual consistency across the interface.

* **Bug Fixes**
  * Topbar action buttons now consistently display icons across all viewport sizes.

* **Style**
  * Updated border colors throughout the application for enhanced visual hierarchy.
  * Refined background accent colors for improved design consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->