### PR TITLE
feat(lane): surface tier2 waterfall in compact layout mode

### DIFF
--- a/src/lib/components/Lane.svelte
+++ b/src/lib/components/Lane.svelte
@@ -74,6 +74,12 @@
   function fmtLoss(pct: number): string {
     return pct === 0 ? '0%' : `${pct.toFixed(1)}%`;
   }
+
+  const hasMeaningfulTier2 = $derived(
+    tier2Averages !== undefined &&
+    tier2Averages.dnsLookup + tier2Averages.tcpConnect + tier2Averages.tlsHandshake +
+      tier2Averages.ttfb + tier2Averages.contentTransfer > 0,
+  );
 </script>
 
 <article
@@ -183,6 +189,11 @@
         <span class="ch-stat"><span class="ch-stat-label">L</span> <span class="ch-stat-val">{fmtLoss(lossPercent)}</span></span>
       {/if}
     </div>
+    {#if ready && hasMeaningfulTier2 && tier2Averages !== undefined}
+      <div class="lane-compact-waterfall">
+        <LaneHeaderWaterfall {tier2Averages} compact={true} />
+      </div>
+    {/if}
   {/if}
   <div class="lane-chart" aria-label="Latency chart for {url}">
     {#if children}
@@ -389,6 +400,20 @@
     backdrop-filter: blur(12px) saturate(1.2);
     -webkit-backdrop-filter: blur(12px) saturate(1.2);
     border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+    pointer-events: none;
+  }
+
+  /* Compact tier2 waterfall — thin overlay below compact-header. Renders only when tier2Averages has non-zero phases (TAO-anchor lanes). */
+  .lane-compact-waterfall {
+    position: absolute;
+    top: var(--compact-header-height);
+    left: 0; right: 0;
+    z-index: 3;
+    padding: 2px 10px;
+    background: rgba(12, 10, 20, 0.5);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.03);
     pointer-events: none;
   }
   .ch-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }

--- a/src/lib/components/LaneHeaderWaterfall.svelte
+++ b/src/lib/components/LaneHeaderWaterfall.svelte
@@ -1,11 +1,12 @@
 <!-- src/lib/components/LaneHeaderWaterfall.svelte -->
-<!-- 6px-tall horizontal stacked bar showing 5 timing phases as proportional flex segments. -->
+<!-- Stacked timing-phase bar. Full mode: 6px bar + labels. Compact mode: 4px bar only, zero-value segments omitted, renders nothing when all phases are zero. -->
 <script lang="ts">
   import { tokens } from '$lib/tokens';
 
   // ── Props ────────────────────────────────────────────────────────────────────
   let {
     tier2Averages,
+    compact = false,
   }: {
     tier2Averages: {
       dnsLookup: number;
@@ -14,6 +15,7 @@
       ttfb: number;
       contentTransfer: number;
     };
+    compact?: boolean;
   } = $props();
 
   // ── Phase definitions ────────────────────────────────────────────────────────
@@ -36,45 +38,61 @@
   );
 </script>
 
