### PR TITLE
fix(bg): replace banding linear-gradient with solid base

### DIFF
--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -105,7 +105,7 @@
     position: fixed; inset: 0; z-index: 0;
     background:
       radial-gradient(ellipse 60% 80% at 85% 90%, var(--bg-accent, rgba(249,168,212,.03)) 0%, transparent 50%),
-      linear-gradient(160deg, #0c0a14 0%, #100e1e 40%, #0e0c18 100%);
+      #0e0c18;
     animation: bgShift 20s ease-in-out infinite alternate;
   }
   @keyframes bgShift {


### PR DESCRIPTION
## Summary
User still saw banding after PR #32 reverted the dither. Root cause confirmed: the linear-gradient has three near-identical dark hex stops (#0c0a14 → #100e1e → #0e0c18) spread across a full viewport — 8-bit sRGB structurally can't smooth this, and browsers don't apply compositor dither to CSS gradients the way macOS does for system wallpapers.

**Fix:** drop the linear, use \`#0e0c18\` solid. One-line change.

**What's preserved:**
- Radial accent (rgba(249,168,212,.03) → transparent) — smooth, no banding because it fades to transparent
- Three blurred ambient orbs — unchanged
- bgShift animation — still works on solid + radial

**Why Apple-aligned:** macOS/iOS apps default to solid backgrounds (Finder, Mail, Messages, Xcode). Depth comes from window chrome, sidebars, and vibrancy — not long near-identical gradients. Apple's dark gradient marketing surfaces use pre-dithered image assets, not CSS.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean
- [x] \`npm test\` — 589/589 pass
- [x] Rendered in dev; no banding, radial accent still visible
- [ ] Live-display verification