### PR TITLE
chore(license): update copyright holder to Shane Wyatt and contributors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Cory Salvesen
+Copyright (c) 2026 Shane Wyatt and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
+  "license": "MIT",
+  "author": "Shane Wyatt",
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary
Make the project's MIT license declaration consistent across all surfaces.

- **LICENSE:** `Copyright (c) 2026 Cory Salvesen` → `Copyright (c) 2026 Shane Wyatt and contributors`. The "and contributors" suffix avoids needing a rename every time someone opens a PR while still satisfying MIT's requirement that a copyright holder be named.
- **package.json:** add `"license": "MIT"` and `"author": "Shane Wyatt"`. Without these, package-metadata scanners (Socket, Snyk, license-checker, Dependabot policies) report the repo as `UNKNOWN` / `UNLICENSED` even though the LICENSE file is canonical MIT — they read the manifest, not the file. `private: true` suppresses the `npm publish` warning but doesn't fix that gap.

Together these make "this project is MIT-licensed, owned by Shane Wyatt" true on every surface a tool might check.

## Test plan
- [x] LICENSE text byte-identical to canonical MIT/SPDX template (verified line-by-line — no smart-quote / CRLF / trailing-whitespace drift)
- [x] `package.json` still parses as valid JSON
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean