### PR TITLE
fix(lane): swap regional probe URLs that hit redirect/image-pipeline detours

### DIFF
--- a/src/lib/regional-defaults.ts
+++ b/src/lib/regional-defaults.ts
@@ -53,46 +53,46 @@ export interface RegionalEndpointSpec {
 
 export const REGIONAL_DEFAULTS: Readonly<Record<Region, readonly RegionalEndpointSpec[]>> = {
   'north-america': [
-    { url: 'https://www.google.com',     label: 'Google',     role: 'Baseline',        enabled: true },
-    { url: 'https://www.cloudflare.com', label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
-    { url: 'https://aws.amazon.com',     label: 'AWS',        role: 'Third-operator',  enabled: true },
-    { url: 'https://www.fastly.com',     label: 'Fastly',     role: 'Fourth-operator', enabled: true },
+    { url: 'https://www.google.com',              label: 'Google',     role: 'Baseline',        enabled: true },
+    { url: 'https://www.cloudflare.com',          label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
+    { url: 'https://aws.amazon.com',              label: 'AWS',        role: 'Third-operator',  enabled: true },
+    { url: 'https://www.fastly.com/robots.txt',   label: 'Fastly',     role: 'Fourth-operator', enabled: true },
   ],
   'europe': [
-    { url: 'https://www.google.com',     label: 'Google',     role: 'Baseline',        enabled: true },
-    { url: 'https://www.cloudflare.com', label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
-    { url: 'https://aws.amazon.com',     label: 'AWS',        role: 'Third-operator',  enabled: true },
-    { url: 'https://www.fastly.com',     label: 'Fastly',     role: 'Fourth-operator', enabled: true },
+    { url: 'https://www.google.com',              label: 'Google',     role: 'Baseline',        enabled: true },
+    { url: 'https://www.cloudflare.com',          label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
+    { url: 'https://aws.amazon.com',              label: 'AWS',        role: 'Third-operator',  enabled: true },
+    { url: 'https://www.fastly.com/robots.txt',   label: 'Fastly',     role: 'Fourth-operator', enabled: true },
   ],
   'east-asia': [
-    { url: 'https://www.google.com',     label: 'Google',     role: 'Baseline',        enabled: true },
-    { url: 'https://www.cloudflare.com', label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
-    { url: 'https://aws.amazon.com',     label: 'AWS',        role: 'Third-operator',  enabled: true },
-    { url: 'https://www.wikipedia.org',  label: 'Wikipedia',  role: 'Long-haul',       enabled: true },
+    { url: 'https://www.google.com',              label: 'Google',     role: 'Baseline',        enabled: true },
+    { url: 'https://www.cloudflare.com',          label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
+    { url: 'https://aws.amazon.com',              label: 'AWS',        role: 'Third-operator',  enabled: true },
+    { url: 'https://en.wikipedia.org',            label: 'Wikipedia',  role: 'Long-haul',       enabled: true },
   ],
   'south-southeast-asia': [
-    { url: 'https://www.google.com',     label: 'Google',     role: 'Baseline',        enabled: true },
-    { url: 'https://www.cloudflare.com', label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
-    { url: 'https://aws.amazon.com',     label: 'AWS',        role: 'Third-operator',  enabled: true },
-    { url: 'https://www.wikipedia.org',  label: 'Wikipedia',  role: 'Long-haul',       enabled: true },
+    { url: 'https://www.google.com',              label: 'Google',     role: 'Baseline',        enabled: true },
+    { url: 'https://www.cloudflare.com',          label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
+    { url: 'https://aws.amazon.com',              label: 'AWS',        role: 'Third-operator',  enabled: true },
+    { url: 'https://en.wikipedia.org',            label: 'Wikipedia',  role: 'Long-haul',       enabled: true },
   ],
   'latam': [
-    { url: 'https://www.google.com',     label: 'Google',     role: 'Baseline',        enabled: true },
-    { url: 'https://www.cloudflare.com', label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
-    { url: 'https://aws.amazon.com',     label: 'AWS',        role: 'Third-operator',  enabled: true },
-    { url: 'https://www.fastly.com',     label: 'Fastly',     role: 'Fourth-operator', enabled: true },
+    { url: 'https://www.google.com',              label: 'Google',     role: 'Baseline',        enabled: true },
+    { url: 'https://www.cloudflare.com',          label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
+    { url: 'https://aws.amazon.com',              label: 'AWS',        role: 'Third-operator',  enabled: true },
+    { url: 'https://www.fastly.com/robots.txt',   label: 'Fastly',     role: 'Fourth-operator', enabled: true },
   ],
   'mea': [
-    { url: 'https://www.google.com',     label: 'Google',     role: 'Baseline',        enabled: true },
-    { url: 'https://www.cloudflare.com', label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
-    { url: 'https://aws.amazon.com',     label: 'AWS',        role: 'Third-operator',  enabled: true },
-    { url: 'https://www.wikipedia.org',  label: 'Wikipedia',  role: 'Long-haul',       enabled: true },
+    { url: 'https://www.google.com',              label: 'Google',     role: 'Baseline',        enabled: true },
+    { url: 'https://www.cloudflare.com',          label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
+    { url: 'https://aws.amazon.com',              label: 'AWS',        role: 'Third-operator',  enabled: true },
+    { url: 'https://en.wikipedia.org',            label: 'Wikipedia',  role: 'Long-haul',       enabled: true },
   ],
   'oceania': [
-    { url: 'https://www.google.com',     label: 'Google',     role: 'Baseline',        enabled: true },
-    { url: 'https://www.cloudflare.com', label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
-    { url: 'https://aws.amazon.com',     label: 'AWS',        role: 'Third-operator',  enabled: true },
-    { url: 'https://www.wikipedia.org',  label: 'Wikipedia',  role: 'Long-haul',       enabled: true },
+    { url: 'https://www.google.com',              label: 'Google',     role: 'Baseline',        enabled: true },
+    { url: 'https://www.cloudflare.com',          label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
+    { url: 'https://aws.amazon.com',              label: 'AWS',        role: 'Third-operator',  enabled: true },
+    { url: 'https://en.wikipedia.org',            label: 'Wikipedia',  role: 'Long-haul',       enabled: true },
   ],
 };
 
@@ -181,11 +181,11 @@ export function normalizeUrlForBrandLookup(url: string): string {
 
 const BRAND_LABELS: ReadonlyMap<string, { readonly label: string; readonly role: LaneRole }> =
   new Map([
-    ['https://www.google.com',     { label: 'Google',     role: 'Baseline' }],
-    ['https://www.cloudflare.com', { label: 'Cloudflare', role: 'Alt-operator' }],
-    ['https://aws.amazon.com',     { label: 'AWS',        role: 'Third-operator' }],
-    ['https://www.fastly.com',     { label: 'Fastly',     role: 'Fourth-operator' }],
-    ['https://www.wikipedia.org',  { label: 'Wikipedia',  role: 'Long-haul' }],
+    ['https://www.google.com',            { label: 'Google',     role: 'Baseline' }],
+    ['https://www.cloudflare.com',        { label: 'Cloudflare', role: 'Alt-operator' }],
+    ['https://aws.amazon.com',            { label: 'AWS',        role: 'Third-operator' }],
+    ['https://www.fastly.com/robots.txt', { label: 'Fastly',     role: 'Fourth-operator' }],
+    ['https://en.wikipedia.org',          { label: 'Wikipedia',  role: 'Long-haul' }],
   ]);
 
 export function brandFor(url: string): { readonly label: string; readonly role: LaneRole } | null {

--- a/tests/unit/regional-defaults.test.ts
+++ b/tests/unit/regional-defaults.test.ts
@@ -39,14 +39,14 @@ describe('REGIONAL_DEFAULTS', () => {
 
   it('NA/EU/LATAM lane 4 is Fastly (Fourth-operator)', () => {
     for (const region of ['north-america', 'europe', 'latam'] as Region[]) {
-      expect(REGIONAL_DEFAULTS[region][3]?.url).toBe('https://www.fastly.com');
+      expect(REGIONAL_DEFAULTS[region][3]?.url).toBe('https://www.fastly.com/robots.txt');
       expect(REGIONAL_DEFAULTS[region][3]?.role).toBe('Fourth-operator');
     }
   });
 
   it('East Asia/SEA/MEA/Oceania lane 4 is Wikipedia (Long-haul)', () => {
     for (const region of ['east-asia', 'south-southeast-asia', 'mea', 'oceania'] as Region[]) {
-      expect(REGIONAL_DEFAULTS[region][3]?.url).toBe('https://www.wikipedia.org');
+      expect(REGIONAL_DEFAULTS[region][3]?.url).toBe('https://en.wikipedia.org');
       expect(REGIONAL_DEFAULTS[region][3]?.role).toBe('Long-haul');
     }
   });
@@ -147,10 +147,10 @@ describe('brandFor', () => {
     expect(brandFor('https://aws.amazon.com')).toEqual({ label: 'AWS', role: 'Third-operator' });
   });
   it('returns Fastly/Fourth-operator', () => {
-    expect(brandFor('https://www.fastly.com')).toEqual({ label: 'Fastly', role: 'Fourth-operator' });
+    expect(brandFor('https://www.fastly.com/robots.txt')).toEqual({ label: 'Fastly', role: 'Fourth-operator' });
   });
   it('returns Wikipedia/Long-haul', () => {
-    expect(brandFor('https://www.wikipedia.org')).toEqual({ label: 'Wikipedia', role: 'Long-haul' });
+    expect(brandFor('https://en.wikipedia.org')).toEqual({ label: 'Wikipedia', role: 'Long-haul' });
   });
   it('matches trailing slash variant', () => {
     expect(brandFor('https://www.google.com/')).toEqual({ label: 'Google', role: 'Baseline' });

--- a/tests/unit/stores/endpoints-regional.test.ts
+++ b/tests/unit/stores/endpoints-regional.test.ts
@@ -21,7 +21,7 @@ describe('buildDefaultEndpoints', () => {
     expect(endpoints[0]?.url).toBe('https://www.google.com');
     expect(endpoints[1]?.url).toBe('https://www.cloudflare.com');
     expect(endpoints[2]?.url).toBe('https://aws.amazon.com');
-    expect(endpoints[3]?.url).toBe('https://www.fastly.com');
+    expect(endpoints[3]?.url).toBe('https://www.fastly.com/robots.txt');
   });
 
   it('endpoints have unique IDs', () => {
@@ -39,12 +39,12 @@ describe('buildDefaultEndpoints', () => {
 
   it('lane 4 for east-asia is Wikipedia', () => {
     const endpoints = buildDefaultEndpoints('east-asia');
-    expect(endpoints[3]?.url).toBe('https://www.wikipedia.org');
+    expect(endpoints[3]?.url).toBe('https://en.wikipedia.org');
   });
 
   it('lane 4 for north-america is Fastly', () => {
     const endpoints = buildDefaultEndpoints('north-america');
-    expect(endpoints[3]?.url).toBe('https://www.fastly.com');
+    expect(endpoints[3]?.url).toBe('https://www.fastly.com/robots.txt');
   });
 });
 
@@ -59,7 +59,7 @@ describe('endpointStore.reset', () => {
     const eps = get(endpointStore);
     expect(eps).toHaveLength(4);
     expect(eps[0]?.url).toBe('https://www.google.com');
-    expect(eps[3]?.url).toBe('https://www.fastly.com');
+    expect(eps[3]?.url).toBe('https://www.fastly.com/robots.txt');
   });
 
   it("reset('europe') replaces store with Europe's 4 endpoints", () => {
@@ -75,6 +75,6 @@ describe('endpointStore.reset', () => {
   it("reset('east-asia') places Wikipedia at lane 4", () => {
     endpointStore.reset('east-asia');
     const eps = get(endpointStore);
-    expect(eps[3]?.url).toBe('https://www.wikipedia.org');
+    expect(eps[3]?.url).toBe('https://en.wikipedia.org');
   });
 });

--- a/tests/visual/regional-defaults-e2e.spec.ts
+++ b/tests/visual/regional-defaults-e2e.spec.ts
@@ -79,6 +79,6 @@ test.describe('Regional Default Lanes — E2E', () => {
 
     // NA defaults: Google, Cloudflare, AWS, Fastly
     await expect(page.locator('[aria-label="Endpoint https://www.google.com"]')).toBeVisible({ timeout: 3000 });
-    await expect(page.locator('[aria-label="Endpoint https://www.fastly.com"]')).toBeVisible({ timeout: 3000 });
+    await expect(page.locator('[aria-label="Endpoint https://www.fastly.com/robots.txt"]')).toBeVisible({ timeout: 3000 });
   });
 });


### PR DESCRIPTION
## Summary

Two of the five default regional probe URLs were measuring the wrong thing. Replacing them gives operator-latency numbers that reflect the edge network instead of noise from redirects and image-optimization pipelines.

- **Fastly**: `https://www.fastly.com` → `https://www.fastly.com/robots.txt`. The `/favicon.ico` path that the probe resolver was appending gets routed through Fastly's Image Optimizer (IO) on www.fastly.com for browser-originated requests, adding ~265ms to TTFB even though `.ico` can't be transcoded. curl from the same machine returns the same URL in ~54ms; Chrome sees ~289ms median (p95 455, p99 521). Other Fastly customers (reddit, jsdelivr, api.github) serve in 17–33ms from Chrome, so the slowness is specific to that host's VCL, not Fastly's edge. `/robots.txt` is `text/plain`, so it bypasses IO and lands in the main cache pipeline. **Result: 289ms → 21ms median**, tied with Google for the fastest lane — a 14× improvement.
- **Wikipedia**: `https://www.wikipedia.org` → `https://en.wikipedia.org`. `www.wikipedia.org` is Wikimedia's language-portal host, not a content host; both `/favicon.ico` and `/robots.txt` return 301 redirects to `en.wikipedia.org/*`, forcing every probe round to do an extra cross-origin hop. The worker's bare-origin resolver still appends `/favicon.ico`, but now to a host that serves content directly.

Applies to all 7 regions: Fastly is the Fourth-operator for NA/EU/LATAM; Wikipedia is the Long-haul for East Asia / South & Southeast Asia / MEA / Oceania.

## Browser TTFB audit (before → after)

| Host                         | Before     | After   |
|------------------------------|------------|---------|
| www.fastly.com/favicon.ico   | 289ms      | —       |
| www.fastly.com/robots.txt    | —          | **21ms**|
| www.wikipedia.org/favicon.ico| 36ms (301) | —       |
| en.wikipedia.org/favicon.ico | —          | 34ms    |
| www.google.com/favicon.ico   | 18ms       | 18ms    |
| www.cloudflare.com/favicon.ico| 83ms      | 83ms    |
| aws.amazon.com/favicon.ico   | 31ms       | 31ms    |

Google/Cloudflare/AWS were audited with the same methodology (curl-vs-browser TTFB comparison, /favicon.ico vs /robots.txt on each host) and showed <10ms gaps — no image-pipeline artifacts, no redirects, no changes needed.

## Data-format note

`BRAND_LABELS` entries were replaced (not appended) to match the new URLs. Existing users with `https://www.fastly.com` or `https://www.wikipedia.org` in localStorage will see those lanes render without brand + role labels until they click "Reset to regional defaults." Accepted because the tool has no deployed user base yet.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — **669/669 pass** (same as baseline)
- [x] Manual verification on chronoscope.dev: edited Fastly lane URL to `/robots.txt` in the live UI and observed median drop from 289ms → 21ms across ~100 rounds
- [x] Audited all 5 regional default hosts for image-pipeline / redirect artifacts; only Fastly and Wikipedia affected

## Files changed

- `src/lib/regional-defaults.ts` — 3 Fastly entries (NA/EU/LATAM) + 4 Wikipedia entries (East Asia/SEA/MEA/Oceania) in `REGIONAL_DEFAULTS`; matching `BRAND_LABELS` entries
- `tests/unit/regional-defaults.test.ts` — URL assertions (2 table + 2 `brandFor`)
- `tests/unit/stores/endpoints-regional.test.ts` — 5 URL assertions
- `tests/visual/regional-defaults-e2e.spec.ts` — aria-label selector

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated regional default endpoint URLs for Fastly and Wikipedia across multiple regions
  * Updated unit and integration tests to reflect new endpoint configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->