### PR TITLE
fix(bg): add SVG dither to eliminate gradient banding

### DIFF
--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -108,6 +108,17 @@
       linear-gradient(160deg, #0c0a14 0%, #100e1e 40%, #0e0c18 100%);
     animation: bgShift 20s ease-in-out infinite alternate;
   }
+  /* Dither overlay: SVG turbulence noise breaks 8-bit color banding on the dark gradient.
+     The eye averages sub-pixel noise into smooth transitions, preventing visible stepping
+     between the near-identical dark hex stops (#0c0a14 → #100e1e → #0e0c18). */
+  .bg::after {
+    content: '';
+    position: absolute; inset: 0;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+    background-size: 200px 200px;
+    opacity: 0.04;
+    pointer-events: none;
+  }
   @keyframes bgShift {
     0%   { filter: hue-rotate(0deg) brightness(1); }
     100% { filter: hue-rotate(8deg) brightness(1.02); }


### PR DESCRIPTION
## Summary
User feedback: visible stepping/lines in the background gradient — 8-bit color banding on the dark linear gradient.

Root cause: \`linear-gradient(160deg, #0c0a14 0%, #100e1e 40%, #0e0c18 100%)\` has only 2-10 RGB delta per channel across a full viewport. Each 1/256 color step covers ~200px, making bands perceptible.

Fix: 4% opacity SVG \`feTurbulence\` noise on \`.bg::after\`. Sub-pixel noise dithers adjacent bands together; the eye averages it into smooth gradient. Standard technique (macOS wallpapers, Spotify, Stripe).

## Cost
- ~250 bytes inline data URI
- One fixed \`::after\` pseudo-element, \`pointer-events: none\`
- GPU-rasterized once, zero JS
- Shows through translucent lane cards consistently (desirable)

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean
- [x] \`npm test\` — 595/595 pass
- [x] Rendered in dev at 1200px; gradient reads smooth, no visible bands
- [ ] Verify on physical display (screenshots can hide or exaggerate banding)
- [ ] Check 375px mobile viewport
- [ ] Verify no perceptible "grain" texture at 100% zoom

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Applied a subtle texture overlay to the background for enhanced visual depth and refinement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->