### PR TITLE
feat: region-aware default lanes (7 regions × 4 lanes)

### DIFF
--- a/src/lib/components/App.svelte
+++ b/src/lib/components/App.svelte
@@ -6,9 +6,11 @@
   import { get } from 'svelte/store';
   import { tokens } from '$lib/tokens';
   import { settingsStore } from '$lib/stores/settings';
-  import { endpointStore } from '$lib/stores/endpoints';
+  import { endpointStore, buildDefaultEndpoints } from '$lib/stores/endpoints';
   import { uiStore } from '$lib/stores/ui';
   import { MeasurementEngine } from '$lib/engine/measurement-engine';
+  import { detectRegion } from '$lib/regional-defaults';
+  import { applyPersistedSettings } from '$lib/utils/apply-persisted-settings';
   import { loadPersistedSettings, saveSettings } from '$lib/utils/persistence';
   import { initHashRouter } from '$lib/share/hash-router';
   import { initShortcuts } from '$lib/utils/shortcuts';
@@ -92,34 +94,6 @@
     root.style.setProperty('--radius-xs', `${tokens.radius.xs}px`);
   }
 
-  // ── Apply persisted settings to stores ──────────────────────────────────────
-  function applyPersistedSettings(persisted: PersistedSettings): void {
-    // Settings
-    settingsStore.set(persisted.settings);
-
-    // Endpoints: replace defaults with persisted ones
-    if (persisted.endpoints.length > 0) {
-      endpointStore.setEndpoints([]);
-      for (const ep of persisted.endpoints) {
-        if (ep.url.trim()) {
-          const id = endpointStore.addEndpoint(ep.url, ep.url);
-          endpointStore.updateEndpoint(id, { enabled: ep.enabled });
-        }
-      }
-    }
-
-    // UI state
-    if (persisted.ui.activeView) {
-      uiStore.setActiveView(persisted.ui.activeView);
-    }
-    for (const cardId of persisted.ui.expandedCards) {
-      // Only expand if not already expanded
-      if (!get(uiStore).expandedCards.has(cardId)) {
-        uiStore.toggleCard(cardId);
-      }
-    }
-  }
-
   // ── Persistence save subscription ───────────────────────────────────────────
   let unsubSettings: (() => void) | null = null;
   let unsubEndpoints: (() => void) | null = null;
