### PR TITLE
feat(lane): re-introduce self-probe lane as Edge (Timing) with legible phase readout

### DIFF
--- a/src/lib/components/Lane.svelte
+++ b/src/lib/components/Lane.svelte
@@ -403,13 +403,13 @@
     pointer-events: none;
   }
 
-  /* Compact tier2 waterfall — thin overlay below compact-header. Renders only when tier2Averages has non-zero phases (TAO-anchor lanes). */
+  /* Compact tier2 waterfall overlay — rendered only on lanes with populated phase data. */
   .lane-compact-waterfall {
     position: absolute;
     top: var(--compact-header-height);
     left: 0; right: 0;
     z-index: 3;
-    padding: 2px 10px;
+    padding: 3px 10px 4px;
     background: rgba(12, 10, 20, 0.5);
     backdrop-filter: blur(8px);
     -webkit-backdrop-filter: blur(8px);

--- a/src/lib/components/Lane.svelte
+++ b/src/lib/components/Lane.svelte
@@ -475,6 +475,10 @@
 
   /* Shift now-label below compact header */
   .lane.compact .now-label { top: 34px; }
+  /* When the compact waterfall overlay is rendered, clear its ~22px block too */
+  .lane.compact .lane-compact-waterfall ~ .lane-chart .now-label {
+    top: calc(var(--compact-header-height) + 22px);
+  }
 
   @keyframes laneEntrance {
     from { opacity: 0; transform: translateY(8px); }

--- a/src/lib/components/LaneHeaderWaterfall.svelte
+++ b/src/lib/components/LaneHeaderWaterfall.svelte
@@ -40,16 +40,27 @@
 
 {#if compact}
   {#if tier2Total > 0}
-    <div class="wf-compact" role="img" aria-label={ariaLabel}>
-      {#each phases as phase (phase.key)}
-        {#if phase.value > 0}
-          <div
-            class="wf-segment wf-segment--compact"
-            style:flex-basis={flexBasis(phase.value)}
-            style:background={phase.color}
-          ></div>
-        {/if}
-      {/each}
+    <div class="wf-compact-wrap" role="img" aria-label={ariaLabel}>
+      <div class="wf-compact">
+        {#each phases as phase (phase.key)}
+          {#if phase.value > 0}
+            <div
+              class="wf-segment wf-segment--compact"
+              style:flex-basis={flexBasis(phase.value)}
+              style:background={phase.color}
+            ></div>
+          {/if}
+        {/each}
+      </div>
+      <div class="wf-compact-labels" aria-hidden="true">
+        {#each phases as phase (phase.key)}
+          {#if phase.value > 0}
+            <span class="wf-compact-label" style:color={phase.color}>
+              {phase.label} {Math.round(phase.value)}ms
+            </span>
+          {/if}
+        {/each}
+      </div>
     </div>
   {/if}
 {:else}
@@ -146,6 +157,12 @@
     opacity: 0.6;
   }
 
+  .wf-compact-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
   .wf-compact {
     display: flex;
     height: 4px;
@@ -162,5 +179,27 @@
     .wf-segment--compact {
       transition: none;
     }
+  }
+
+  .wf-compact-labels {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2px 8px;
+    font-family: var(--mono);
+    font-size: 9px;
+    font-weight: 400;
+    line-height: 1;
+    letter-spacing: 0.03em;
+  }
+
+  .wf-compact-label {
+    white-space: nowrap;
+  }
+
+  .wf-compact-label + .wf-compact-label::before {
+    content: '·';
+    color: var(--wf-label-color, rgba(255, 255, 255, 0.35));
+    margin-right: 8px;
+    margin-left: -6px;
   }
 </style>

--- a/src/lib/regional-defaults.ts
+++ b/src/lib/regional-defaults.ts
@@ -41,7 +41,7 @@ export type LaneRole =
   | 'Third-operator'
   | 'Fourth-operator'
   | 'Long-haul'
-  | 'TAO-anchor';
+  | 'Timing';
 
 export interface RegionalEndpointSpec {
   readonly url: string;
@@ -55,43 +55,43 @@ export interface RegionalEndpointSpec {
 export const REGIONAL_DEFAULTS: Readonly<Record<Region, readonly RegionalEndpointSpec[]>> = {
   'north-america': [
     { url: 'https://www.google.com',              label: 'Google',     role: 'Baseline',        enabled: true },
-    { url: 'https://www.cloudflare.com',          label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
+    { url: 'https://chronoscope.dev/probe',       label: 'Edge',       role: 'Timing',          enabled: true },
     { url: 'https://aws.amazon.com',              label: 'AWS',        role: 'Third-operator',  enabled: true },
     { url: 'https://www.fastly.com/robots.txt',   label: 'Fastly',     role: 'Fourth-operator', enabled: true },
   ],
   'europe': [
     { url: 'https://www.google.com',              label: 'Google',     role: 'Baseline',        enabled: true },
-    { url: 'https://www.cloudflare.com',          label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
+    { url: 'https://chronoscope.dev/probe',       label: 'Edge',       role: 'Timing',          enabled: true },
     { url: 'https://aws.amazon.com',              label: 'AWS',        role: 'Third-operator',  enabled: true },
     { url: 'https://www.fastly.com/robots.txt',   label: 'Fastly',     role: 'Fourth-operator', enabled: true },
   ],
   'east-asia': [
     { url: 'https://www.google.com',              label: 'Google',     role: 'Baseline',        enabled: true },
-    { url: 'https://www.cloudflare.com',          label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
+    { url: 'https://chronoscope.dev/probe',       label: 'Edge',       role: 'Timing',          enabled: true },
     { url: 'https://aws.amazon.com',              label: 'AWS',        role: 'Third-operator',  enabled: true },
     { url: 'https://en.wikipedia.org',            label: 'Wikipedia',  role: 'Long-haul',       enabled: true },
   ],
   'south-southeast-asia': [
     { url: 'https://www.google.com',              label: 'Google',     role: 'Baseline',        enabled: true },
-    { url: 'https://www.cloudflare.com',          label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
+    { url: 'https://chronoscope.dev/probe',       label: 'Edge',       role: 'Timing',          enabled: true },
     { url: 'https://aws.amazon.com',              label: 'AWS',        role: 'Third-operator',  enabled: true },
     { url: 'https://en.wikipedia.org',            label: 'Wikipedia',  role: 'Long-haul',       enabled: true },
   ],
   'latam': [
     { url: 'https://www.google.com',              label: 'Google',     role: 'Baseline',        enabled: true },
-    { url: 'https://www.cloudflare.com',          label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
+    { url: 'https://chronoscope.dev/probe',       label: 'Edge',       role: 'Timing',          enabled: true },
     { url: 'https://aws.amazon.com',              label: 'AWS',        role: 'Third-operator',  enabled: true },
     { url: 'https://www.fastly.com/robots.txt',   label: 'Fastly',     role: 'Fourth-operator', enabled: true },
   ],
   'mea': [
     { url: 'https://www.google.com',              label: 'Google',     role: 'Baseline',        enabled: true },
-    { url: 'https://www.cloudflare.com',          label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
+    { url: 'https://chronoscope.dev/probe',       label: 'Edge',       role: 'Timing',          enabled: true },
     { url: 'https://aws.amazon.com',              label: 'AWS',        role: 'Third-operator',  enabled: true },
     { url: 'https://en.wikipedia.org',            label: 'Wikipedia',  role: 'Long-haul',       enabled: true },
   ],
   'oceania': [
     { url: 'https://www.google.com',              label: 'Google',     role: 'Baseline',        enabled: true },
-    { url: 'https://www.cloudflare.com',          label: 'Cloudflare', role: 'Alt-operator',    enabled: true },
+    { url: 'https://chronoscope.dev/probe',       label: 'Edge',       role: 'Timing',          enabled: true },
     { url: 'https://aws.amazon.com',              label: 'AWS',        role: 'Third-operator',  enabled: true },
     { url: 'https://en.wikipedia.org',            label: 'Wikipedia',  role: 'Long-haul',       enabled: true },
   ],
@@ -183,12 +183,12 @@ export function normalizeUrlForBrandLookup(url: string): string {
 const BRAND_LABELS: ReadonlyMap<string, { readonly label: string; readonly role: LaneRole }> =
   new Map([
     ['https://www.google.com',            { label: 'Google',     role: 'Baseline' }],
-    ['https://www.cloudflare.com',        { label: 'Cloudflare', role: 'Alt-operator' }],
+    ['https://chronoscope.dev/probe',     { label: 'Edge',       role: 'Timing' }],
     ['https://aws.amazon.com',            { label: 'AWS',        role: 'Third-operator' }],
     ['https://www.fastly.com/robots.txt', { label: 'Fastly',     role: 'Fourth-operator' }],
     ['https://en.wikipedia.org',          { label: 'Wikipedia',  role: 'Long-haul' }],
-    // Power-user opt-in URL — not in REGIONAL_DEFAULTS; manual-add only.
-    ['https://chronoscope.dev/probe',     { label: 'Self',       role: 'TAO-anchor' }],
+    // Preserved for users who manually add Cloudflare's marketing origin as a custom lane.
+    ['https://www.cloudflare.com',        { label: 'Cloudflare', role: 'Alt-operator' }],
   ]);
 
 export function brandFor(url: string): { readonly label: string; readonly role: LaneRole } | null {

--- a/tests/unit/components/lane-header-waterfall.test.ts
+++ b/tests/unit/components/lane-header-waterfall.test.ts
@@ -158,4 +158,27 @@ describe('LaneHeaderWaterfall — compact variant', () => {
     const label = bar?.getAttribute('aria-label') ?? '';
     expect(label).toContain('TTFB');
   });
+
+  it('compact variant renders .wf-compact-labels with text for non-zero phases', () => {
+    const warmAverages = {
+      dnsLookup: 0, tcpConnect: 0, tlsHandshake: 0, ttfb: 30, contentTransfer: 1,
+    };
+    const { container } = render(LaneHeaderWaterfall, { props: { tier2Averages: warmAverages, compact: true } });
+    const labels = container.querySelectorAll('.wf-compact-label');
+    expect(labels.length).toBe(2);
+    const combined = Array.from(labels).map(l => l.textContent?.trim()).join(' ');
+    expect(combined).toContain('TTFB');
+    expect(combined).toContain('30ms');
+    expect(combined).toContain('Transfer');
+    expect(combined).toContain('1ms');
+  });
+
+  it('compact variant colors each phase label with its segment color', () => {
+    const { container } = render(LaneHeaderWaterfall, { props: { tier2Averages, compact: true } });
+    const labels = container.querySelectorAll('.wf-compact-label');
+    labels.forEach(l => {
+      const style = (l as HTMLElement).getAttribute('style') ?? '';
+      expect(style).toContain('color:');
+    });
+  });
 });

--- a/tests/unit/regional-defaults.test.ts
+++ b/tests/unit/regional-defaults.test.ts
@@ -25,10 +25,11 @@ describe('REGIONAL_DEFAULTS', () => {
     }
   });
 
-  it('lane 2 is Cloudflare URL for every region', () => {
+  it('lane 2 is the Edge (Timing) self-probe for every region', () => {
     for (const region of REGIONS) {
-      expect(REGIONAL_DEFAULTS[region][1]?.url).toBe('https://www.cloudflare.com');
-      expect(REGIONAL_DEFAULTS[region][1]?.role).toBe('Alt-operator');
+      expect(REGIONAL_DEFAULTS[region][1]?.url).toBe('https://chronoscope.dev/probe');
+      expect(REGIONAL_DEFAULTS[region][1]?.role).toBe('Timing');
+      expect(REGIONAL_DEFAULTS[region][1]?.label).toBe('Edge');
     }
   });
 
@@ -141,12 +142,12 @@ describe('brandFor', () => {
   it('returns Google/Baseline for canonical URL', () => {
     expect(brandFor('https://www.google.com')).toEqual({ label: 'Google', role: 'Baseline' });
   });
-  it('returns Cloudflare/Alt-operator', () => {
-    expect(brandFor('https://www.cloudflare.com')).toEqual({ label: 'Cloudflare', role: 'Alt-operator' });
+  it('returns Edge/Timing for the self-probe URL', () => {
+    expect(brandFor('https://chronoscope.dev/probe')).toEqual({ label: 'Edge', role: 'Timing' });
   });
 
-  it('returns Self/TAO-anchor for the power-user probe URL', () => {
-    expect(brandFor('https://chronoscope.dev/probe')).toEqual({ label: 'Self', role: 'TAO-anchor' });
+  it('returns Cloudflare/Alt-operator for the retained custom-add URL', () => {
+    expect(brandFor('https://www.cloudflare.com')).toEqual({ label: 'Cloudflare', role: 'Alt-operator' });
   });
   it('returns AWS/Third-operator', () => {
     expect(brandFor('https://aws.amazon.com')).toEqual({ label: 'AWS', role: 'Third-operator' });

--- a/tests/unit/stores/endpoints-regional.test.ts
+++ b/tests/unit/stores/endpoints-regional.test.ts
@@ -19,7 +19,7 @@ describe('buildDefaultEndpoints', () => {
     const endpoints = buildDefaultEndpoints(undefined);
     expect(endpoints).toHaveLength(4);
     expect(endpoints[0]?.url).toBe('https://www.google.com');
-    expect(endpoints[1]?.url).toBe('https://www.cloudflare.com');
+    expect(endpoints[1]?.url).toBe('https://chronoscope.dev/probe');
     expect(endpoints[2]?.url).toBe('https://aws.amazon.com');
     expect(endpoints[3]?.url).toBe('https://www.fastly.com/robots.txt');
   });

--- a/tests/visual/regional-defaults-e2e.spec.ts
+++ b/tests/visual/regional-defaults-e2e.spec.ts
@@ -77,7 +77,7 @@ test.describe('Regional Default Lanes — E2E', () => {
     const lanes = page.locator('article[data-endpoint-id]');
     await expect(lanes).toHaveCount(4, { timeout: 3000 });
 
-    // NA defaults: Google, Cloudflare, AWS, Fastly
+    // NA defaults: Google, Edge (Timing self-probe), AWS, Fastly
     await expect(page.locator('[aria-label="Endpoint https://www.google.com"]')).toBeVisible({ timeout: 3000 });
     await expect(page.locator('[aria-label="Endpoint https://www.fastly.com/robots.txt"]')).toBeVisible({ timeout: 3000 });
   });

--- a/tests/visual/regional-defaults-e2e.spec.ts
+++ b/tests/visual/regional-defaults-e2e.spec.ts
@@ -79,6 +79,8 @@ test.describe('Regional Default Lanes — E2E', () => {
 
     // NA defaults: Google, Edge (Timing self-probe), AWS, Fastly
     await expect(page.locator('[aria-label="Endpoint https://www.google.com"]')).toBeVisible({ timeout: 3000 });
+    await expect(page.locator('[aria-label="Endpoint https://chronoscope.dev/probe"]')).toBeVisible({ timeout: 3000 });
+    await expect(page.locator('[aria-label="Endpoint https://aws.amazon.com"]')).toBeVisible({ timeout: 3000 });
     await expect(page.locator('[aria-label="Endpoint https://www.fastly.com/robots.txt"]')).toBeVisible({ timeout: 3000 });
   });
 });


### PR DESCRIPTION
## Summary

Restores the same-origin self-probe as default slot-2 in all 7 regions (reverted in PR #41) but fixes the UX gaps that made the original version uninterpretable. The design changes target the three failure modes we identified:

| Failure | Fix |
|---|---|
| \`Self\` label required insider knowledge | Renamed to \`Edge\` — "the edge POP nearest you," clear to both audiences |
| \`TAO-ANCHOR\` role was jargon | Renamed to \`Timing\` — tells the user what the lane does, not what protocol trick enables it |
| Unlabeled 4px color bar required a color legend | Added a colored-text phase readout below the bar — numbers are self-explaining; phase color matches bar segment, making the legend implicit |

## What users see now

**Warm samples** (typical, probe reuses the page's connection):
\`\`\`
Edge  TIMING  34ms  P95 47ms  P99 61ms  J 9ms  L 0%
▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰
TTFB 34ms · Transfer 1ms
\`\`\`

**Cold samples** (first probe of a session, post-idle):
\`\`\`
Edge  TIMING  61ms  P95 68ms  P99 78ms  J 4ms  L 0%
▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▰▰▰▰
DNS 5ms · TCP 15ms · TLS 10ms · TTFB 30ms · Transfer 1ms
\`\`\`

Design principle: **values before names**. Numbers render at the same font size as their phase labels, so the reader's eye lands on "34ms" before parsing "TTFB." Even users who don't know what TTFB is get a useful signal.

## Design decisions documented

- **Only non-zero phases in text.** Warm samples don't waste horizontal space on `DNS 0ms · TCP 0ms · TLS 0ms`. The full 5-phase breakdown is preserved in the aria-label for screen readers.
- **Bar kept.** It shows proportion at a glance (the "which phase dominates" signal) and reinforces the color-to-phase mapping in the text below. Dropping it would lose the scanability advantage.
- **Implicit legend via color matching.** Each phase label renders in its bar segment's color. First exposure teaches the mapping; subsequent exposures read at a glance.
- **~22px total overlay** (up from 9px in the previous iteration). Trade-off: Phases lane is visibly taller than the others, which correctly signals "this lane carries more data."

## Files changed

- \`src/lib/regional-defaults.ts\` — \`LaneRole\` union gets \`'Timing'\`, drops \`'TAO-anchor'\`. \`REGIONAL_DEFAULTS\` slot 2 swap across all 7 regions (\`chronoscope.dev/probe\` / \`Edge\` / \`Timing\`). \`BRAND_LABELS\` updated, retains www.cloudflare.com for custom-add compatibility.
- \`src/lib/components/LaneHeaderWaterfall.svelte\` — compact variant restructured from single bar to wrapped \`.wf-compact-wrap\` containing the bar plus \`.wf-compact-labels\` text line. Non-zero phase filtering preserved; colors pulled from \`tokens.color.tier2.*\`.
- \`src/lib/components/Lane.svelte\` — \`.lane-compact-waterfall\` padding adjusted for the taller overlay.
- Tests: new assertions covering the text line's content, color styling, and non-zero filtering.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm test\` — **677/677 pass** (2 new compact-variant tests added)
- [x] Local visual verification with injected test data: \`Edge TIMING\` label renders correctly, phase text line shows \`TTFB 34ms · Transfer 1ms\` in amber + pink matching the bar segments
- [ ] Post-deploy verification on chronoscope.dev: same-origin fetches to /probe populate phases; text line reads legibly on real displays at 9px mono

## Rollback notes

If the new UX still doesn't land, the revert path is trivial (single slot-2 swap). Infrastructure (\`/probe\` endpoint, TAO header, full-mode waterfall component) is all pre-existing — this PR only touches the default table, the label/role strings, and the compact overlay rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compact waterfall now shows per-phase labels with formatted durations and color markers for non-zero phases.

* **Style**
  * Adjusted compact overlay padding and repositioned timeline "now" label for improved alignment.

* **Chores**
  * Default regional endpoint lineup updated to include an Edge self-probe entry and adjust associated role/labeling.

* **Tests**
  * Added/updated unit and visual tests covering compact labels and regional defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->