### PR TITLE
revert(lane): restore Cloudflare as default slot-2, make TAO-anchor opt-in

### DIFF
--- a/src/lib/regional-defaults.ts
+++ b/src/lib/regional-defaults.ts
@@ -55,43 +55,43 @@ export interface RegionalEndpointSpec {
 export const REGIONAL_DEFAULTS: Readonly<Record<Region, readonly RegionalEndpointSpec[]>> = {
   'north-america': [
     { url: 'https://www.google.com',              label: 'Google',     role: 'Baseline',        enabled: true },
-    { url: 'https://chronoscope.dev/probe',       label: 'Self',       role: 'TAO-anchor',      enabled: true },
+    { url: 'https://www.cloudflare.com',          label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
     { url: 'https://aws.amazon.com',              label: 'AWS',        role: 'Third-operator',  enabled: true },
     { url: 'https://www.fastly.com/robots.txt',   label: 'Fastly',     role: 'Fourth-operator', enabled: true },
   ],
   'europe': [
     { url: 'https://www.google.com',              label: 'Google',     role: 'Baseline',        enabled: true },
-    { url: 'https://chronoscope.dev/probe',       label: 'Self',       role: 'TAO-anchor',      enabled: true },
+    { url: 'https://www.cloudflare.com',          label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
     { url: 'https://aws.amazon.com',              label: 'AWS',        role: 'Third-operator',  enabled: true },
     { url: 'https://www.fastly.com/robots.txt',   label: 'Fastly',     role: 'Fourth-operator', enabled: true },
   ],
   'east-asia': [
     { url: 'https://www.google.com',              label: 'Google',     role: 'Baseline',        enabled: true },
-    { url: 'https://chronoscope.dev/probe',       label: 'Self',       role: 'TAO-anchor',      enabled: true },
+    { url: 'https://www.cloudflare.com',          label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
     { url: 'https://aws.amazon.com',              label: 'AWS',        role: 'Third-operator',  enabled: true },
     { url: 'https://en.wikipedia.org',            label: 'Wikipedia',  role: 'Long-haul',       enabled: true },
   ],
   'south-southeast-asia': [
     { url: 'https://www.google.com',              label: 'Google',     role: 'Baseline',        enabled: true },
-    { url: 'https://chronoscope.dev/probe',       label: 'Self',       role: 'TAO-anchor',      enabled: true },
+    { url: 'https://www.cloudflare.com',          label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
     { url: 'https://aws.amazon.com',              label: 'AWS',        role: 'Third-operator',  enabled: true },
     { url: 'https://en.wikipedia.org',            label: 'Wikipedia',  role: 'Long-haul',       enabled: true },
   ],
   'latam': [
     { url: 'https://www.google.com',              label: 'Google',     role: 'Baseline',        enabled: true },
-    { url: 'https://chronoscope.dev/probe',       label: 'Self',       role: 'TAO-anchor',      enabled: true },
+    { url: 'https://www.cloudflare.com',          label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
     { url: 'https://aws.amazon.com',              label: 'AWS',        role: 'Third-operator',  enabled: true },
     { url: 'https://www.fastly.com/robots.txt',   label: 'Fastly',     role: 'Fourth-operator', enabled: true },
   ],
   'mea': [
     { url: 'https://www.google.com',              label: 'Google',     role: 'Baseline',        enabled: true },
-    { url: 'https://chronoscope.dev/probe',       label: 'Self',       role: 'TAO-anchor',      enabled: true },
+    { url: 'https://www.cloudflare.com',          label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
     { url: 'https://aws.amazon.com',              label: 'AWS',        role: 'Third-operator',  enabled: true },
     { url: 'https://en.wikipedia.org',            label: 'Wikipedia',  role: 'Long-haul',       enabled: true },
   ],
   'oceania': [
     { url: 'https://www.google.com',              label: 'Google',     role: 'Baseline',        enabled: true },
-    { url: 'https://chronoscope.dev/probe',       label: 'Self',       role: 'TAO-anchor',      enabled: true },
+    { url: 'https://www.cloudflare.com',          label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
     { url: 'https://aws.amazon.com',              label: 'AWS',        role: 'Third-operator',  enabled: true },
     { url: 'https://en.wikipedia.org',            label: 'Wikipedia',  role: 'Long-haul',       enabled: true },
   ],
@@ -183,10 +183,12 @@ export function normalizeUrlForBrandLookup(url: string): string {
 const BRAND_LABELS: ReadonlyMap<string, { readonly label: string; readonly role: LaneRole }> =
   new Map([
     ['https://www.google.com',            { label: 'Google',     role: 'Baseline' }],
-    ['https://chronoscope.dev/probe',     { label: 'Self',       role: 'TAO-anchor' }],
+    ['https://www.cloudflare.com',        { label: 'Cloudflare', role: 'Alt-operator' }],
     ['https://aws.amazon.com',            { label: 'AWS',        role: 'Third-operator' }],
     ['https://www.fastly.com/robots.txt', { label: 'Fastly',     role: 'Fourth-operator' }],
     ['https://en.wikipedia.org',          { label: 'Wikipedia',  role: 'Long-haul' }],
+    // Power-user opt-in URL — not in REGIONAL_DEFAULTS; manual-add only.
+    ['https://chronoscope.dev/probe',     { label: 'Self',       role: 'TAO-anchor' }],
   ]);
 
 export function brandFor(url: string): { readonly label: string; readonly role: LaneRole } | null {

--- a/tests/unit/regional-defaults.test.ts
+++ b/tests/unit/regional-defaults.test.ts
@@ -25,10 +25,10 @@ describe('REGIONAL_DEFAULTS', () => {
     }
   });
 
-  it('lane 2 is the TAO-anchor self-probe for every region', () => {
+  it('lane 2 is Cloudflare URL for every region', () => {
     for (const region of REGIONS) {
-      expect(REGIONAL_DEFAULTS[region][1]?.url).toBe('https://chronoscope.dev/probe');
-      expect(REGIONAL_DEFAULTS[region][1]?.role).toBe('TAO-anchor');
+      expect(REGIONAL_DEFAULTS[region][1]?.url).toBe('https://www.cloudflare.com');
+      expect(REGIONAL_DEFAULTS[region][1]?.role).toBe('Alt-operator');
     }
   });
 
@@ -141,7 +141,11 @@ describe('brandFor', () => {
   it('returns Google/Baseline for canonical URL', () => {
     expect(brandFor('https://www.google.com')).toEqual({ label: 'Google', role: 'Baseline' });
   });
-  it('returns Self/TAO-anchor for the probe URL', () => {
+  it('returns Cloudflare/Alt-operator', () => {
+    expect(brandFor('https://www.cloudflare.com')).toEqual({ label: 'Cloudflare', role: 'Alt-operator' });
+  });
+
+  it('returns Self/TAO-anchor for the power-user probe URL', () => {
     expect(brandFor('https://chronoscope.dev/probe')).toEqual({ label: 'Self', role: 'TAO-anchor' });
   });
   it('returns AWS/Third-operator', () => {

--- a/tests/unit/stores/endpoints-regional.test.ts
+++ b/tests/unit/stores/endpoints-regional.test.ts
@@ -19,7 +19,7 @@ describe('buildDefaultEndpoints', () => {
     const endpoints = buildDefaultEndpoints(undefined);
     expect(endpoints).toHaveLength(4);
     expect(endpoints[0]?.url).toBe('https://www.google.com');
-    expect(endpoints[1]?.url).toBe('https://chronoscope.dev/probe');
+    expect(endpoints[1]?.url).toBe('https://www.cloudflare.com');
     expect(endpoints[2]?.url).toBe('https://aws.amazon.com');
     expect(endpoints[3]?.url).toBe('https://www.fastly.com/robots.txt');
   });

--- a/tests/visual/regional-defaults-e2e.spec.ts
+++ b/tests/visual/regional-defaults-e2e.spec.ts
@@ -77,7 +77,7 @@ test.describe('Regional Default Lanes — E2E', () => {
     const lanes = page.locator('article[data-endpoint-id]');
     await expect(lanes).toHaveCount(4, { timeout: 3000 });
 
-    // NA defaults: Google, Self (TAO-anchor), AWS, Fastly
+    // NA defaults: Google, Cloudflare, AWS, Fastly
     await expect(page.locator('[aria-label="Endpoint https://www.google.com"]')).toBeVisible({ timeout: 3000 });
     await expect(page.locator('[aria-label="Endpoint https://www.fastly.com/robots.txt"]')).toBeVisible({ timeout: 3000 });
   });


### PR DESCRIPTION
## Summary

PR #39 swapped default slot-2 from \`https://www.cloudflare.com\` to \`https://chronoscope.dev/probe\` to unlock phase decomposition. PR #40 surfaced that data via a compact waterfall bar under the lane header. After shipping, the assessment is that the waterfall is uninterpretable without context that default users don't have:

- "Self" as a label means nothing to a new user
- "TAO-ANCHOR" as a role badge is jargon
- The bar itself has no legend, tooltip, or visible explanation of what its colored segments represent
- On warm connections (~99% of samples) the bar degenerates to "TTFB dominates," which conveys nothing beyond the aggregate latency number already shown

This is UI noise for the default "is my internet OK" user. The phase-decomposition benefit is real but only legible to a user who already knows what DNS/TCP/TLS/TTFB are — i.e., the power user.

## What this PR does

Reverts the default slot-2 swap. All 7 regional tables restore \`https://www.cloudflare.com\` (Alt-operator) as slot 2. Users see four recognizable CDN lanes again: Google, Cloudflare, AWS, Fastly (or Wikipedia long-haul for APAC/MEA/Oceania).

## What this PR keeps

- **\`/probe\` endpoint stays hosted.** \`public/probe\` and the \`_headers\` rule with \`Timing-Allow-Origin: *\` remain — zero ongoing cost.
- **\`LaneHeaderWaterfall\` compact variant stays.** The component renders nothing when \`hasMeaningfulTier2\` is false, so default users see no change.
- **\`brandFor('https://chronoscope.dev/probe')\` still returns \`{label: 'Self', role: 'TAO-anchor'}\`.** Annotated as opt-in-only in \`BRAND_LABELS\`. A power user who manually adds the probe URL as a custom endpoint gets the full phase-decomposition waterfall and proper brand+role badges — no extra config needed from them.
- **\`'TAO-anchor'\` stays in the \`LaneRole\` union.** Future work can surface this as an opt-in setting without another type change.

## Future work (not in scope)

- Settings toggle: "Show phase decomposition lane" that injects the probe endpoint on opt-in. Shifts TAO-anchor from hidden-capability to discoverable-expert-view.
- Consider whether the compact waterfall needs a tooltip/help affordance if the toggle ships — users who opt in still need to read the bar correctly.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm test\` — **675/675 pass** (one new test covering the opt-in brandFor mapping)
- [ ] Post-deploy: confirm chronoscope.dev shows Cloudflare lane again on reset-to-defaults; confirm /probe endpoint still returns TAO header