@@ -138,7 +112,7 @@
       const endpoints = get(endpointStore);
 
       const payload: PersistedSettings = {
-        version: 3,
+        version: 4,
         endpoints: endpoints.map(ep => ({ url: ep.url, enabled: ep.enabled })),
         settings,
         ui: {
@@ -189,9 +163,13 @@
       if (persisted) {
         // 3a. Apply persisted state
         applyPersistedSettings(persisted);
+      } else {
+        // First install: seed region-aware defaults (AC1)
+        const detected = detectRegion();
+        endpointStore.setEndpoints(buildDefaultEndpoints(detected));
+        settingsStore.update(s => ({ ...s, region: detected }));
       }
     }
-    // 3b. If no persisted settings and no share URL, defaults are already in stores
 
     // 4. Create engine
     engine = new MeasurementEngine();

--- a/src/lib/components/Lane.svelte
+++ b/src/lib/components/Lane.svelte
@@ -25,11 +25,15 @@
     onGripPointerDown = undefined,
     tier2Averages = undefined,
     onGripKeyDown = undefined,
+    label = undefined,
+    brandRole = undefined,
     children,
   }: {
     endpointId: string;
     color: string;
     url: string;
+    label?: string | undefined;
+    brandRole?: string | undefined;
     p50: number;
     p95: number;
     p99: number;
@@ -119,7 +123,12 @@
         </svg>
       </button>
     {/if}
-    <div class="lane-url">{url}</div>
+    <div class="lane-header-row">
+      <div class="lane-url">{label ?? url}</div>
+      {#if brandRole}
+        <span class="lane-role" aria-label="Role: {brandRole}">{brandRole}</span>
+      {/if}
+    </div>
     <div class="lane-body">
       <div class="lane-hero" aria-label="Median latency {fmt(p50)}">
         <span class="hero-value">{Math.round(p50)}</span>
@@ -162,7 +171,10 @@
         </button>
       {/if}
       <span class="ch-dot" style:background={color}></span>
-      <span class="ch-url">{url}</span>
+      <span class="ch-url">{label ?? url}</span>
+      {#if brandRole}
+        <span class="ch-role" aria-label="Role: {brandRole}">{brandRole}</span>
+      {/if}
       <span class="ch-hero" style:color={color}>{Math.round(p50)}<span class="ch-hero-unit">ms</span></span>
       {#if ready}
         <span class="ch-stat"><span class="ch-stat-label">P95</span> <span class="ch-stat-val">{fmt(p95)}</span></span>
@@ -259,6 +271,45 @@
     min-height: 0; overflow: hidden;
     container-type: size;
     container-name: lane-body;
+  }
+
+  /* Lane header row — url + role badge side by side */
+  .lane-header-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  .lane-role {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 9px;
+    font-weight: 400;
+    color: var(--t4);
+    background: rgba(255,255,255,0.05);
+    border: 1px solid rgba(255,255,255,0.08);
+    border-radius: 3px;
+    padding: 1px 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .ch-role {
+    font-family: var(--mono);
+    font-size: 8px;
+    font-weight: 400;
+    color: var(--t4);
+    background: rgba(255,255,255,0.05);
+    border: 1px solid rgba(255,255,255,0.06);
+    border-radius: 2px;
+    padding: 1px 3px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    white-space: nowrap;
+    flex-shrink: 0;
   }
 
   .lane-url {

--- a/src/lib/components/Lane.svelte
+++ b/src/lib/components/Lane.svelte
@@ -316,6 +316,7 @@
     font-family: var(--sans); font-size: 12px; font-weight: 500;
     color: var(--t2); letter-spacing: 0.02em;
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    min-width: 0; flex: 1 1 0;
   }
   .lane-hero {
     display: flex; align-items: baseline;

--- a/src/lib/components/LanesView.svelte
+++ b/src/lib/components/LanesView.svelte
@@ -434,7 +434,7 @@
         showEntrance={hasAnimatedEntrance}
         color={ep.color}
         url={ep.url}
-        label={brand?.label ?? ep.label}
+        label={ep.label === ep.url ? (brand?.label ?? ep.url) : ep.label}
         brandRole={brand?.role}
         p50={laneProps.p50}
         p95={laneProps.p95}

--- a/src/lib/components/LanesView.svelte
+++ b/src/lib/components/LanesView.svelte
@@ -11,6 +11,7 @@
   import { deriveLayoutMode } from '$lib/layout';
   import type { LayoutMode } from '$lib/layout';
   import type { HeatmapCellData, RibbonData, MeasurementSample } from '$lib/types';
+  import { brandFor } from '$lib/regional-defaults';
   import Lane from './Lane.svelte';
   import LaneSvgChart from './LaneSvgChart.svelte';
   import LaneTimingTooltip from './LaneTimingTooltip.svelte';
@@ -426,12 +427,15 @@
       {@const isDragging = dragState?.fromIndex === i}
       {@const isSettling = settlingIndex === i}
       {@const offset = dragOffsets[i] ?? 0}
+      {@const brand = brandFor(ep.url)}
       <Lane
         endpointId={ep.id}
         laneIndex={i}
         showEntrance={hasAnimatedEntrance}
         color={ep.color}
-        url={ep.label || ep.url}
+        url={ep.url}
+        label={brand?.label ?? ep.label}
+        brandRole={brand?.role}
         p50={laneProps.p50}
         p95={laneProps.p95}
         p99={laneProps.p99}

--- a/src/lib/components/SettingsDrawer.svelte
+++ b/src/lib/components/SettingsDrawer.svelte
@@ -11,6 +11,8 @@
   import { clearPersistedSettings } from '$lib/utils/persistence';
   import { DEFAULT_SETTINGS } from '$lib/types';
   import { tokens } from '$lib/tokens';
+  import { REGIONS, REGION_DISPLAY_NAMES, detectRegion } from '$lib/regional-defaults';
+  import type { Region } from '$lib/regional-defaults';
 
 
   let dialogEl: HTMLDialogElement;
@@ -132,6 +134,27 @@
 
   let showClearConfirm = $state(false);
   let showResetConfirm = $state(false);
+  let showResetRegionalConfirm = $state(false);
+
+  function requestResetRegional(): void {
+    showResetRegionalConfirm = true;
+  }
+
+  function confirmResetRegional(): void {
+    if (isRunning) return;
+    showResetRegionalConfirm = false;
+    const currentRegion: Region = $settingsStore.region ?? detectRegion();
+    endpointStore.reset(currentRegion);
+  }
+
+  function cancelResetRegional(): void {
+    showResetRegionalConfirm = false;
+  }
+
+  function applyRegion(value: string): void {
+    if (value === '') return;
+    settingsStore.update(s => ({ ...s, region: value as Region }));
+  }
 
   function requestClear(): void {
     showClearConfirm = true;
@@ -159,9 +182,12 @@
   function confirmReset(): void {
     if (isRunning) return;
     showResetConfirm = false;
+    // Preserve the user's region across a "Reset to defaults" so regional lanes
+    // re-seed to their region, not NA. Spec §7.5.
+    const currentRegion: Region = $settingsStore.region ?? detectRegion();
     clearPersistedSettings();
-    endpointStore.reset();
-    settingsStore.set({ ...DEFAULT_SETTINGS });
+    endpointStore.reset(currentRegion);
+    settingsStore.set({ ...DEFAULT_SETTINGS, region: currentRegion });
     measurementStore.reset();
     // Re-init default endpoints in measurement store
     const endpoints = get(endpointStore);
@@ -282,6 +308,23 @@
         </fieldset>
       </div>
 
+      <!-- Region select -->
+      <div class="field">
+        <label class="field-label" for="region-select">
+          Region
+        </label>
+        <select
+          id="region-select"
+          class="field-input"
+          value={$settingsStore.region ?? detectRegion()}
+          onchange={(e) => applyRegion((e.target as HTMLSelectElement).value)}
+        >
+          {#each REGIONS as region (region)}
+            <option value={region}>{REGION_DISPLAY_NAMES[region]}</option>
+          {/each}
+        </select>
+      </div>
+
       <!-- Divider -->
       <div class="divider" aria-hidden="true"></div>
 
@@ -290,6 +333,21 @@
         <div class="danger-header">
           <span class="danger-label">Danger zone</span>
         </div>
+
+        <!-- Reset to regional defaults -->
+        {#if !showResetRegionalConfirm}
+          <button type="button" class="btn-danger" disabled={isRunning} aria-disabled={isRunning} onclick={requestResetRegional}>
+            Reset to regional defaults
+          </button>
+        {:else}
+          <div class="confirm-group" role="alert" aria-live="assertive">
+            <p class="confirm-text">Replaces current endpoints with regional defaults. Continue?</p>
+            <div class="confirm-actions">
+              <button type="button" class="btn-danger" disabled={isRunning} onclick={confirmResetRegional}>Yes, reset</button>
+              <button type="button" class="btn-secondary" onclick={cancelResetRegional}>Cancel</button>
+            </div>
+          </div>
+        {/if}
 
         <!-- Reset to defaults -->
         {#if !showResetConfirm}
@@ -817,5 +875,16 @@
   .confirm-actions {
     display: flex;
     gap: var(--spacing-sm);
+  }
+
+  /* Normalize select to match text inputs */
+  select.field-input {
+    appearance: none;
+    -webkit-appearance: none;
+    cursor: pointer;
+    padding-right: 28px;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='rgba(255,255,255,0.3)' stroke-width='1.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 8px center;
   }
 </style>

--- a/src/lib/components/SettingsDrawer.svelte
+++ b/src/lib/components/SettingsDrawer.svelte
@@ -145,6 +145,9 @@
     showResetRegionalConfirm = false;
     const currentRegion: Region = $settingsStore.region ?? detectRegion();
     endpointStore.reset(currentRegion);
+    if (!$settingsStore.region) {
+      settingsStore.update(s => ({ ...s, region: currentRegion }));
+    }
   }
 
   function cancelResetRegional(): void {

--- a/src/lib/components/SharePopover.svelte
+++ b/src/lib/components/SharePopover.svelte
@@ -8,7 +8,7 @@
   import { endpointStore } from '$lib/stores/endpoints';
   import { settingsStore } from '$lib/stores/settings';
   import { measurementStore } from '$lib/stores/measurements';
-  import { buildShareURL, estimateShareSize, truncatePayload } from '$lib/share/share-manager';
+  import { buildShareURL, estimateShareSize, truncatePayload, toSharedSettings } from '$lib/share/share-manager';
   import { tokens } from '$lib/tokens';
   import type { SharePayload } from '$lib/types';
 
@@ -37,7 +37,7 @@
       v: 1,
       mode: 'config',
       endpoints: endpoints.map(ep => ({ url: ep.url, enabled: ep.enabled })),
-      settings,
+      settings: toSharedSettings(settings),
     };
   }
 
@@ -62,7 +62,7 @@
       v: 1,
       mode: 'results',
       endpoints: endpoints.map(ep => ({ url: ep.url, enabled: ep.enabled })),
-      settings,
+      settings: toSharedSettings(settings),
       results,
     };
 

--- a/src/lib/regional-defaults.ts
+++ b/src/lib/regional-defaults.ts
@@ -1,0 +1,193 @@
+// src/lib/regional-defaults.ts
+// Regional defaults module — single source of truth for Region enum, detection,
+// the 7-region endpoint table, and URL-to-brand lookup.
+
+// ── Region type ────────────────────────────────────────────────────────────
+
+export type Region =
+  | 'north-america'
+  | 'europe'
+  | 'east-asia'
+  | 'south-southeast-asia'
+  | 'latam'
+  | 'mea'
+  | 'oceania';
+
+export const REGIONS: readonly Region[] = [
+  'north-america',
+  'europe',
+  'east-asia',
+  'south-southeast-asia',
+  'latam',
+  'mea',
+  'oceania',
+];
+
+export const REGION_DISPLAY_NAMES: Readonly<Record<Region, string>> = {
+  'north-america':        'North America',
+  'europe':               'Europe',
+  'east-asia':            'East Asia',
+  'south-southeast-asia': 'South & Southeast Asia',
+  'latam':                'Latin America',
+  'mea':                  'Middle East & Africa',
+  'oceania':              'Oceania',
+};
+
+// ── LaneRole ───────────────────────────────────────────────────────────────
+
+export type LaneRole =
+  | 'Baseline'
+  | 'Alt-operator'
+  | 'Third-operator'
+  | 'Fourth-operator'
+  | 'Long-haul';
+
+export interface RegionalEndpointSpec {
+  readonly url: string;
+  readonly label: string;
+  readonly role: LaneRole;
+  readonly enabled: true;
+}
+
+// ── REGIONAL_DEFAULTS ──────────────────────────────────────────────────────
+
+export const REGIONAL_DEFAULTS: Readonly<Record<Region, readonly RegionalEndpointSpec[]>> = {
+  'north-america': [
+    { url: 'https://www.google.com',     label: 'Google',     role: 'Baseline',        enabled: true },
+    { url: 'https://www.cloudflare.com', label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
+    { url: 'https://aws.amazon.com',     label: 'AWS',        role: 'Third-operator',  enabled: true },
+    { url: 'https://www.fastly.com',     label: 'Fastly',     role: 'Fourth-operator', enabled: true },
+  ],
+  'europe': [
+    { url: 'https://www.google.com',     label: 'Google',     role: 'Baseline',        enabled: true },
+    { url: 'https://www.cloudflare.com', label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
+    { url: 'https://aws.amazon.com',     label: 'AWS',        role: 'Third-operator',  enabled: true },
+    { url: 'https://www.fastly.com',     label: 'Fastly',     role: 'Fourth-operator', enabled: true },
+  ],
+  'east-asia': [
+    { url: 'https://www.google.com',     label: 'Google',     role: 'Baseline',        enabled: true },
+    { url: 'https://www.cloudflare.com', label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
+    { url: 'https://aws.amazon.com',     label: 'AWS',        role: 'Third-operator',  enabled: true },
+    { url: 'https://www.wikipedia.org',  label: 'Wikipedia',  role: 'Long-haul',       enabled: true },
+  ],
+  'south-southeast-asia': [
+    { url: 'https://www.google.com',     label: 'Google',     role: 'Baseline',        enabled: true },
+    { url: 'https://www.cloudflare.com', label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
+    { url: 'https://aws.amazon.com',     label: 'AWS',        role: 'Third-operator',  enabled: true },
+    { url: 'https://www.wikipedia.org',  label: 'Wikipedia',  role: 'Long-haul',       enabled: true },
+  ],
+  'latam': [
+    { url: 'https://www.google.com',     label: 'Google',     role: 'Baseline',        enabled: true },
+    { url: 'https://www.cloudflare.com', label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
+    { url: 'https://aws.amazon.com',     label: 'AWS',        role: 'Third-operator',  enabled: true },
+    { url: 'https://www.fastly.com',     label: 'Fastly',     role: 'Fourth-operator', enabled: true },
+  ],
+  'mea': [
+    { url: 'https://www.google.com',     label: 'Google',     role: 'Baseline',        enabled: true },
+    { url: 'https://www.cloudflare.com', label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
+    { url: 'https://aws.amazon.com',     label: 'AWS',        role: 'Third-operator',  enabled: true },
+    { url: 'https://www.wikipedia.org',  label: 'Wikipedia',  role: 'Long-haul',       enabled: true },
+  ],
+  'oceania': [
+    { url: 'https://www.google.com',     label: 'Google',     role: 'Baseline',        enabled: true },
+    { url: 'https://www.cloudflare.com', label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
+    { url: 'https://aws.amazon.com',     label: 'AWS',        role: 'Third-operator',  enabled: true },
+    { url: 'https://www.wikipedia.org',  label: 'Wikipedia',  role: 'Long-haul',       enabled: true },
+  ],
+};
+
+// ── isValidRegion ──────────────────────────────────────────────────────────
+
+export function isValidRegion(value: unknown): value is Region {
+  return typeof value === 'string' && (REGIONS as readonly string[]).includes(value);
+}
+
+// ── TZ city sets for detectRegion ──────────────────────────────────────────
+
+const LATAM_TZ_CITIES: ReadonlySet<string> = new Set([
+  'Bogota', 'Buenos_Aires', 'Caracas', 'Cayenne', 'Costa_Rica', 'El_Salvador',
+  'Guatemala', 'Guayaquil', 'Havana', 'La_Paz', 'Lima', 'Managua', 'Mazatlan',
+  'Mexico_City', 'Montevideo', 'Panama', 'Paramaribo', 'Port-au-Prince',
+  'Puerto_Rico', 'Santiago', 'Santo_Domingo', 'Sao_Paulo', 'Tegucigalpa', 'Tijuana',
+]);
+
+const EAST_ASIA_TZ_CITIES: ReadonlySet<string> = new Set([
+  'Shanghai', 'Beijing', 'Chongqing', 'Harbin', 'Kashgar', 'Urumqi',
+  'Hong_Kong', 'Macau', 'Taipei', 'Tokyo', 'Seoul', 'Pyongyang', 'Ulaanbaatar',
+]);
+
+const MEA_TZ_CITIES: ReadonlySet<string> = new Set([
+  'Dubai', 'Muscat', 'Riyadh', 'Qatar', 'Bahrain', 'Kuwait', 'Baghdad', 'Tehran',
+  'Jerusalem', 'Beirut', 'Damascus', 'Amman', 'Aden', 'Yerevan', 'Tbilisi',
+  'Baku', 'Nicosia',
+]);
+
+// ── detectRegion ──────────────────────────────────────────────────────────
+// Never throws. Returns 'north-america' for any unrecognized TZ, UTC, empty, or exception.
+
+export function detectRegion(): Region {
+  try {
+    const tz = String(Intl.DateTimeFormat().resolvedOptions().timeZone || '');
+    const lang = String(navigator.language || '').toLowerCase();
+    const slashIdx = tz.indexOf('/');
+    const continent = slashIdx === -1 ? tz : tz.slice(0, slashIdx);
+    const afterContinent = slashIdx === -1 ? '' : tz.slice(slashIdx + 1);
+    const firstSegment = afterContinent.split('/')[0] ?? '';
+
+    switch (continent) {
+      case 'America': {
+        if (lang.startsWith('pt-br') || lang.startsWith('es-')) return 'latam';
+        if (tz.startsWith('America/Argentina/')) return 'latam';
+        if (tz.startsWith('America/Indiana/')) return 'north-america';
+        if (tz.startsWith('America/Kentucky/')) return 'north-america';
+        if (tz.startsWith('America/North_Dakota/')) return 'north-america';
+        if (LATAM_TZ_CITIES.has(firstSegment)) return 'latam';
+        return 'north-america';
+      }
+      case 'Europe':
+      case 'Atlantic':
+        return 'europe';
+      case 'Asia': {
+        if (EAST_ASIA_TZ_CITIES.has(firstSegment)) return 'east-asia';
+        if (MEA_TZ_CITIES.has(firstSegment))       return 'mea';
+        return 'south-southeast-asia';
+      }
+      case 'Africa':
+      case 'Indian':
+        return 'mea';
+      case 'Australia':
+      case 'Pacific':
+        return 'oceania';
+      default:
+        return 'north-america';
+    }
+  } catch {
+    return 'north-america';
+  }
+}
+
+// ── URL normalization + brand lookup ───────────────────────────────────────
+
+export function normalizeUrlForBrandLookup(url: string): string {
+  try {
+    const parsed = new URL(url);
+    parsed.hostname = parsed.hostname.toLowerCase();
+    const path = parsed.pathname === '/' ? '' : parsed.pathname;
+    return `${parsed.protocol}//${parsed.hostname}${path}${parsed.search}${parsed.hash}`;
+  } catch {
+    return url;
+  }
+}
+
+const BRAND_LABELS: ReadonlyMap<string, { readonly label: string; readonly role: LaneRole }> =
+  new Map([
+    ['https://www.google.com',     { label: 'Google',     role: 'Baseline' }],
+    ['https://www.cloudflare.com', { label: 'Cloudflare', role: 'Alt-operator' }],
+    ['https://aws.amazon.com',     { label: 'AWS',        role: 'Third-operator' }],
+    ['https://www.fastly.com',     { label: 'Fastly',     role: 'Fourth-operator' }],
+    ['https://www.wikipedia.org',  { label: 'Wikipedia',  role: 'Long-haul' }],
+  ]);
+
+export function brandFor(url: string): { readonly label: string; readonly role: LaneRole } | null {
+  return BRAND_LABELS.get(normalizeUrlForBrandLookup(url)) ?? null;
+}

--- a/src/lib/share/share-manager.ts
+++ b/src/lib/share/share-manager.ts
@@ -3,7 +3,17 @@
 // All functions are pure (no DOM side effects) except buildShareURL and parseShareURL.
 
 import LZString from 'lz-string';
-import type { SharePayload } from '../types';
+import type { SharePayload, Settings } from '../types';
+
+// ── Share settings helper ──────────────────────────────────────────────────
+// Explicitly destructures only the 6 allowed share fields.
+// Prevents region (and any future Settings-only fields) from leaking
+// into share links via TypeScript's structural-subtype-allows-excess-fields behavior.
+
+export function toSharedSettings(s: Settings): SharePayload['settings'] {
+  const { timeout, delay, burstRounds, monitorDelay, cap, corsMode } = s;
+  return { timeout, delay, burstRounds, monitorDelay, cap, corsMode };
+}
 
 // ── Encode / Decode ────────────────────────────────────────────────────────
 

--- a/src/lib/stores/endpoints.ts
+++ b/src/lib/stores/endpoints.ts
@@ -3,7 +3,8 @@
 
 import { writable, derived } from 'svelte/store';
 import { tokens } from '../tokens';
-import { DEFAULT_ENDPOINTS } from '../types';
+import { REGIONAL_DEFAULTS } from '../regional-defaults';
+import type { Region } from '../regional-defaults';
 import type { Endpoint } from '../types';
 
 let _idCounter = 0;
@@ -17,12 +18,16 @@ function pickColor(index: number): string {
   return palette[index % palette.length] ?? (tokens.color.endpoint[0] as string);
 }
 
-function buildDefaultEndpoints(): Endpoint[] {
-  return DEFAULT_ENDPOINTS.map((def, i) => ({
+// Exported so App.svelte can call it with a detected region at onMount.
+// Does NOT call detectRegion() — detection is the caller's responsibility.
+// When region is undefined, returns north-america defaults (deterministic module-load behavior).
+export function buildDefaultEndpoints(region?: Region): Endpoint[] {
+  const specs = REGIONAL_DEFAULTS[region ?? 'north-america'];
+  return specs.map((spec, i) => ({
     id: generateId(),
-    url: def.url,
-    enabled: def.enabled,
-    label: def.label,
+    url: spec.url,
+    enabled: spec.enabled,
+    label: spec.label,
     color: pickColor(i),
   }));
 }
@@ -87,8 +92,8 @@ function createEndpointStore() {
       set(endpoints);
     },
 
-    reset(): void {
-      set(buildDefaultEndpoints());
+    reset(region?: Region): void {
+      set(buildDefaultEndpoints(region));
     },
   };
 }

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -6,14 +6,14 @@ import { DEFAULT_SETTINGS } from '../types';
 import type { Settings } from '../types';
 
 function createSettingsStore() {
-  const { subscribe, set, update } = writable<Settings>({ ...DEFAULT_SETTINGS });
+  const { subscribe, set, update } = writable<Settings>({ ...DEFAULT_SETTINGS, region: undefined });
 
   return {
     subscribe,
     update,
     set,
     reset() {
-      set({ ...DEFAULT_SETTINGS });
+      set({ ...DEFAULT_SETTINGS, region: undefined });
     },
   };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,6 +2,8 @@
 // Cross-boundary TypeScript contracts. All worker messages, store shapes, and
 // share payloads are defined here. No logic — only types and interfaces.
 
+import type { Region } from './regional-defaults';
+
 // ── Lifecycle ──────────────────────────────────────────────────────────────
 export type TestLifecycleState =
   | 'idle'
@@ -171,6 +173,7 @@ export interface Settings {
   monitorDelay: number;
   cap: number;
   corsMode: 'no-cors' | 'cors';
+  region?: Region;
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -259,7 +262,7 @@ export interface SharePayload {
 
 // ── Persistence schema ─────────────────────────────────────────────────────
 export interface PersistedSettings {
-  version: 2 | 3;
+  version: 2 | 3 | 4;
   endpoints: { url: string; enabled: boolean }[];
   settings: Settings;
   ui: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -185,11 +185,6 @@ export const DEFAULT_SETTINGS: Settings = {
   corsMode: 'no-cors',
 };
 
-export const DEFAULT_ENDPOINTS: Omit<Endpoint, 'id' | 'color'>[] = [
-  { url: 'https://www.google.com', enabled: true, label: 'Google' },
-  { url: 'https://1.1.1.1', enabled: true, label: 'Cloudflare DNS' },
-];
-
 // ── UI store ───────────────────────────────────────────────────────────────
 export type ActiveView = 'timeline' | 'heatmap' | 'split';
 

--- a/src/lib/utils/apply-persisted-settings.ts
+++ b/src/lib/utils/apply-persisted-settings.ts
@@ -1,0 +1,36 @@
+// src/lib/utils/apply-persisted-settings.ts
+// Applies a loaded PersistedSettings payload to the runtime stores.
+// Always replaces the endpoint store (including with empty array) so persisted
+// state — including explicit "no endpoints" — is faithfully restored.
+
+import { get } from 'svelte/store';
+import { endpointStore } from '../stores/endpoints';
+import { settingsStore } from '../stores/settings';
+import { uiStore } from '../stores/ui';
+import type { PersistedSettings } from '../types';
+
+export function applyPersistedSettings(persisted: PersistedSettings): void {
+  // Settings (includes region if present in persisted data)
+  settingsStore.set(persisted.settings);
+
+  // Endpoints: ALWAYS clear the module-load placeholder first, then repopulate.
+  // This ensures persisted.endpoints:[] is respected and not silently overridden
+  // by the module-load NA seed (spec §6.2).
+  endpointStore.setEndpoints([]);
+  for (const ep of persisted.endpoints) {
+    if (ep.url.trim()) {
+      const id = endpointStore.addEndpoint(ep.url, ep.url);
+      endpointStore.updateEndpoint(id, { enabled: ep.enabled });
+    }
+  }
+
+  // UI state
+  if (persisted.ui.activeView) {
+    uiStore.setActiveView(persisted.ui.activeView);
+  }
+  for (const cardId of persisted.ui.expandedCards) {
+    if (!get(uiStore).expandedCards.has(cardId)) {
+      uiStore.toggleCard(cardId);
+    }
+  }
+}

--- a/src/lib/utils/persistence.ts
+++ b/src/lib/utils/persistence.ts
@@ -2,17 +2,17 @@
 // Versioned localStorage persistence with forward-only migration support.
 
 import { DEFAULT_SETTINGS } from '../types';
+import { detectRegion, isValidRegion } from '../regional-defaults';
 import type { PersistedSettings, ActiveView } from '../types';
+import type { Region } from '../regional-defaults';
 
 const STORAGE_KEY = 'chronoscope_settings'; // skipcq: JS-0860 — localStorage key, not a credential
 const LEGACY_STORAGE_KEY = 'chronoscope_v2_settings'; // skipcq: JS-0860 — localStorage key, not a credential
-const CURRENT_VERSION = 3;
+const CURRENT_VERSION = 4;
 
 export function loadPersistedSettings(): PersistedSettings | null {
   try {
     let raw = localStorage.getItem(STORAGE_KEY);
-
-    // Migrate from legacy key name
     if (raw === null) {
       raw = localStorage.getItem(LEGACY_STORAGE_KEY);
       if (raw !== null) {
@@ -20,7 +20,6 @@ export function loadPersistedSettings(): PersistedSettings | null {
         localStorage.removeItem(LEGACY_STORAGE_KEY);
       }
     }
-
     if (raw === null) return null;
     const parsed: unknown = JSON.parse(raw);
     return migrateSettings(parsed);
@@ -50,15 +49,27 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
   const version = typeof record['version'] === 'number' ? record['version'] : 0;
 
   if (version === CURRENT_VERSION) {
-    return normalizeV3(record);
+    return normalizeV4(record);
+  }
+
+  if (version === 3) {
+    const v3 = normalizeV3(record);
+    if (!v3) return null;
+    return {
+      ...v3,
+      version: 4,
+      settings: {
+        ...v3.settings,
+        region: detectRegion(),
+      },
+    };
   }
 
   if (version === 2) {
-    // v2 → v3: add burstRounds + monitorDelay, migrate delay
     const v2 = normalizeV2(record);
     if (!v2) return null;
     const oldDelay = v2.settings.delay;
-    return {
+    const v3: PersistedSettings = {
       ...v2,
       version: 3,
       settings: {
@@ -68,10 +79,17 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
         monitorDelay: oldDelay >= 0 ? oldDelay : DEFAULT_SETTINGS.monitorDelay,
       },
     };
+    return {
+      ...v3,
+      version: 4,
+      settings: {
+        ...v3.settings,
+        region: detectRegion(),
+      },
+    };
   }
 
   if (version === 1) {
-    // v1 → v2 → v3: add ui object, normalize settings, then migrate to v3
     const rawEndpoints = Array.isArray(record['endpoints']) ? record['endpoints'] : [];
     const endpoints = rawEndpoints
       .filter((e): e is Record<string, unknown> => e !== null && typeof e === 'object')
@@ -81,9 +99,9 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
       }));
 
     return {
-      version: 3,
+      version: 4,
       endpoints,
-      settings: { ...DEFAULT_SETTINGS },
+      settings: { ...DEFAULT_SETTINGS, region: detectRegion() },
       ui: {
         expandedCards: [],
         activeView: 'split' as ActiveView,
@@ -91,6 +109,9 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
     };
   }
 
+  // Unknown version — return null (triggers first-install path).
+  // Spec §5: we deliberately do NOT coerce unknown versions through normalizeV4,
+  // because that silently drops shape changes to existing fields.
   return null;
 }
 
@@ -110,10 +131,8 @@ function normalizeV2(record: Record<string, unknown>): PersistedSettings | null 
         : {};
 
     const settings = {
-      timeout:
-        typeof rawSettings['timeout'] === 'number' ? rawSettings['timeout'] : DEFAULT_SETTINGS.timeout,
-      delay:
-        typeof rawSettings['delay'] === 'number' ? rawSettings['delay'] : DEFAULT_SETTINGS.delay,
+      timeout: typeof rawSettings['timeout'] === 'number' ? rawSettings['timeout'] : DEFAULT_SETTINGS.timeout,
+      delay: typeof rawSettings['delay'] === 'number' ? rawSettings['delay'] : DEFAULT_SETTINGS.delay,
       burstRounds: DEFAULT_SETTINGS.burstRounds,
       monitorDelay: DEFAULT_SETTINGS.monitorDelay,
       cap: typeof rawSettings['cap'] === 'number' ? rawSettings['cap'] : DEFAULT_SETTINGS.cap,
@@ -133,18 +152,11 @@ function normalizeV2(record: Record<string, unknown>): PersistedSettings | null 
       : [];
 
     const activeView: ActiveView =
-      rawUi['activeView'] === 'timeline' ||
-      rawUi['activeView'] === 'heatmap' ||
-      rawUi['activeView'] === 'split'
+      rawUi['activeView'] === 'timeline' || rawUi['activeView'] === 'heatmap' || rawUi['activeView'] === 'split'
         ? rawUi['activeView']
         : 'split';
 
-    return {
-      version: 2,
-      endpoints,
-      settings,
-      ui: { expandedCards, activeView },
-    };
+    return { version: 2, endpoints, settings, ui: { expandedCards, activeView } };
   } catch {
     return null;
   }
@@ -166,14 +178,10 @@ function normalizeV3(record: Record<string, unknown>): PersistedSettings | null 
         : {};
 
     const settings = {
-      timeout:
-        typeof rawSettings['timeout'] === 'number' ? rawSettings['timeout'] : DEFAULT_SETTINGS.timeout,
-      delay:
-        typeof rawSettings['delay'] === 'number' ? rawSettings['delay'] : DEFAULT_SETTINGS.delay,
-      burstRounds:
-        typeof rawSettings['burstRounds'] === 'number' ? rawSettings['burstRounds'] : DEFAULT_SETTINGS.burstRounds,
-      monitorDelay:
-        typeof rawSettings['monitorDelay'] === 'number' ? rawSettings['monitorDelay'] : DEFAULT_SETTINGS.monitorDelay,
+      timeout: typeof rawSettings['timeout'] === 'number' ? rawSettings['timeout'] : DEFAULT_SETTINGS.timeout,
+      delay: typeof rawSettings['delay'] === 'number' ? rawSettings['delay'] : DEFAULT_SETTINGS.delay,
+      burstRounds: typeof rawSettings['burstRounds'] === 'number' ? rawSettings['burstRounds'] : DEFAULT_SETTINGS.burstRounds,
+      monitorDelay: typeof rawSettings['monitorDelay'] === 'number' ? rawSettings['monitorDelay'] : DEFAULT_SETTINGS.monitorDelay,
       cap: typeof rawSettings['cap'] === 'number' ? rawSettings['cap'] : DEFAULT_SETTINGS.cap,
       corsMode:
         rawSettings['corsMode'] === 'cors' || rawSettings['corsMode'] === 'no-cors'
@@ -191,18 +199,62 @@ function normalizeV3(record: Record<string, unknown>): PersistedSettings | null 
       : [];
 
     const activeView: ActiveView =
-      rawUi['activeView'] === 'timeline' ||
-      rawUi['activeView'] === 'heatmap' ||
-      rawUi['activeView'] === 'split'
+      rawUi['activeView'] === 'timeline' || rawUi['activeView'] === 'heatmap' || rawUi['activeView'] === 'split'
         ? rawUi['activeView']
         : 'split';
 
-    return {
-      version: 3,
-      endpoints,
-      settings,
-      ui: { expandedCards, activeView },
+    return { version: 3, endpoints, settings, ui: { expandedCards, activeView } };
+  } catch {
+    return null;
+  }
+}
+
+function normalizeV4(record: Record<string, unknown>): PersistedSettings | null {
+  try {
+    const rawEndpoints = Array.isArray(record['endpoints']) ? record['endpoints'] : [];
+    const endpoints = rawEndpoints
+      .filter((e): e is Record<string, unknown> => e !== null && typeof e === 'object')
+      .map((e) => ({
+        url: typeof e['url'] === 'string' ? e['url'] : '',
+        enabled: typeof e['enabled'] === 'boolean' ? e['enabled'] : true,
+      }));
+
+    const rawSettings =
+      record['settings'] !== null && typeof record['settings'] === 'object'
+        ? (record['settings'] as Record<string, unknown>)
+        : {};
+
+    const rawRegion: unknown = rawSettings['region'];
+    const region: Region | undefined = isValidRegion(rawRegion) ? rawRegion : undefined;
+
+    const settings = {
+      timeout: typeof rawSettings['timeout'] === 'number' ? rawSettings['timeout'] : DEFAULT_SETTINGS.timeout,
+      delay: typeof rawSettings['delay'] === 'number' ? rawSettings['delay'] : DEFAULT_SETTINGS.delay,
+      burstRounds: typeof rawSettings['burstRounds'] === 'number' ? rawSettings['burstRounds'] : DEFAULT_SETTINGS.burstRounds,
+      monitorDelay: typeof rawSettings['monitorDelay'] === 'number' ? rawSettings['monitorDelay'] : DEFAULT_SETTINGS.monitorDelay,
+      cap: typeof rawSettings['cap'] === 'number' ? rawSettings['cap'] : DEFAULT_SETTINGS.cap,
+      corsMode:
+        rawSettings['corsMode'] === 'cors' || rawSettings['corsMode'] === 'no-cors'
+          ? rawSettings['corsMode']
+          : DEFAULT_SETTINGS.corsMode,
+      ...(region !== undefined ? { region } : {}),
     };
+
+    const rawUi =
+      record['ui'] !== null && typeof record['ui'] === 'object'
+        ? (record['ui'] as Record<string, unknown>)
+        : {};
+
+    const expandedCards = Array.isArray(rawUi['expandedCards'])
+      ? (rawUi['expandedCards'] as unknown[]).filter((x): x is string => typeof x === 'string')
+      : [];
+
+    const activeView: ActiveView =
+      rawUi['activeView'] === 'timeline' || rawUi['activeView'] === 'heatmap' || rawUi['activeView'] === 'split'
+        ? rawUi['activeView']
+        : 'split';
+
+    return { version: 4, endpoints, settings, ui: { expandedCards, activeView } };
   } catch {
     return null;
   }

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -37,6 +37,7 @@ if (typeof HTMLDialogElement !== 'undefined') {
   if (!HTMLDialogElement.prototype.close) {
     HTMLDialogElement.prototype.close = function () {
       this.removeAttribute('open');
+      this.dispatchEvent(new Event('close'));
     };
   }
 }

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -25,3 +25,18 @@ if (typeof window !== 'undefined' && !window.ResizeObserver) {
     disconnect() {}
   };
 }
+
+// HTMLDialogElement.showModal / close are not implemented in jsdom; provide stubs
+// so SettingsDrawer (which uses <dialog>) can be rendered in unit tests.
+if (typeof HTMLDialogElement !== 'undefined') {
+  if (!HTMLDialogElement.prototype.showModal) {
+    HTMLDialogElement.prototype.showModal = function () {
+      this.setAttribute('open', '');
+    };
+  }
+  if (!HTMLDialogElement.prototype.close) {
+    HTMLDialogElement.prototype.close = function () {
+      this.removeAttribute('open');
+    };
+  }
+}

--- a/tests/unit/components/lanes-view.test.ts
+++ b/tests/unit/components/lanes-view.test.ts
@@ -21,6 +21,11 @@ describe('LanesView', () => {
   });
 
   it('renders grip handles for each lane when multiple endpoints', () => {
+    // Trim to 2 endpoints so JSDOM (containerHeight=0) stays in 'full' layout mode
+    // and showGrip is true. The compact-2col layout (≥4 endpoints) hides grips by design.
+    const eps = get(endpointStore);
+    eps.slice(2).forEach(ep => endpointStore.removeEndpoint(ep.id));
+
     const { container } = render(LanesView, { props: {} });
     const grips = container.querySelectorAll('.lane-grip');
     const lanes = container.querySelectorAll('.lane');

--- a/tests/unit/components/settings-region-select.test.ts
+++ b/tests/unit/components/settings-region-select.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+
+// Mock stores and dependencies that SettingsDrawer imports
+vi.mock('$lib/stores/ui', () => ({
+  uiStore: {
+    subscribe: vi.fn((cb: (v: { showSettings: boolean; lifecycle: string }) => void) => {
+      cb({ showSettings: true, lifecycle: 'idle' });
+      return () => {};
+    }),
+    toggleSettings: vi.fn(),
+    setActiveView: vi.fn(),
+    toggleCard: vi.fn(),
+  },
+}));
+vi.mock('$lib/stores/measurements', () => ({
+  measurementStore: {
+    subscribe: vi.fn((cb: (v: { lifecycle: string; endpoints: Record<string, unknown> }) => void) => {
+      cb({ lifecycle: 'idle', endpoints: {} });
+      return () => {};
+    }),
+    reset: vi.fn(),
+    initEndpoint: vi.fn(),
+  },
+}));
+vi.mock('$lib/stores/endpoints', () => ({
+  endpointStore: {
+    subscribe: vi.fn((cb: (v: unknown[]) => void) => { cb([]); return () => {}; }),
+    reset: vi.fn(),
+  },
+}));
+vi.mock('$lib/utils/persistence', () => ({
+  clearPersistedSettings: vi.fn(),
+}));
+vi.mock('$lib/regional-defaults', () => ({
+  REGIONS: ['north-america', 'europe', 'east-asia', 'south-southeast-asia', 'latam', 'mea', 'oceania'],
+  REGION_DISPLAY_NAMES: {
+    'north-america': 'North America',
+    'europe': 'Europe',
+    'east-asia': 'East Asia',
+    'south-southeast-asia': 'South & Southeast Asia',
+    'latam': 'Latin America',
+    'mea': 'Middle East & Africa',
+    'oceania': 'Oceania',
+  },
+  detectRegion: vi.fn(() => 'north-america'),
+}));
+
+import { settingsStore } from '$lib/stores/settings';
+import SettingsDrawer from '../../../src/lib/components/SettingsDrawer.svelte';
+
+describe('SettingsDrawer Region select (AC3)', () => {
+  it('renders a Region label associated with a select', async () => {
+    const { getByLabelText } = render(SettingsDrawer);
+    // AC3: label text MUST be exactly "Region" for Playwright getByLabel to work
+    const select = getByLabelText('Region');
+    expect(select.tagName).toBe('SELECT');
+  });
+
+  it('select has exactly 7 options', async () => {
+    const { getByLabelText } = render(SettingsDrawer);
+    const select = getByLabelText('Region') as HTMLSelectElement;
+    expect(select.options.length).toBe(7);
+  });
+
+  it('option values match the 7 Region strings', async () => {
+    const { getByLabelText } = render(SettingsDrawer);
+    const select = getByLabelText('Region') as HTMLSelectElement;
+    const values = Array.from(select.options).map(o => o.value);
+    expect(values).toContain('north-america');
+    expect(values).toContain('europe');
+    expect(values).toContain('east-asia');
+    expect(values).toContain('south-southeast-asia');
+    expect(values).toContain('latam');
+    expect(values).toContain('mea');
+    expect(values).toContain('oceania');
+  });
+
+  it('option display text matches REGION_DISPLAY_NAMES', async () => {
+    const { getByLabelText } = render(SettingsDrawer);
+    const select = getByLabelText('Region') as HTMLSelectElement;
+    const optionByValue = (v: string) =>
+      Array.from(select.options).find(o => o.value === v)?.text;
+    expect(optionByValue('north-america')).toBe('North America');
+    expect(optionByValue('europe')).toBe('Europe');
+    expect(optionByValue('latam')).toBe('Latin America');
+  });
+
+  it('changing the select updates settingsStore.region', async () => {
+    const { getByLabelText } = render(SettingsDrawer);
+    const select = getByLabelText('Region') as HTMLSelectElement;
+    await fireEvent.change(select, { target: { value: 'east-asia' } });
+    expect(get(settingsStore).region).toBe('east-asia');
+  });
+
+  it('Reset to regional defaults button is present', async () => {
+    const { getByRole } = render(SettingsDrawer);
+    // AC4: accessible name must match /reset to regional defaults/i
+    const btn = getByRole('button', { name: /reset to regional defaults/i });
+    expect(btn).toBeTruthy();
+  });
+});

--- a/tests/unit/persistence.test.ts
+++ b/tests/unit/persistence.test.ts
@@ -29,7 +29,7 @@ describe('persistence', () => {
     };
     saveSettings(settings);
     const loaded = loadPersistedSettings();
-    expect(loaded?.version).toBe(3);
+    expect(loaded?.version).toBe(4);
     expect(loaded?.endpoints[0]?.url).toBe('https://example.com');
     expect(loaded?.settings.burstRounds).toBe(50);
     expect(loaded?.settings.monitorDelay).toBe(1000);
@@ -50,21 +50,21 @@ describe('persistence', () => {
     };
     localStorageMock.setItem('chronoscope_v2_settings', JSON.stringify(settings));
     const loaded = loadPersistedSettings();
-    expect(loaded?.version).toBe(3);
+    expect(loaded?.version).toBe(4);
     // Legacy key should be removed, new key should exist
     expect(localStorageMock.getItem('chronoscope_v2_settings')).toBeNull();
     expect(localStorageMock.getItem('chronoscope_settings')).not.toBeNull();
   });
 
-  it('migrates v1 data to v3', () => {
+  it('migrates v1 data to v4', () => {
     const v1Data = { version: 1, endpoints: [{ url: 'https://example.com' }] };
     const migrated = migrateSettings(v1Data);
-    expect(migrated?.version).toBe(3);
+    expect(migrated?.version).toBe(4);
     expect(migrated?.settings.burstRounds).toBe(50);
     expect(migrated?.settings.monitorDelay).toBe(1000);
   });
 
-  it('migrates v2 data to v3 with old delay as monitorDelay', () => {
+  it('migrates v2 data to v4 with old delay as monitorDelay', () => {
     const v2Data = {
       version: 2,
       endpoints: [{ url: 'https://example.com', enabled: true }],
@@ -72,7 +72,7 @@ describe('persistence', () => {
       ui: { expandedCards: [], activeView: 'split' },
     };
     const migrated = migrateSettings(v2Data);
-    expect(migrated?.version).toBe(3);
+    expect(migrated?.version).toBe(4);
     expect(migrated?.settings.monitorDelay).toBe(500);
     expect(migrated?.settings.burstRounds).toBe(50);
     expect(migrated?.settings.delay).toBe(0);

--- a/tests/unit/regional-defaults.test.ts
+++ b/tests/unit/regional-defaults.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  REGIONS,
+  REGION_DISPLAY_NAMES,
+  REGIONAL_DEFAULTS,
+  isValidRegion,
+  detectRegion,
+  brandFor,
+  normalizeUrlForBrandLookup,
+} from '../../src/lib/regional-defaults';
+import type { Region } from '../../src/lib/regional-defaults';
+
+// ── REGIONAL_DEFAULTS invariants ───────────────────────────────────────────
+
+describe('REGIONAL_DEFAULTS', () => {
+  it('all 7 regions have exactly 4 entries', () => {
+    for (const region of REGIONS) {
+      expect(REGIONAL_DEFAULTS[region]).toHaveLength(4);
+    }
+  });
+
+  it('lane 1 is Google URL for every region', () => {
+    for (const region of REGIONS) {
+      expect(REGIONAL_DEFAULTS[region][0]?.url).toBe('https://www.google.com');
+    }
+  });
+
+  it('lane 2 is Cloudflare URL for every region', () => {
+    for (const region of REGIONS) {
+      expect(REGIONAL_DEFAULTS[region][1]?.url).toBe('https://www.cloudflare.com');
+    }
+  });
+
+  it('lane 3 is AWS URL for every region', () => {
+    for (const region of REGIONS) {
+      expect(REGIONAL_DEFAULTS[region][2]?.url).toBe('https://aws.amazon.com');
+    }
+  });
+
+  it('NA/EU/LATAM lane 4 is Fastly (Fourth-operator)', () => {
+    for (const region of ['north-america', 'europe', 'latam'] as Region[]) {
+      expect(REGIONAL_DEFAULTS[region][3]?.url).toBe('https://www.fastly.com');
+      expect(REGIONAL_DEFAULTS[region][3]?.role).toBe('Fourth-operator');
+    }
+  });
+
+  it('East Asia/SEA/MEA/Oceania lane 4 is Wikipedia (Long-haul)', () => {
+    for (const region of ['east-asia', 'south-southeast-asia', 'mea', 'oceania'] as Region[]) {
+      expect(REGIONAL_DEFAULTS[region][3]?.url).toBe('https://www.wikipedia.org');
+      expect(REGIONAL_DEFAULTS[region][3]?.role).toBe('Long-haul');
+    }
+  });
+
+  it('every URL in the table has a matching BRAND_LABELS entry (brandFor returns non-null)', () => {
+    for (const region of REGIONS) {
+      for (const spec of REGIONAL_DEFAULTS[region]) {
+        expect(brandFor(spec.url)).not.toBeNull();
+      }
+    }
+  });
+
+  it('all entries have enabled: true', () => {
+    for (const region of REGIONS) {
+      for (const spec of REGIONAL_DEFAULTS[region]) {
+        expect(spec.enabled).toBe(true);
+      }
+    }
+  });
+});
+
+describe('REGION_DISPLAY_NAMES', () => {
+  it('has exactly 7 keys matching REGIONS', () => {
+    expect(Object.keys(REGION_DISPLAY_NAMES)).toHaveLength(7);
+    for (const region of REGIONS) {
+      expect(REGION_DISPLAY_NAMES[region]).toBeTruthy();
+    }
+  });
+
+  it('has correct display strings', () => {
+    expect(REGION_DISPLAY_NAMES['north-america']).toBe('North America');
+    expect(REGION_DISPLAY_NAMES['europe']).toBe('Europe');
+    expect(REGION_DISPLAY_NAMES['east-asia']).toBe('East Asia');
+    expect(REGION_DISPLAY_NAMES['south-southeast-asia']).toBe('South & Southeast Asia');
+    expect(REGION_DISPLAY_NAMES['latam']).toBe('Latin America');
+    expect(REGION_DISPLAY_NAMES['mea']).toBe('Middle East & Africa');
+    expect(REGION_DISPLAY_NAMES['oceania']).toBe('Oceania');
+  });
+});
+
+describe('isValidRegion', () => {
+  it('returns true for all 7 valid region strings', () => {
+    for (const region of REGIONS) {
+      expect(isValidRegion(region)).toBe(true);
+    }
+  });
+  it('returns false for undefined', () => { expect(isValidRegion(undefined)).toBe(false); });
+  it('returns false for null', () => { expect(isValidRegion(null)).toBe(false); });
+  it('returns false for empty string', () => { expect(isValidRegion('')).toBe(false); });
+  it('returns false for hyphen-missing variant', () => { expect(isValidRegion('northamerica')).toBe(false); });
+  it('returns false for uppercase', () => { expect(isValidRegion('NA')).toBe(false); });
+  it('returns false for plain object', () => { expect(isValidRegion({})).toBe(false); });
+  it('returns false for number', () => { expect(isValidRegion(42)).toBe(false); });
+});
+
+function mockTz(tz: string, lang = 'en-US'): void {
+  vi.spyOn(Intl, 'DateTimeFormat').mockReturnValue({
+    resolvedOptions: () => ({ timeZone: tz } as Intl.ResolvedDateTimeFormatOptions),
+  } as Intl.DateTimeFormat);
+  Object.defineProperty(navigator, 'language', { value: lang, configurable: true });
+}
+
+describe('detectRegion', () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it('UTC → north-america (AC5)', () => { mockTz('UTC'); expect(detectRegion()).toBe('north-america'); });
+  it('empty string → north-america (AC5)', () => { mockTz(''); expect(detectRegion()).toBe('north-america'); });
+  it('Asia/Tokyo → east-asia', () => { mockTz('Asia/Tokyo'); expect(detectRegion()).toBe('east-asia'); });
+  it('Asia/Kolkata → south-southeast-asia', () => { mockTz('Asia/Kolkata'); expect(detectRegion()).toBe('south-southeast-asia'); });
+  it('Asia/Dubai → mea', () => { mockTz('Asia/Dubai'); expect(detectRegion()).toBe('mea'); });
+  it('America/Sao_Paulo → latam', () => { mockTz('America/Sao_Paulo', 'pt-BR'); expect(detectRegion()).toBe('latam'); });
+  it('America/Argentina/Buenos_Aires → latam', () => { mockTz('America/Argentina/Buenos_Aires', 'es-AR'); expect(detectRegion()).toBe('latam'); });
+  it('America/Indiana/Indianapolis → north-america (US nested zone)', () => { mockTz('America/Indiana/Indianapolis', 'en-US'); expect(detectRegion()).toBe('north-america'); });
+  it('America/New_York + pt-BR → latam (locale tiebreaker)', () => { mockTz('America/New_York', 'pt-BR'); expect(detectRegion()).toBe('latam'); });
+  it('America/New_York + en-US → north-america', () => { mockTz('America/New_York', 'en-US'); expect(detectRegion()).toBe('north-america'); });
+  it('Europe/Berlin → europe', () => { mockTz('Europe/Berlin'); expect(detectRegion()).toBe('europe'); });
+  it('Atlantic/Azores → europe', () => { mockTz('Atlantic/Azores'); expect(detectRegion()).toBe('europe'); });
+  it('Australia/Sydney → oceania', () => { mockTz('Australia/Sydney'); expect(detectRegion()).toBe('oceania'); });
+  it('Pacific/Auckland → oceania', () => { mockTz('Pacific/Auckland'); expect(detectRegion()).toBe('oceania'); });
+  it('Africa/Johannesburg → mea', () => { mockTz('Africa/Johannesburg'); expect(detectRegion()).toBe('mea'); });
+  it('Indian/Mauritius → mea', () => { mockTz('Indian/Mauritius'); expect(detectRegion()).toBe('mea'); });
+  it('Antarctica/* → north-america (default fallback)', () => { mockTz('Antarctica/McMurdo'); expect(detectRegion()).toBe('north-america'); });
+  it('does not throw when Intl.DateTimeFormat throws', () => {
+    vi.spyOn(Intl, 'DateTimeFormat').mockImplementation(() => { throw new Error('Intl unavailable'); });
+    expect(() => detectRegion()).not.toThrow();
+    expect(detectRegion()).toBe('north-america');
+  });
+});
+
+describe('brandFor', () => {
+  it('returns Google/Baseline for canonical URL', () => {
+    expect(brandFor('https://www.google.com')).toEqual({ label: 'Google', role: 'Baseline' });
+  });
+  it('returns Cloudflare/Alt-operator', () => {
+    expect(brandFor('https://www.cloudflare.com')).toEqual({ label: 'Cloudflare', role: 'Alt-operator' });
+  });
+  it('returns AWS/Third-operator', () => {
+    expect(brandFor('https://aws.amazon.com')).toEqual({ label: 'AWS', role: 'Third-operator' });
+  });
+  it('returns Fastly/Fourth-operator', () => {
+    expect(brandFor('https://www.fastly.com')).toEqual({ label: 'Fastly', role: 'Fourth-operator' });
+  });
+  it('returns Wikipedia/Long-haul', () => {
+    expect(brandFor('https://www.wikipedia.org')).toEqual({ label: 'Wikipedia', role: 'Long-haul' });
+  });
+  it('matches trailing slash variant', () => {
+    expect(brandFor('https://www.google.com/')).toEqual({ label: 'Google', role: 'Baseline' });
+  });
+  it('matches mixed-case URL', () => {
+    expect(brandFor('HTTPS://WWW.GOOGLE.COM')).toEqual({ label: 'Google', role: 'Baseline' });
+  });
+  it('returns null for http:// (protocol difference — intentional miss)', () => {
+    expect(brandFor('http://www.google.com')).toBeNull();
+  });
+  it('returns null for no-protocol URL', () => {
+    expect(brandFor('google.com')).toBeNull();
+  });
+  it('returns null for arbitrary user-added URL', () => {
+    expect(brandFor('https://example.com')).toBeNull();
+  });
+});
+
+describe('normalizeUrlForBrandLookup', () => {
+  it('lowercases hostname', () => {
+    expect(normalizeUrlForBrandLookup('https://WWW.GOOGLE.COM')).toBe('https://www.google.com');
+  });
+  it('strips trailing slash on root path', () => {
+    expect(normalizeUrlForBrandLookup('https://www.google.com/')).toBe('https://www.google.com');
+  });
+  it('preserves non-root path', () => {
+    expect(normalizeUrlForBrandLookup('https://www.google.com/search')).toBe('https://www.google.com/search');
+  });
+  it('preserves protocol (http vs https treated as distinct)', () => {
+    expect(normalizeUrlForBrandLookup('http://www.google.com')).toBe('http://www.google.com');
+  });
+  it('returns input as-is for malformed URL', () => {
+    expect(normalizeUrlForBrandLookup('not a url')).toBe('not a url');
+  });
+});

--- a/tests/unit/share/to-shared-settings.test.ts
+++ b/tests/unit/share/to-shared-settings.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { toSharedSettings } from '../../../src/lib/share/share-manager';
+import type { Settings } from '../../../src/lib/types';
+
+describe('toSharedSettings', () => {
+  it('strips region from the output', () => {
+    const settings: Settings = {
+      timeout: 5000,
+      delay: 0,
+      burstRounds: 50,
+      monitorDelay: 1000,
+      cap: 0,
+      corsMode: 'no-cors',
+      region: 'europe',
+    };
+    const shared = toSharedSettings(settings);
+    expect('region' in shared).toBe(false);
+  });
+
+  it('preserves all 6 share fields', () => {
+    const settings: Settings = {
+      timeout: 3000,
+      delay: 100,
+      burstRounds: 25,
+      monitorDelay: 500,
+      cap: 100,
+      corsMode: 'cors',
+      region: 'east-asia',
+    };
+    const shared = toSharedSettings(settings);
+    expect(shared.timeout).toBe(3000);
+    expect(shared.delay).toBe(100);
+    expect(shared.burstRounds).toBe(25);
+    expect(shared.monitorDelay).toBe(500);
+    expect(shared.cap).toBe(100);
+    expect(shared.corsMode).toBe('cors');
+  });
+
+  it('output is assignable to SharePayload[settings] shape', () => {
+    const settings: Settings = {
+      timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors',
+    };
+    const shared = toSharedSettings(settings);
+    expect(shared).toHaveProperty('timeout');
+    expect(shared).toHaveProperty('delay');
+    expect(shared).toHaveProperty('cap');
+    expect(shared).toHaveProperty('corsMode');
+  });
+
+  it('works when region is undefined (no region field in source)', () => {
+    const settings: Settings = {
+      timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors',
+    };
+    const shared = toSharedSettings(settings);
+    expect('region' in shared).toBe(false);
+  });
+});

--- a/tests/unit/stores/endpoints-regional.test.ts
+++ b/tests/unit/stores/endpoints-regional.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import { endpointStore, buildDefaultEndpoints } from '../../../src/lib/stores/endpoints';
+import { REGIONAL_DEFAULTS, REGIONS } from '../../../src/lib/regional-defaults';
+import type { Region } from '../../../src/lib/regional-defaults';
+
+describe('buildDefaultEndpoints', () => {
+  it('given each of the 7 regions, returns 4 endpoints matching the table', () => {
+    for (const region of REGIONS) {
+      const endpoints = buildDefaultEndpoints(region as Region);
+      expect(endpoints).toHaveLength(4);
+      for (let i = 0; i < 4; i++) {
+        expect(endpoints[i]?.url).toBe(REGIONAL_DEFAULTS[region as Region][i]?.url);
+      }
+    }
+  });
+
+  it('given undefined, returns north-america endpoints (no detectRegion call)', () => {
+    const endpoints = buildDefaultEndpoints(undefined);
+    expect(endpoints).toHaveLength(4);
+    expect(endpoints[0]?.url).toBe('https://www.google.com');
+    expect(endpoints[1]?.url).toBe('https://www.cloudflare.com');
+    expect(endpoints[2]?.url).toBe('https://aws.amazon.com');
+    expect(endpoints[3]?.url).toBe('https://www.fastly.com');
+  });
+
+  it('endpoints have unique IDs', () => {
+    const endpoints = buildDefaultEndpoints('europe');
+    const ids = endpoints.map(ep => ep.id);
+    expect(new Set(ids).size).toBe(4);
+  });
+
+  it('all endpoints are enabled', () => {
+    const endpoints = buildDefaultEndpoints('east-asia');
+    for (const ep of endpoints) {
+      expect(ep.enabled).toBe(true);
+    }
+  });
+
+  it('lane 4 for east-asia is Wikipedia', () => {
+    const endpoints = buildDefaultEndpoints('east-asia');
+    expect(endpoints[3]?.url).toBe('https://www.wikipedia.org');
+  });
+
+  it('lane 4 for north-america is Fastly', () => {
+    const endpoints = buildDefaultEndpoints('north-america');
+    expect(endpoints[3]?.url).toBe('https://www.fastly.com');
+  });
+});
+
+describe('endpointStore.reset', () => {
+  beforeEach(() => {
+    endpointStore.reset();
+  });
+
+  it('reset() with no arg uses north-america (legacy fallback)', () => {
+    endpointStore.addEndpoint('https://example.com');
+    endpointStore.reset();
+    const eps = get(endpointStore);
+    expect(eps).toHaveLength(4);
+    expect(eps[0]?.url).toBe('https://www.google.com');
+    expect(eps[3]?.url).toBe('https://www.fastly.com');
+  });
+
+  it("reset('europe') replaces store with Europe's 4 endpoints", () => {
+    endpointStore.addEndpoint('https://example.com');
+    endpointStore.reset('europe');
+    const eps = get(endpointStore);
+    expect(eps).toHaveLength(4);
+    for (let i = 0; i < 4; i++) {
+      expect(eps[i]?.url).toBe(REGIONAL_DEFAULTS['europe'][i]?.url);
+    }
+  });
+
+  it("reset('east-asia') places Wikipedia at lane 4", () => {
+    endpointStore.reset('east-asia');
+    const eps = get(endpointStore);
+    expect(eps[3]?.url).toBe('https://www.wikipedia.org');
+  });
+});

--- a/tests/unit/types.test.ts
+++ b/tests/unit/types.test.ts
@@ -14,7 +14,8 @@ import type {
   PersistedSettings,
   TestLifecycleState,
 } from '../../src/lib/types';
-import { DEFAULT_SETTINGS, DEFAULT_ENDPOINTS } from '../../src/lib/types';
+import { DEFAULT_SETTINGS } from '../../src/lib/types';
+import { REGIONAL_DEFAULTS } from '../../src/lib/regional-defaults';
 import type { FrameData, RibbonData, XTick, YRange, Gridline, HeatmapCellData } from '../../src/lib/types';
 
 describe('types', () => {
@@ -87,10 +88,10 @@ describe('types', () => {
     expect(DEFAULT_SETTINGS.corsMode).toBe('no-cors');
   });
 
-  it('DEFAULT_ENDPOINTS has 2 entries', () => {
-    expect(DEFAULT_ENDPOINTS).toHaveLength(2);
-    expect(DEFAULT_ENDPOINTS[0]?.url).toBe('https://www.google.com');
-    expect(DEFAULT_ENDPOINTS[1]?.url).toBe('https://1.1.1.1');
+  it('REGIONAL_DEFAULTS north-america has 4 entries with Google as first URL', () => {
+    // AC1/AC5: north-america is the default fallback region
+    expect(REGIONAL_DEFAULTS['north-america']).toHaveLength(4);
+    expect(REGIONAL_DEFAULTS['north-america'][0]?.url).toBe('https://www.google.com');
   });
 
   it('UIState has showKeyboardHelp field', () => {

--- a/tests/unit/utils/apply-persisted-settings.test.ts
+++ b/tests/unit/utils/apply-persisted-settings.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import { applyPersistedSettings } from '../../../src/lib/utils/apply-persisted-settings';
+import { endpointStore } from '../../../src/lib/stores/endpoints';
+import { settingsStore } from '../../../src/lib/stores/settings';
+import type { PersistedSettings } from '../../../src/lib/types';
+
+beforeEach(() => {
+  // Start each test from a placeholder state to confirm applyPersistedSettings overrides it.
+  endpointStore.setEndpoints([
+    { id: 'placeholder-1', url: 'https://example.com', enabled: true, label: 'placeholder', color: '#000' },
+  ]);
+});
+
+describe('applyPersistedSettings — AC2 empty-endpoints contract (§6.2)', () => {
+  it('persisted v4 with endpoints:[] results in empty endpoint store', () => {
+    const persisted: PersistedSettings = {
+      version: 4,
+      endpoints: [],
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors' },
+      ui: { expandedCards: [], activeView: 'split' },
+    };
+
+    applyPersistedSettings(persisted);
+
+    const eps = get(endpointStore);
+    expect(eps).toHaveLength(0);
+  });
+
+  it('persisted v4 with endpoints:[{url,enabled}, ...] replaces placeholder', () => {
+    const persisted: PersistedSettings = {
+      version: 4,
+      endpoints: [
+        { url: 'https://user-added.example', enabled: true },
+        { url: 'https://another.example', enabled: false },
+      ],
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors' },
+      ui: { expandedCards: [], activeView: 'split' },
+    };
+
+    applyPersistedSettings(persisted);
+
+    const eps = get(endpointStore);
+    expect(eps).toHaveLength(2);
+    expect(eps[0]?.url).toBe('https://user-added.example');
+    expect(eps[0]?.enabled).toBe(true);
+    expect(eps[1]?.url).toBe('https://another.example');
+    expect(eps[1]?.enabled).toBe(false);
+  });
+
+  it('applies persisted settings (including region) to settingsStore', () => {
+    const persisted: PersistedSettings = {
+      version: 4,
+      endpoints: [],
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', region: 'europe' },
+      ui: { expandedCards: [], activeView: 'split' },
+    };
+
+    applyPersistedSettings(persisted);
+
+    expect(get(settingsStore).region).toBe('europe');
+  });
+});

--- a/tests/unit/utils/persistence-migration.test.ts
+++ b/tests/unit/utils/persistence-migration.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { migrateSettings } from '../../../src/lib/utils/persistence';
+
+vi.mock('../../../src/lib/regional-defaults', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../../src/lib/regional-defaults')>();
+  return {
+    ...original,
+    detectRegion: vi.fn(() => 'europe' as const),
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('migrateSettings v3 → v4', () => {
+  it('v3 payload with no region → v4 with region = detectRegion()', () => {
+    const v3 = {
+      version: 3,
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors' },
+      ui: { expandedCards: [], activeView: 'timeline' },
+    };
+    const result = migrateSettings(v3);
+    expect(result?.version).toBe(4);
+    expect(result?.settings.region).toBe('europe');
+    expect(result?.endpoints[0]?.url).toBe('https://example.com');
+  });
+
+  it('v4 payload with valid region passes through unchanged', () => {
+    const v4 = {
+      version: 4,
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', region: 'east-asia' },
+      ui: { expandedCards: [], activeView: 'split' },
+    };
+    const result = migrateSettings(v4);
+    expect(result?.version).toBe(4);
+    expect(result?.settings.region).toBe('east-asia');
+  });
+
+  it('v4 payload with invalid region string strips the field', () => {
+    const v4 = {
+      version: 4,
+      endpoints: [],
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', region: 'fakeland' },
+      ui: { expandedCards: [], activeView: 'split' },
+    };
+    const result = migrateSettings(v4);
+    expect(result?.version).toBe(4);
+    expect(result?.settings.region).toBeUndefined();
+  });
+
+  it('v4 payload with null region strips the field', () => {
+    const v4 = {
+      version: 4,
+      endpoints: [],
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', region: null },
+      ui: { expandedCards: [], activeView: 'split' },
+    };
+    const result = migrateSettings(v4);
+    expect(result?.settings.region).toBeUndefined();
+  });
+
+  it('v2 payload migrates through to v4 (chain migration)', () => {
+    const v2 = {
+      version: 2,
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 500, cap: 0, corsMode: 'no-cors' },
+      ui: { expandedCards: [], activeView: 'split' },
+    };
+    const result = migrateSettings(v2);
+    expect(result?.version).toBe(4);
+    expect(result?.settings.burstRounds).toBe(50);
+    expect(result?.settings.region).toBe('europe');
+  });
+
+  it('v1 payload migrates through to v4', () => {
+    const v1 = {
+      version: 1,
+      endpoints: [{ url: 'https://example.com' }],
+    };
+    const result = migrateSettings(v1);
+    expect(result?.version).toBe(4);
+  });
+
+  it('version 99 (future unknown): returns null — no forward-compat coercion', () => {
+    // Spec §5: migrateSettings returns null for unknown versions.
+    const future = {
+      version: 99,
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', region: 'europe' },
+      ui: { expandedCards: [], activeView: 'split' },
+      unknownFutureField: 'ignored',
+    };
+    const result = migrateSettings(future);
+    expect(result).toBeNull();
+  });
+});

--- a/tests/visual/regional-defaults-e2e.spec.ts
+++ b/tests/visual/regional-defaults-e2e.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test';
+import { REGIONAL_DEFAULTS } from '../../src/lib/regional-defaults';
+
+test.describe('Regional Default Lanes — E2E', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+    await page.waitForSelector('#chronoscope-root');
+  });
+
+  // AC4: manual region override reseeds lanes and survives reload
+  test('AC4: select LATAM region + reset → 4 LATAM URLs persist across reload', async ({ page }) => {
+    // Open settings drawer
+    await page.getByRole('button', { name: /open settings/i }).click();
+    await expect(page.getByRole('dialog', { name: /^settings$/i })).toBeVisible({ timeout: 2000 });
+
+    // AC3: Region select is present with exactly 7 options
+    const regionSelect = page.getByLabel('Region');
+    await expect(regionSelect).toBeVisible();
+    const options = regionSelect.locator('option');
+    await expect(options).toHaveCount(7);
+
+    // Select LATAM
+    await regionSelect.selectOption('latam');
+
+    // Click Reset to regional defaults — should show confirmation dialog
+    await page.getByRole('button', { name: /reset to regional defaults/i }).click();
+
+    // Confirm dialog
+    await page.getByRole('button', { name: /yes, reset/i }).click();
+
+    // Close settings drawer
+    await page.getByRole('button', { name: /close settings/i }).click();
+
+    // Wait for DOM to reflect 4 lanes
+    const laneArticles = page.locator('article[data-endpoint-id]');
+    await expect(laneArticles).toHaveCount(4, { timeout: 3000 });
+
+    // Assert URLs match LATAM defaults — via aria-label on the Lane article
+    const expectedUrls = REGIONAL_DEFAULTS['latam'].map(s => s.url);
+    for (const url of expectedUrls) {
+      await expect(page.locator(`[aria-label="Endpoint ${url}"]`)).toBeVisible({ timeout: 3000 });
+    }
+
+    // Reload and verify persistence
+    await page.reload();
+    await page.waitForSelector('#chronoscope-root');
+
+    // Same 4 lanes must be present after reload
+    const lanesAfterReload = page.locator('article[data-endpoint-id]');
+    await expect(lanesAfterReload).toHaveCount(4, { timeout: 3000 });
+
+    for (const url of expectedUrls) {
+      await expect(page.locator(`[aria-label="Endpoint ${url}"]`)).toBeVisible({ timeout: 3000 });
+    }
+  });
+
+  // AC5: UTC timezone falls back to NA defaults
+  test('AC5: fresh install with UTC timezone gets NA defaults', async ({ page }) => {
+    await page.addInitScript(() => {
+      const orig = Intl.DateTimeFormat;
+      // @ts-expect-error — browser context override
+      Intl.DateTimeFormat = function(...args: unknown[]) {
+        const fmt = new orig(...(args as []));
+        const origResolved = fmt.resolvedOptions.bind(fmt);
+        fmt.resolvedOptions = () => ({ ...origResolved(), timeZone: 'UTC' });
+        return fmt;
+      };
+      Object.assign(Intl.DateTimeFormat, orig);
+      localStorage.clear();
+    });
+
+    await page.goto('/');
+    await page.waitForSelector('#chronoscope-root');
+
+    const lanes = page.locator('article[data-endpoint-id]');
+    await expect(lanes).toHaveCount(4, { timeout: 3000 });
+
+    // NA defaults: Google, Cloudflare, AWS, Fastly
+    await expect(page.locator('[aria-label="Endpoint https://www.google.com"]')).toBeVisible({ timeout: 3000 });
+    await expect(page.locator('[aria-label="Endpoint https://www.fastly.com"]')).toBeVisible({ timeout: 3000 });
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces the 2-lane anycast default (`google.com` + `1.1.1.1`) with **4 region-aware default lanes** seeded on first install, detected silently via timezone + `navigator.language` (7 regions: NA, Europe, East Asia, S/SE Asia, LATAM, MEA, Oceania).
- Each lane has a **role**: Baseline (Google) / Alt-operator (Cloudflare) / Third-operator (AWS) / Long-haul (Wikipedia, for APAC+MEA+Oceania) or Fourth-operator (Fastly, for NA+EU+LATAM where Wikipedia is in-region).
- Settings drawer gains a **Region** select + **Reset to regional defaults** button (with confirmation); existing **Reset to defaults** now preserves the user's region instead of silently reverting to NA.

## Key implementation details

- **New module** `src/lib/regional-defaults.ts` — `Region` union, 7×4 `REGIONAL_DEFAULTS` table, `detectRegion()` (total, never throws, NA fallback), `brandFor(url)` with URL normalization.
- **Schema migration** `PersistedSettings` v3 → v4 — adds `region` to `Settings`; unknown versions return `null` (no forward-compat coercion — see spec §5 rationale).
- **Extracted** `applyPersistedSettings` from `App.svelte` into a module for direct unit-testability; now correctly respects `endpoints: []` empty state.
- **Share-link isolation** — new `toSharedSettings()` helper explicitly destructures the 6 allowed fields, preventing `region` from leaking into share URLs.
- **Lane aria-label** now uses the real URL (`url={ep.url}`) instead of the display label — unblocks URL-based E2E selectors.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — **669/669 unit tests pass** (up from 589 — added 80 new tests)
- [x] `npx playwright test tests/visual/regional-defaults-e2e.spec.ts` — **2/2 AC tests pass** (AC4 LATAM reset+reload persistence; AC5 UTC→NA fallback)
- [x] Manual verification of region detection across mocked TZs: Tokyo → east-asia; Sao_Paulo → latam; Argentina/Buenos_Aires → latam; Indiana/Indianapolis → north-america; UTC → north-america; throwing `Intl.DateTimeFormat` → north-america
- [x] Migration chain tested: v1 → v4, v2 → v4, v3 → v4, v4 passthrough, v99 → null, invalid-region strip
- [x] Pre-existing visual regression flakes unchanged (main has 48 failures; this branch has 34 — no new regressions)

## Spec + plan artifacts

- Spec: `docs/superpowers/specs/2026-04-17-regional-default-lanes-design.md`
- Plan: `docs/plans/2026-04-17-regional-default-lanes-plan.md`
- Retrospective: `docs/superpowers/retrospectives/2026-04-17-regional-default-lanes-retro.md`

## Known limitations (documented in spec §5 / §8)

- **Rollback from v4 to v3 is destructive** — `migrateSettings` returns null for v4 data under v3 code. Accepted: pure-frontend tool, data is user-reconfigurable.
- **No TAO headers on any default origin** — lanes return duration-only timing (no DNS/TCP/TLS phase breakdown). Pre-existing behavior, not a regression.
- **Label-persistence bug for user-added endpoints unchanged** — pre-existing issue; intentionally out of scope per ADM (see approach memo).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic region detection based on browser timezone and language
  * Region selection in settings with region-specific endpoint defaults
  * Lane headers now display branded labels and operational roles
  * New "Reset to regional defaults" button to restore region-specific endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->