-<div
-  class="wf-root"
-  style:--wf-label-color={tokens.color.tier2.labelText}
->
-  {#if tier2Total === 0}
-    <div
-      class="wf-fallback"
-      role="status"
-      aria-label="Timing decomposition unavailable in this browser"
-    >
-      <span class="wf-fallback-text">Timing data limited</span>
-    </div>
-  {:else}
-    <!-- Stacked timing bar -->
-    <div
-      class="waterfall-bar"
-      role="img"
-      aria-label={ariaLabel}
-    >
-      {#each phases as phase (phase.key)}
-        <div
-          class="wf-segment"
-          style:flex-basis={flexBasis(phase.value)}
-          style:min-width="2px"
-          style:background={phase.color}
-        ></div>
-      {/each}
-    </div>
-
-    <!-- Phase labels — only show phases with value > 0 -->
-    <div class="wf-labels" aria-hidden="true">
+{#if compact}
+  {#if tier2Total > 0}
+    <div class="wf-compact" role="img" aria-label={ariaLabel}>
       {#each phases as phase (phase.key)}
         {#if phase.value > 0}
-          <span class="wf-label">{phase.label} {Math.round(phase.value)}ms</span>
+          <div
+            class="wf-segment wf-segment--compact"
+            style:flex-basis={flexBasis(phase.value)}
+            style:background={phase.color}
+          ></div>
         {/if}
       {/each}
     </div>
   {/if}
-</div>
+{:else}
+  <div
+    class="wf-root"
+    style:--wf-label-color={tokens.color.tier2.labelText}
+  >
+    {#if tier2Total === 0}
+      <div
+        class="wf-fallback"
+        role="status"
+        aria-label="Timing decomposition unavailable in this browser"
+      >
+        <span class="wf-fallback-text">Timing data limited</span>
+      </div>
+    {:else}
+      <!-- Stacked timing bar -->
+      <div
+        class="waterfall-bar"
+        role="img"
+        aria-label={ariaLabel}
+      >
+        {#each phases as phase (phase.key)}
+          <div
+            class="wf-segment"
+            style:flex-basis={flexBasis(phase.value)}
+            style:min-width="2px"
+            style:background={phase.color}
+          ></div>
+        {/each}
+      </div>
+
+      <!-- Phase labels — only show phases with value > 0 -->
+      <div class="wf-labels" aria-hidden="true">
+        {#each phases as phase (phase.key)}
+          {#if phase.value > 0}
+            <span class="wf-label">{phase.label} {Math.round(phase.value)}ms</span>
+          {/if}
+        {/each}
+      </div>
+    {/if}
+  </div>
+{/if}
 
 <style>
   .wf-root {
@@ -126,5 +144,23 @@
     font-family: var(--mono);
     color: var(--wf-label-color);
     opacity: 0.6;
+  }
+
+  .wf-compact {
+    display: flex;
+    height: 4px;
+    border-radius: 2px;
+    overflow: hidden;
+    gap: 0.5px;
+  }
+
+  .wf-segment--compact {
+    transition: flex-basis 400ms ease;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .wf-segment--compact {
+      transition: none;
+    }
   }
 </style>

--- a/tests/unit/components/lane-header-waterfall.test.ts
+++ b/tests/unit/components/lane-header-waterfall.test.ts
@@ -121,3 +121,41 @@ describe('LaneHeaderWaterfall — fallback warning badge', () => {
     expect(container.querySelector('.wf-fallback')).toBeNull();
   });
 });
+
+describe('LaneHeaderWaterfall — compact variant', () => {
+  it('renders .wf-compact instead of .wf-root when compact=true', () => {
+    const { container } = render(LaneHeaderWaterfall, { props: { tier2Averages, compact: true } });
+    expect(container.querySelector('.wf-compact')).not.toBeNull();
+    expect(container.querySelector('.wf-root')).toBeNull();
+  });
+
+  it('compact variant omits .wf-labels', () => {
+    const { container } = render(LaneHeaderWaterfall, { props: { tier2Averages, compact: true } });
+    expect(container.querySelector('.wf-labels')).toBeNull();
+  });
+
+  it('compact variant renders only non-zero segments', () => {
+    // Warm-connection shape: only ttfb and contentTransfer non-zero
+    const warmAverages = {
+      dnsLookup: 0, tcpConnect: 0, tlsHandshake: 0, ttfb: 30, contentTransfer: 0.5,
+    };
+    const { container } = render(LaneHeaderWaterfall, { props: { tier2Averages: warmAverages, compact: true } });
+    const segments = container.querySelectorAll('.wf-segment--compact');
+    expect(segments.length).toBe(2);
+  });
+
+  it('compact variant renders nothing when all phases are zero (no bar, no fallback text)', () => {
+    const { container } = render(LaneHeaderWaterfall, { props: { tier2Averages: allZero, compact: true } });
+    expect(container.querySelector('.wf-compact')).toBeNull();
+    expect(container.querySelector('.wf-fallback')).toBeNull();
+    expect(container.querySelector('.waterfall-bar')).toBeNull();
+  });
+
+  it('compact variant preserves aria-label with phase breakdown', () => {
+    const { container } = render(LaneHeaderWaterfall, { props: { tier2Averages, compact: true } });
+    const bar = container.querySelector('[role="img"]');
+    expect(bar).not.toBeNull();
+    const label = bar?.getAttribute('aria-label') ?? '';
+    expect(label).toContain('TTFB');
+  });
+});


### PR DESCRIPTION
## Summary

PR #21 shipped the tier2 timing-decomposition waterfall but gated it behind \`!compact\` in \`Lane.svelte\`. PR #37 then bumped the default endpoint count from 2 to 4 lanes, which pushes \`deriveLayoutMode()\` into \`'compact'\` for every user's default state. Net effect: **the waterfall has never rendered in the default UI since PR #37 shipped**. PR #39 added the self-probe that can actually populate phase data, exposing the gap.

This PR adds a compact variant of the waterfall that fits under the 28px compact-header as a thin 9px absolutely-positioned overlay, so the Self (TAO-anchor) lane shows its phase breakdown in the default 4-lane layout.

## Design choices

| Decision | Rationale |
|---|---|
| **4px bar (vs 6px in full mode)** | Fits the vertical budget of a compact lane without disturbing chart pixels. |
| **Labels omitted** | No room for "DNS 10ms TCP 20ms ..." text in compact layout. The \`aria-label\` on the bar still carries the full breakdown for screen readers. |
| **Only non-zero phase segments render** | A warm self-probe typically shows only TTFB + Transfer (connection is reused so DNS/TCP/TLS = 0). Rendering 5 segments where 3 are zero flex-basis looks broken; filtering produces a clean proportional bar. |
| **Outer overlay gated on \`hasMeaningfulTier2\`** | Non-TAO lanes (Google/AWS/Fastly/Wikipedia — cross-origin without TAO) have \`tier2Averages\` populated but all phases zero. Skipping the overlay \`<div>\` entirely for those lanes avoids wasted backdrop-filter compositing and keeps the non-TAO lanes visually unchanged. |
| **Absolutely-positioned overlay below \`.lane-compact-header\`** | Mirrors the existing compact-header pattern (\`top: 0; z-index: 3; backdrop-filter: blur\`). The waterfall overlay uses \`top: var(--compact-header-height)\` (28px) with a lighter blur, so it reads as a continuation of the header rather than a new layer. |

## What you'll see

- **Self lane**: a thin phase-breakdown strip directly below the compact header. On warm connections (most probes) this is dominated by TTFB — single light-blue segment with a tiny green transfer tail. On cold connections (first probe, post-idle) it shows DNS / TCP / TLS / TTFB / Transfer segments proportionally.
- **Google / AWS / Fastly / Wikipedia lanes**: visually identical to before — no overlay added. (These lanes are cross-origin without TAO, so tier2 phases are all zero; the \`hasMeaningfulTier2\` guard skips the overlay entirely.)

## Visual verification

On localhost with synthetic tier2 data injected, the compact waterfall renders as designed — a thin 4px stacked bar immediately below the Self lane's compact header, non-intrusive, clear signal. Full end-to-end verification requires deploy: Chrome suppresses Resource Timing phase data for cross-origin no-cors responses regardless of TAO headers, so \`localhost → chronoscope.dev/probe\` can't populate phases. Production same-origin fetches (\`chronoscope.dev → chronoscope.dev/probe\`) do populate phases — this was verified on the live site after PR #39 merged.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm test\` — **674/674 pass** (5 new compact-variant tests added)
- [x] \`npm run dev\` + inject test tier2 data → compact waterfall renders under Self lane's compact header with expected proportions and colors; non-TAO lanes unchanged
- [ ] Post-deploy verification on chronoscope.dev: waterfall renders automatically once data flows through the worker; visible on Self lane only

## Files changed

- \`src/lib/components/LaneHeaderWaterfall.svelte\` — new \`compact?: boolean\` prop; compact branch renders a 4px bar with non-zero segments only and no labels or fallback text
- \`src/lib/components/Lane.svelte\` — \`hasMeaningfulTier2\` derived guard; new \`.lane-compact-waterfall\` overlay below \`.lane-compact-header\`
- \`tests/unit/components/lane-header-waterfall.test.ts\` — 5 new tests covering the compact variant

## Follow-ups (not in scope)

- The compact waterfall is purely informational. Could add a hover tooltip showing phase labels + ms values as a power-user affordance.
- PR #21's original waterfall stayed in full-mode layout. With this PR, the only way to see full labels is to drop to 1-3 endpoints (which force \`'full'\` layout). That's fine for now; can revisit if users want labels in compact mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Performance metrics now display in a more compact waterfall visualization within compact mode, showing DNS lookup, TCP, TLS handshake, TTFB, and content transfer timings with improved space efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->