### PR TITLE
feat(foundations): v2 tokens, types, format/classify utils, persistence v4→v5

### DIFF
--- a/src/lib/components/App.svelte
+++ b/src/lib/components/App.svelte
@@ -39,10 +39,17 @@
     root.style.setProperty('--t5', tokens.color.text.t5);
 
     // Accent
-    root.style.setProperty('--accent-cyan',   tokens.color.accent.cyan);
-    root.style.setProperty('--accent-pink',   tokens.color.accent.pink);
-    root.style.setProperty('--accent-green',  tokens.color.accent.green);
-    root.style.setProperty('--green-glow',    tokens.color.accent.greenGlow);
+    root.style.setProperty('--accent-cyan',       tokens.color.accent.cyan);
+    root.style.setProperty('--accent-cyan-glow',  tokens.color.accent.cyanGlow);
+    root.style.setProperty('--accent-cyan-tone',  tokens.color.accent.cyanTone);
+    root.style.setProperty('--accent-pink',       tokens.color.accent.pink);
+    root.style.setProperty('--accent-pink-glow',  tokens.color.accent.pinkGlow);
+    root.style.setProperty('--accent-pink-tone',  tokens.color.accent.pinkTone);
+    root.style.setProperty('--accent-amber',      tokens.color.accent.amber);
+    root.style.setProperty('--accent-amber-glow', tokens.color.accent.amberGlow);
+    root.style.setProperty('--accent-amber-tone', tokens.color.accent.amberTone);
+    root.style.setProperty('--accent-green',      tokens.color.accent.green);
+    root.style.setProperty('--green-glow',        tokens.color.accent.greenGlow);
 
     // Glass
     root.style.setProperty('--glass-bg',        tokens.color.glass.bg);
@@ -52,6 +59,17 @@
     // Fonts
     root.style.setProperty('--sans', tokens.typography.sans.fontFamily);
     root.style.setProperty('--mono', tokens.typography.mono.fontFamily);
+
+    // Typography scale + tracking (v2 views)
+    root.style.setProperty('--ts-xs',     tokens.typography.scale.xs);
+    root.style.setProperty('--ts-sm',     tokens.typography.scale.sm);
+    root.style.setProperty('--ts-md',     tokens.typography.scale.md);
+    root.style.setProperty('--ts-lg',     tokens.typography.scale.lg);
+    root.style.setProperty('--ts-xl',     tokens.typography.scale.xl);
+    root.style.setProperty('--ts-xxl',    tokens.typography.scale.xxl);
+    root.style.setProperty('--tr-kicker', tokens.typography.tracking.kicker);
+    root.style.setProperty('--tr-label',  tokens.typography.tracking.label);
+    root.style.setProperty('--tr-body',   tokens.typography.tracking.body);
 
     // Spacing
     root.style.setProperty('--spacing-xxs', `${tokens.spacing.xxs}px`);
@@ -112,12 +130,15 @@
       const endpoints = get(endpointStore);
 
       const payload: PersistedSettings = {
-        version: 4,
+        version: 5,
         endpoints: endpoints.map(ep => ({ url: ep.url, enabled: ep.enabled })),
         settings,
         ui: {
           expandedCards: [...ui.expandedCards],
           activeView: ui.activeView,
+          focusedEndpointId: ui.focusedEndpointId,
+          liveOptions: { split: ui.liveOptions.split, timeRange: ui.liveOptions.timeRange },
+          terminalFilters: [...ui.terminalFilters],
         },
       };
       saveSettings(payload);

--- a/src/lib/stores/derived.ts
+++ b/src/lib/stores/derived.ts
@@ -1,0 +1,26 @@
+// src/lib/stores/derived.ts
+// Cross-store derived values. Kept out of individual store modules so each
+// store stays a simple `writable`; composite reads live here.
+
+import { derived } from 'svelte/store';
+import { endpointStore } from './endpoints';
+import { settingsStore } from './settings';
+import { statisticsStore } from './statistics';
+import { networkQuality } from '../utils/classify';
+
+/**
+ * Aggregate 0–100 network-health score, driven by every enabled endpoint's
+ * rolling stats. OverviewView's chronograph hand and the Topbar status chip
+ * MUST subscribe to this rather than recomputing `networkQuality()` inline —
+ * that is the alignment rule called out in `06-implementation-plan.md`.
+ *
+ * Returns `null` while no endpoint is ready yet (dial shows "No data").
+ */
+export const networkQualityStore = derived(
+  [endpointStore, statisticsStore, settingsStore],
+  ([$endpoints, $statistics, $settings]) => {
+    const enabled = $endpoints.filter((e) => e.enabled);
+    const statsList = enabled.map((e) => $statistics[e.id]);
+    return networkQuality(statsList, $settings.healthThreshold);
+  },
+);

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -6,3 +6,4 @@ export { endpointStore, validEndpoints } from './endpoints';
 export { measurementStore } from './measurements';
 export { statisticsStore } from './statistics';
 export { uiStore } from './ui';
+export { networkQualityStore } from './derived';

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -2,8 +2,19 @@
 // Writable store for measurement settings with reset capability.
 
 import { writable } from 'svelte/store';
-import { DEFAULT_SETTINGS } from '../types';
+import { DEFAULT_HEALTH_THRESHOLD, DEFAULT_SETTINGS } from '../types';
 import type { Settings } from '../types';
+
+/**
+ * Clamp the health-alarm threshold so it can never reach or exceed the hard
+ * abort `timeout`. The dial and classifier assume threshold < timeout; a caller
+ * that passes an invalid value gets silently clamped to `timeout - 1`.
+ */
+function clampHealthThreshold(threshold: number, timeout: number): number {
+  if (!Number.isFinite(threshold) || threshold <= 0) return DEFAULT_HEALTH_THRESHOLD;
+  if (threshold >= timeout) return Math.max(1, timeout - 1);
+  return threshold;
+}
 
 function createSettingsStore() {
   const { subscribe, set, update } = writable<Settings>({ ...DEFAULT_SETTINGS, region: undefined });
@@ -12,6 +23,9 @@ function createSettingsStore() {
     subscribe,
     update,
     set,
+    setHealthThreshold(ms: number): void {
+      update((s) => ({ ...s, healthThreshold: clampHealthThreshold(ms, s.timeout) }));
+    },
     reset() {
       set({ ...DEFAULT_SETTINGS, region: undefined });
     },

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -7,13 +7,21 @@ import type { Settings } from '../types';
 
 /**
  * Clamp the health-alarm threshold so it can never reach or exceed the hard
- * abort `timeout`. The dial and classifier assume threshold < timeout; a caller
- * that passes an invalid value gets silently clamped to `timeout - 1`.
+ * abort `timeout`. The dial and classifier assume threshold < timeout.
+ *
+ * Both inputs are defensively validated: an invalid caller-supplied threshold
+ * falls back to the project default, and the result is always re-clamped
+ * against timeout so the invariant holds even for tiny or non-finite timeouts.
  */
 function clampHealthThreshold(threshold: number, timeout: number): number {
-  if (!Number.isFinite(threshold) || threshold <= 0) return DEFAULT_HEALTH_THRESHOLD;
-  if (threshold >= timeout) return Math.max(1, timeout - 1);
-  return threshold;
+  const safeTimeout = Number.isFinite(timeout) && timeout > 1
+    ? timeout
+    : DEFAULT_SETTINGS.timeout;
+  const candidate = Number.isFinite(threshold) && threshold > 0
+    ? threshold
+    : DEFAULT_HEALTH_THRESHOLD;
+  if (candidate >= safeTimeout) return safeTimeout - 1;
+  return candidate;
 }
 
 function createSettingsStore() {

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -3,8 +3,11 @@
 // and panel visibility. No side effects; all state is local to this module.
 
 import { writable } from 'svelte/store';
-import type { UIState } from '../types';
+import type { LiveTimeRange, TerminalEventType, UIState } from '../types';
 
+// Phase 0 keeps `activeView: 'split'` as the default so no runtime behaviour
+// changes yet. Phase 1 flips the default to `'overview'` once the stub view is
+// mounted.
 const initialState = (): UIState => ({
   activeView: 'split',
   expandedCards: new Set<string>(),
@@ -20,6 +23,12 @@ const initialState = (): UIState => ({
   laneHoverY: null,
   heatmapTooltip: null,
   showEndpoints: false,
+  focusedEndpointId: null,
+  liveOptions: {
+    split: false,
+    timeRange: '5m',
+  },
+  terminalFilters: new Set<TerminalEventType>(),
 });
 
 function createUiStore() {
@@ -75,6 +84,32 @@ function createUiStore() {
     },
     toggleEndpoints(): void {
       update((s) => ({ ...s, showEndpoints: !s.showEndpoints }));
+    },
+    setFocusedEndpoint(id: string | null): void {
+      update((s) => ({ ...s, focusedEndpointId: id }));
+    },
+    toggleFocusedEndpoint(id: string): void {
+      update((s) => ({
+        ...s,
+        focusedEndpointId: s.focusedEndpointId === id ? null : id,
+      }));
+    },
+    setLiveSplit(split: boolean): void {
+      update((s) => ({ ...s, liveOptions: { ...s.liveOptions, split } }));
+    },
+    setLiveTimeRange(range: LiveTimeRange): void {
+      update((s) => ({ ...s, liveOptions: { ...s.liveOptions, timeRange: range } }));
+    },
+    toggleTerminalFilter(type: TerminalEventType): void {
+      update((s) => {
+        const next = new Set(s.terminalFilters);
+        if (next.has(type)) {
+          next.delete(type);
+        } else {
+          next.add(type);
+        }
+        return { ...s, terminalFilters: next };
+      });
     },
     reset(): void {
       set(initialState());

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -42,6 +42,28 @@ const primitive = {
   green:     '#86efac',
   greenGlow: 'rgba(134,239,172,.5)',
 
+  // Accent glows (33-alpha) and tones (darker variants) — health classifier styles
+  cyanGlow:  'rgba(103,232,249,.33)',
+  cyanTone:  '#3aa7b8',
+  pinkGlow:  'rgba(249,168,212,.33)',
+  pinkTone:  '#b0628a',
+  amberGlow: 'rgba(251,191,36,.33)',
+  amberTone: '#b38410',
+
+  // SVG primitives for chronograph dial + scope canvas (Phase 2+3)
+  svgGridLineMajor: 'rgba(255,255,255,.06)',
+  svgTickMinor:     'rgba(255,255,255,.18)',
+  svgTickMajor:     'rgba(255,255,255,.50)',
+  svgHandStroke:    '#ffffff',
+  svgDialRim:       'rgba(255,255,255,.14)',
+  svgOrbitTrack:    'rgba(255,255,255,.06)',
+  svgOrbitEdge:     'rgba(255,255,249,.10)',
+
+  // Tooltip surface extensions (existing bg stays)
+  tooltipBorder:  'rgba(255,255,255,.10)',
+  tooltipText:    'rgba(255,255,255,.95)',
+  tooltipTextDim: 'rgba(255,255,255,.55)',
+
   // Tier2 phase palette (opacity-attenuated primitives for waterfall segments)
   tier2Dns:      'rgba(134,239,172,.7)',   // green   — DNS resolution
   tier2Tcp:      'rgba(103,232,249,.7)',   // cyan    — TCP connect
@@ -140,12 +162,16 @@ export const tokens = {
       cyan20:     primitive.cyan20,
       cyan12:     primitive.cyan12,
       cyan06:     primitive.cyan06,
+      cyanGlow:   primitive.cyanGlow,
+      cyanTone:   primitive.cyanTone,
       pink:       primitive.pink,
       pinkBright: primitive.pinkBright,
       pink40:     primitive.pink40,
       pink20:     primitive.pink20,
       pink12:     primitive.pink12,
       pink06:     primitive.pink06,
+      pinkGlow:   primitive.pinkGlow,
+      pinkTone:   primitive.pinkTone,
       cyan25:           primitive.cyan25,
       cyanBgSubtle:     primitive.cyan15,
       cyanBorderSubtle: primitive.cyan25,
@@ -154,6 +180,9 @@ export const tokens = {
       pinkBorderSubtle: primitive.pink25,
       green:      primitive.green,
       greenGlow:  primitive.greenGlow,
+      amber:      primitive.amber,
+      amberGlow:  primitive.amberGlow,
+      amberTone:  primitive.amberTone,
     },
 
     glow: {
@@ -187,11 +216,21 @@ export const tokens = {
     },
 
     tooltip: {
-      bg: primitive.tooltipBg,
+      bg:      primitive.tooltipBg,
+      border:  primitive.tooltipBorder,
+      text:    primitive.tooltipText,
+      textDim: primitive.tooltipTextDim,
     },
 
     svg: {
       gridLine:        primitive.gridLine,
+      gridLineMajor:   primitive.svgGridLineMajor,
+      tickMinor:       primitive.svgTickMinor,
+      tickMajor:       primitive.svgTickMajor,
+      handStroke:      primitive.svgHandStroke,
+      dialRim:         primitive.svgDialRim,
+      orbitTrack:      primitive.svgOrbitTrack,
+      orbitEdge:       primitive.svgOrbitEdge,
       futureZone:      primitive.futureZone,
       nowDotCyan:      primitive.nowDotCyan,
       nowDotPink:      primitive.nowDotPink,
@@ -268,6 +307,20 @@ export const tokens = {
     caption: { size: 9,  weight: 400, opacity: 0.5,  letterSpacing: '0.04em' },
     label:   { size: 11, weight: 500, opacity: 0.58, letterSpacing: '0.06em' },
     body:    { size: 14, weight: 400, opacity: 0.94, letterSpacing: '0' },
+    // Named scale for v2 views — chip labels → overview triptych values
+    scale: {
+      xs:  '9px',    // chip labels, metadata kickers
+      sm:  '10px',   // rail url, axis labels, severity chips
+      md:  '11.5px', // rail label, segment labels
+      lg:  '14px',   // rail metric, sub-metric numbers
+      xl:  '18px',   // verdict title
+      xxl: '32px',   // overview triptych values
+    },
+    tracking: {
+      kicker: '0.18em',
+      label:  '0.08em',
+      body:   '0',
+    },
   },
 
   spacing: {
@@ -296,6 +349,12 @@ export const tokens = {
     btnHover:        200,
     domThrottle:     100,
     copiedFeedback: 2000,
+    // v2 motion primitives (dial + scope)
+    handLerp:          0.15,  // per-frame lerp factor for dial hand interpolation
+    pulseRim:           400,  // dial rim pulse on threshold cross
+    orbitPulse:        1400,  // orbit pip pulse when endpoint is over threshold
+    traceRepaint:        16,  // scope canvas repaint throttle (~60fps)
+    networkQualityThrottle: 250, // derived-store debounce for networkQualityStore
     // Legacy — timeline-data-pipeline.ts and statistics store still reference these
     progressiveDisclosure: 250,
     sonarPingFast: 300,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -160,6 +160,13 @@ export interface EndpointStatistics {
     ttfb: number;
     contentTransfer: number;
   };
+  readonly tier2P95?: {
+    dnsLookup: number;
+    tcpConnect: number;
+    tlsHandshake: number;
+    ttfb: number;
+    contentTransfer: number;
+  };
   readonly ready: boolean;
 }
 
@@ -174,7 +181,11 @@ export interface Settings {
   cap: number;
   corsMode: 'no-cors' | 'cors';
   region?: Region;
+  /** Health alarm threshold in ms (distinct from hard-abort `timeout`). Must be < timeout. */
+  healthThreshold: number;
 }
+
+export const DEFAULT_HEALTH_THRESHOLD = 120;
 
 export const DEFAULT_SETTINGS: Settings = {
   timeout: 5000,
@@ -183,10 +194,38 @@ export const DEFAULT_SETTINGS: Settings = {
   monitorDelay: 1000,
   cap: 0,
   corsMode: 'no-cors',
+  healthThreshold: DEFAULT_HEALTH_THRESHOLD,
 };
 
 // ── UI store ───────────────────────────────────────────────────────────────
-export type ActiveView = 'timeline' | 'heatmap' | 'split';
+/**
+ * UI view routing. `overview | live | atlas | strata | terminal | lanes` are
+ * the v2 surfaces. `timeline | heatmap | split` remain in the union for one
+ * release so persistence loaders can recognise legacy payloads; they are
+ * remapped to `lanes` on migration (see persistence.ts v4→v5).
+ */
+export type ActiveView =
+  | 'overview'
+  | 'live'
+  | 'atlas'
+  | 'strata'
+  | 'terminal'
+  | 'lanes'
+  | 'timeline'
+  | 'heatmap'
+  | 'split';
+
+export type LiveTimeRange = '1m' | '5m' | '15m' | '1h' | '24h';
+
+export type TerminalEventType =
+  | 'timeout'
+  | 'error'
+  | 'threshold_up'
+  | 'threshold_down'
+  | 'freeze'
+  | 'endpoint_added'
+  | 'endpoint_removed'
+  | 'reuse_change';
 
 export interface HoverTarget {
   readonly endpointId: string;
@@ -213,6 +252,16 @@ export interface UIState {
   laneHoverY: number | null;
   heatmapTooltip: { text: string; x: number; y: number } | null;
   showEndpoints: boolean;
+  /** Globally focused endpoint — drives EndpointRail selection and per-view focus. null = unfocused. */
+  focusedEndpointId: string | null;
+  /** Live view layout options. */
+  liveOptions: {
+    /** If true, each endpoint gets its own scope row; false = overlaid unified view. */
+    split: boolean;
+    timeRange: LiveTimeRange;
+  };
+  /** Terminal view event-type filter. Empty set = show all. */
+  terminalFilters: Set<TerminalEventType>;
 }
 
 // ── Lane hover ─────────────────────────────────────────────────────────────
@@ -257,12 +306,20 @@ export interface SharePayload {
 
 // ── Persistence schema ─────────────────────────────────────────────────────
 export interface PersistedSettings {
-  version: 2 | 3 | 4;
+  version: 2 | 3 | 4 | 5;
   endpoints: { url: string; enabled: boolean }[];
   settings: Settings;
   ui: {
     expandedCards: string[];
     activeView: ActiveView;
+    // v5+ fields — optional so v2-v4 normalisers can omit them.
+    focusedEndpointId?: string | null;
+    liveOptions?: {
+      split: boolean;
+      timeRange: LiveTimeRange;
+    };
+    /** Persisted as an array (Set does not JSON-serialise). Rehydrated into a Set at apply time. */
+    terminalFilters?: TerminalEventType[];
   };
 }
 

--- a/src/lib/utils/apply-persisted-settings.ts
+++ b/src/lib/utils/apply-persisted-settings.ts
@@ -33,4 +33,19 @@ export function applyPersistedSettings(persisted: PersistedSettings): void {
       uiStore.toggleCard(cardId);
     }
   }
+
+  // v5 UI additions — guarded so v2–v4 payloads that were up-migrated without
+  // these fields still apply cleanly.
+  if (persisted.ui.focusedEndpointId !== undefined) {
+    uiStore.setFocusedEndpoint(persisted.ui.focusedEndpointId);
+  }
+  if (persisted.ui.liveOptions) {
+    uiStore.setLiveSplit(persisted.ui.liveOptions.split);
+    uiStore.setLiveTimeRange(persisted.ui.liveOptions.timeRange);
+  }
+  if (persisted.ui.terminalFilters && persisted.ui.terminalFilters.length > 0) {
+    for (const type of persisted.ui.terminalFilters) {
+      uiStore.toggleTerminalFilter(type);
+    }
+  }
 }

--- a/src/lib/utils/classify.ts
+++ b/src/lib/utils/classify.ts
@@ -77,7 +77,7 @@ export function networkQuality(
   stats: readonly (EndpointStatistics | null | undefined)[],
   threshold: number,
 ): number | null {
-  const ready = stats.filter((s): s is EndpointStatistics => !!s && s.ready);
+  const ready = stats.filter((s): s is EndpointStatistics => s != null && s.ready);
   if (ready.length === 0) return null;
 
   let total = 0;

--- a/src/lib/utils/classify.ts
+++ b/src/lib/utils/classify.ts
@@ -1,0 +1,90 @@
+// src/lib/utils/classify.ts
+// Centralised health classifier — the single alignment point for dial colour,
+// rail pip colour, verdict text, and the aggregate network quality score.
+// Components MUST NOT recompute these inline; always read through the derived
+// store (`networkQualityStore`) or call these helpers directly.
+
+import type { EndpointStatistics } from '../types';
+
+export type HealthBucket = 'healthy' | 'degraded' | 'unhealthy' | 'unknown';
+
+export interface HealthStyle {
+  /** CSS colour token reference — resolves to the accent for this bucket. */
+  readonly color: string;
+  /** Softer glow variant — typically a .33-alpha of `color`. */
+  readonly glow: string;
+  /** Human-readable label for chips and verdicts. */
+  readonly label: string;
+  /** Darker tone variant for arcs, borders, and text-on-accent surfaces. */
+  readonly tone: string;
+}
+
+/**
+ * Style map keyed by bucket. Values reference CSS vars emitted by
+ * App.svelte's bridgeTokensToCss so components can use them directly in style
+ * attributes without importing the tokens object.
+ */
+export const HEALTH_STYLES: Record<HealthBucket, HealthStyle> = {
+  healthy:   { color: 'var(--accent-cyan)',  glow: 'var(--accent-cyan-glow)',  label: 'Healthy',   tone: 'var(--accent-cyan-tone)' },
+  degraded:  { color: 'var(--accent-amber)', glow: 'var(--accent-amber-glow)', label: 'Degraded',  tone: 'var(--accent-amber-tone)' },
+  unhealthy: { color: 'var(--accent-pink)',  glow: 'var(--accent-pink-glow)',  label: 'Unhealthy', tone: 'var(--accent-pink-tone)' },
+  unknown:   { color: 'var(--t4)',           glow: 'transparent',              label: 'No data',   tone: 'var(--t4)' },
+};
+
+/**
+ * Classify an endpoint's current health from its rolling stats and the
+ * configured health threshold.
+ *
+ * - healthy:   p95 <= threshold AND p50 <= threshold * 0.5
+ * - degraded:  p95 <= threshold * 2 OR  p50 <= threshold
+ * - unhealthy: otherwise
+ * - unknown:   stats is null / not ready
+ *
+ * Missing `p50`/`p95` (pathological but possible during init) are treated as
+ * Infinity so the result is conservatively "unhealthy" rather than throwing.
+ */
+export function classify(
+  stats: EndpointStatistics | null | undefined,
+  threshold: number,
+): HealthBucket {
+  if (!stats || !stats.ready) return 'unknown';
+
+  const p50 = stats.p50 ?? Number.POSITIVE_INFINITY;
+  const p95 = stats.p95 ?? Number.POSITIVE_INFINITY;
+
+  if (p95 <= threshold && p50 <= threshold * 0.5) return 'healthy';
+  if (p95 <= threshold * 2 || p50 <= threshold)   return 'degraded';
+  return 'unhealthy';
+}
+
+const SCORE_BY_BUCKET: Record<Exclude<HealthBucket, 'unknown'>, number> = {
+  healthy:   100,
+  degraded:   60,
+  unhealthy:  20,
+};
+
+/**
+ * Aggregate 0–100 network-health score from every ready endpoint's stats.
+ *
+ * - 100 = every ready endpoint classifies as healthy
+ * -  20 = every ready endpoint classifies as unhealthy
+ * - null = no endpoint is ready yet (dial shows "No data")
+ *
+ * Not-ready endpoints are excluded from the denominator so ramp-up doesn't
+ * depress the aggregate.
+ */
+export function networkQuality(
+  stats: readonly (EndpointStatistics | null | undefined)[],
+  threshold: number,
+): number | null {
+  const ready = stats.filter((s): s is EndpointStatistics => !!s && s.ready);
+  if (ready.length === 0) return null;
+
+  let total = 0;
+  for (const s of ready) {
+    const bucket = classify(s, threshold);
+    if (bucket === 'unknown') continue; // defensive — filter() above excludes, but keep exhaustive
+    total += SCORE_BY_BUCKET[bucket];
+  }
+  return Math.round(total / ready.length);
+}

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -1,0 +1,46 @@
+// src/lib/utils/format.ts
+// Single source of truth for rendering ms/percent/count values in the v2 views.
+// Every latency readout in chrono/live/atlas/strata/terminal goes through fmt().
+// Ad-hoc `toFixed` calls in component templates are forbidden (see 03-components/shared.md).
+
+/**
+ * Format a millisecond value for display.
+ *
+ *   fmt(0.43)      → "0.43"
+ *   fmt(1)         → "1.0"
+ *   fmt(127.4)     → "127"
+ *   fmt(1234)      → "1,234"
+ *   fmt(12345)     → "12.3s"
+ *   fmt(null)      → "—"
+ *   fmt(NaN)       → "—"
+ *   fmt(Infinity)  → "—"
+ *   fmt(-1)        → "—"  (negative latency is invalid)
+ */
+export function fmt(ms: number | null | undefined): string {
+  if (ms == null || !Number.isFinite(ms) || ms < 0) return '—';
+  if (ms < 1)     return ms.toFixed(2);
+  if (ms < 10)    return ms.toFixed(1);
+  if (ms < 10_000) return Math.round(ms).toLocaleString('en-US');
+  return (ms / 1000).toFixed(1) + 's';
+}
+
+/**
+ * Split into independently-styleable number and unit parts.
+ * Used by the rail metric + overview triptych where the unit is typographically
+ * smaller than the numeric value.
+ */
+export function fmtParts(ms: number | null | undefined): { num: string; unit: string } {
+  if (ms == null || !Number.isFinite(ms) || ms < 0) return { num: '—', unit: '' };
+  if (ms < 10_000) return { num: fmt(ms), unit: 'ms' };
+  return { num: (ms / 1000).toFixed(1), unit: 's' };
+}
+
+/** Ratio in 0..1 → rounded integer percent with `%` suffix. */
+export function fmtPct(ratio: number): string {
+  return Math.round(ratio * 100) + '%';
+}
+
+/** Integer with locale thousands separator. */
+export function fmtCount(n: number): string {
+  return n.toLocaleString('en-US');
+}

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -21,7 +21,7 @@ export function fmt(ms: number | null | undefined): string {
   if (ms < 1)     return ms.toFixed(2);
   if (ms < 10)    return ms.toFixed(1);
   if (ms < 10_000) return Math.round(ms).toLocaleString('en-US');
-  return (ms / 1000).toFixed(1) + 's';
+  return `${(ms / 1000).toFixed(1)}s`;
 }
 
 /**
@@ -37,7 +37,7 @@ export function fmtParts(ms: number | null | undefined): { num: string; unit: st
 
 /** Ratio in 0..1 → rounded integer percent with `%` suffix. */
 export function fmtPct(ratio: number): string {
-  return Math.round(ratio * 100) + '%';
+  return `${Math.round(ratio * 100)}%`;
 }
 
 /** Integer with locale thousands separator. */

--- a/src/lib/utils/persistence.ts
+++ b/src/lib/utils/persistence.ts
@@ -1,14 +1,41 @@
 // src/lib/utils/persistence.ts
 // Versioned localStorage persistence with forward-only migration support.
 
-import { DEFAULT_SETTINGS } from '../types';
+import { DEFAULT_HEALTH_THRESHOLD, DEFAULT_SETTINGS } from '../types';
 import { detectRegion, isValidRegion } from '../regional-defaults';
-import type { PersistedSettings, ActiveView } from '../types';
+import type { ActiveView, LiveTimeRange, PersistedSettings, TerminalEventType } from '../types';
 import type { Region } from '../regional-defaults';
 
 const STORAGE_KEY = 'chronoscope_settings'; // skipcq: JS-0860 — localStorage key, not a credential
 const LEGACY_STORAGE_KEY = 'chronoscope_v2_settings'; // skipcq: JS-0860 — localStorage key, not a credential
-const CURRENT_VERSION = 4;
+const CURRENT_VERSION = 5;
+
+// ── v5 constants ─────────────────────────────────────────────────────────
+const V2_ACTIVE_VIEWS = new Set<string>(['timeline', 'heatmap', 'split']);
+const V5_ACTIVE_VIEWS = new Set<ActiveView>([
+  'overview', 'live', 'atlas', 'strata', 'terminal', 'lanes',
+  'timeline', 'heatmap', 'split',
+]);
+const VALID_TIME_RANGES = new Set<LiveTimeRange>(['1m', '5m', '15m', '1h', '24h']);
+const VALID_TERMINAL_EVENTS = new Set<TerminalEventType>([
+  'timeout', 'error', 'threshold_up', 'threshold_down',
+  'freeze', 'endpoint_added', 'endpoint_removed', 'reuse_change',
+]);
+
+function clampHealthThreshold(value: unknown, timeout: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return DEFAULT_HEALTH_THRESHOLD;
+  }
+  if (value >= timeout) return Math.max(1, timeout - 1);
+  return value;
+}
+
+function sanitizeActiveView(raw: unknown): ActiveView {
+  if (typeof raw !== 'string') return 'lanes';
+  if (V2_ACTIVE_VIEWS.has(raw)) return 'lanes';
+  if (V5_ACTIVE_VIEWS.has(raw as ActiveView)) return raw as ActiveView;
+  return 'lanes';
+}
 
 export function loadPersistedSettings(): PersistedSettings | null {
   try {
@@ -49,20 +76,24 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
   const version = typeof record['version'] === 'number' ? record['version'] : 0;
 
   if (version === CURRENT_VERSION) {
-    return normalizeV4(record);
+    return normalizeV5(record);
+  }
+
+  if (version === 4) {
+    const v4 = normalizeV4(record);
+    if (!v4) return null;
+    return upgradeToV5(v4, record);
   }
 
   if (version === 3) {
     const v3 = normalizeV3(record);
     if (!v3) return null;
-    return {
+    const v4: PersistedSettings = {
       ...v3,
       version: 4,
-      settings: {
-        ...v3.settings,
-        region: detectRegion(),
-      },
+      settings: { ...v3.settings, region: detectRegion() },
     };
+    return upgradeToV5(v4, record);
   }
 
   if (version === 2) {
@@ -79,14 +110,12 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
         monitorDelay: oldDelay >= 0 ? oldDelay : DEFAULT_SETTINGS.monitorDelay,
       },
     };
-    return {
+    const v4: PersistedSettings = {
       ...v3,
       version: 4,
-      settings: {
-        ...v3.settings,
-        region: detectRegion(),
-      },
+      settings: { ...v3.settings, region: detectRegion() },
     };
+    return upgradeToV5(v4, record);
   }
 
   if (version === 1) {
@@ -98,7 +127,7 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
         enabled: typeof e['enabled'] === 'boolean' ? e['enabled'] : true,
       }));
 
-    return {
+    const v4: PersistedSettings = {
       version: 4,
       endpoints,
       settings: { ...DEFAULT_SETTINGS, region: detectRegion() },
@@ -107,12 +136,67 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
         activeView: 'split' as ActiveView,
       },
     };
+    return upgradeToV5(v4, record);
   }
 
   // Unknown version — return null (triggers first-install path).
-  // Spec §5: we deliberately do NOT coerce unknown versions through normalizeV4,
+  // Spec §5: we deliberately do NOT coerce unknown versions through normalizeV5,
   // because that silently drops shape changes to existing fields.
   return null;
+}
+
+/**
+ * Shared v4 → v5 upgrade. Pulls optional v5-only fields off the raw record (so a
+ * user who opened a future build and was downgraded doesn't lose their data),
+ * but relies on defaults otherwise.
+ */
+function upgradeToV5(v4: PersistedSettings, raw: Record<string, unknown>): PersistedSettings {
+  const rawSettings =
+    raw['settings'] !== null && typeof raw['settings'] === 'object'
+      ? (raw['settings'] as Record<string, unknown>)
+      : {};
+  const rawUi =
+    raw['ui'] !== null && typeof raw['ui'] === 'object'
+      ? (raw['ui'] as Record<string, unknown>)
+      : {};
+
+  const healthThreshold = clampHealthThreshold(rawSettings['healthThreshold'], v4.settings.timeout);
+
+  return {
+    ...v4,
+    version: 5,
+    settings: { ...v4.settings, healthThreshold },
+    ui: {
+      expandedCards: v4.ui.expandedCards,
+      activeView: sanitizeActiveView(v4.ui.activeView),
+      focusedEndpointId: parseFocusedEndpointId(rawUi['focusedEndpointId']),
+      liveOptions: parseLiveOptions(rawUi['liveOptions']),
+      terminalFilters: parseTerminalFilters(rawUi['terminalFilters']),
+    },
+  };
+}
+
+function parseFocusedEndpointId(raw: unknown): string | null {
+  if (typeof raw === 'string' && raw.length > 0) return raw;
+  return null;
+}
+
+function parseLiveOptions(raw: unknown): { split: boolean; timeRange: LiveTimeRange } {
+  const defaults = { split: false, timeRange: '5m' as LiveTimeRange };
+  if (raw === null || typeof raw !== 'object') return defaults;
+  const r = raw as Record<string, unknown>;
+  const timeRange = VALID_TIME_RANGES.has(r['timeRange'] as LiveTimeRange)
+    ? (r['timeRange'] as LiveTimeRange)
+    : defaults.timeRange;
+  return {
+    split: typeof r['split'] === 'boolean' ? r['split'] : defaults.split,
+    timeRange,
+  };
+}
+
+function parseTerminalFilters(raw: unknown): TerminalEventType[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((x): x is TerminalEventType => VALID_TERMINAL_EVENTS.has(x as TerminalEventType));
 }
 
 function normalizeV2(record: Record<string, unknown>): PersistedSettings | null {
@@ -140,6 +224,7 @@ function normalizeV2(record: Record<string, unknown>): PersistedSettings | null 
         rawSettings['corsMode'] === 'cors' || rawSettings['corsMode'] === 'no-cors'
           ? rawSettings['corsMode']
           : DEFAULT_SETTINGS.corsMode,
+      healthThreshold: DEFAULT_HEALTH_THRESHOLD,
     };
 
     const rawUi =
@@ -187,6 +272,7 @@ function normalizeV3(record: Record<string, unknown>): PersistedSettings | null 
         rawSettings['corsMode'] === 'cors' || rawSettings['corsMode'] === 'no-cors'
           ? rawSettings['corsMode']
           : DEFAULT_SETTINGS.corsMode,
+      healthThreshold: DEFAULT_HEALTH_THRESHOLD,
     };
 
     const rawUi =
@@ -237,6 +323,7 @@ function normalizeV4(record: Record<string, unknown>): PersistedSettings | null 
         rawSettings['corsMode'] === 'cors' || rawSettings['corsMode'] === 'no-cors'
           ? rawSettings['corsMode']
           : DEFAULT_SETTINGS.corsMode,
+      healthThreshold: DEFAULT_HEALTH_THRESHOLD,
       ...(region !== undefined ? { region } : {}),
     };
 
@@ -255,6 +342,66 @@ function normalizeV4(record: Record<string, unknown>): PersistedSettings | null 
         : 'split';
 
     return { version: 4, endpoints, settings, ui: { expandedCards, activeView } };
+  } catch {
+    return null;
+  }
+}
+
+function normalizeV5(record: Record<string, unknown>): PersistedSettings | null {
+  try {
+    const rawEndpoints = Array.isArray(record['endpoints']) ? record['endpoints'] : [];
+    const endpoints = rawEndpoints
+      .filter((e): e is Record<string, unknown> => e !== null && typeof e === 'object')
+      .map((e) => ({
+        url: typeof e['url'] === 'string' ? e['url'] : '',
+        enabled: typeof e['enabled'] === 'boolean' ? e['enabled'] : true,
+      }));
+
+    const rawSettings =
+      record['settings'] !== null && typeof record['settings'] === 'object'
+        ? (record['settings'] as Record<string, unknown>)
+        : {};
+
+    const rawRegion: unknown = rawSettings['region'];
+    const region: Region | undefined = isValidRegion(rawRegion) ? rawRegion : undefined;
+
+    const timeout = typeof rawSettings['timeout'] === 'number' ? rawSettings['timeout'] : DEFAULT_SETTINGS.timeout;
+
+    const settings = {
+      timeout,
+      delay: typeof rawSettings['delay'] === 'number' ? rawSettings['delay'] : DEFAULT_SETTINGS.delay,
+      burstRounds: typeof rawSettings['burstRounds'] === 'number' ? rawSettings['burstRounds'] : DEFAULT_SETTINGS.burstRounds,
+      monitorDelay: typeof rawSettings['monitorDelay'] === 'number' ? rawSettings['monitorDelay'] : DEFAULT_SETTINGS.monitorDelay,
+      cap: typeof rawSettings['cap'] === 'number' ? rawSettings['cap'] : DEFAULT_SETTINGS.cap,
+      corsMode:
+        rawSettings['corsMode'] === 'cors' || rawSettings['corsMode'] === 'no-cors'
+          ? rawSettings['corsMode']
+          : DEFAULT_SETTINGS.corsMode,
+      healthThreshold: clampHealthThreshold(rawSettings['healthThreshold'], timeout),
+      ...(region !== undefined ? { region } : {}),
+    };
+
+    const rawUi =
+      record['ui'] !== null && typeof record['ui'] === 'object'
+        ? (record['ui'] as Record<string, unknown>)
+        : {};
+
+    const expandedCards = Array.isArray(rawUi['expandedCards'])
+      ? (rawUi['expandedCards'] as unknown[]).filter((x): x is string => typeof x === 'string')
+      : [];
+
+    return {
+      version: 5,
+      endpoints,
+      settings,
+      ui: {
+        expandedCards,
+        activeView: sanitizeActiveView(rawUi['activeView']),
+        focusedEndpointId: parseFocusedEndpointId(rawUi['focusedEndpointId']),
+        liveOptions: parseLiveOptions(rawUi['liveOptions']),
+        terminalFilters: parseTerminalFilters(rawUi['terminalFilters']),
+      },
+    };
   } catch {
     return null;
   }

--- a/src/lib/utils/persistence.ts
+++ b/src/lib/utils/persistence.ts
@@ -23,11 +23,15 @@ const VALID_TERMINAL_EVENTS = new Set<TerminalEventType>([
 ]);
 
 function clampHealthThreshold(value: unknown, timeout: number): number {
-  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
-    return DEFAULT_HEALTH_THRESHOLD;
-  }
-  if (value >= timeout) return Math.max(1, timeout - 1);
-  return value;
+  const safeTimeout = Number.isFinite(timeout) && timeout > 1
+    ? timeout
+    : DEFAULT_SETTINGS.timeout;
+  const candidate =
+    typeof value === 'number' && Number.isFinite(value) && value > 0
+      ? value
+      : DEFAULT_HEALTH_THRESHOLD;
+  if (candidate >= safeTimeout) return safeTimeout - 1;
+  return candidate;
 }
 
 function sanitizeActiveView(raw: unknown): ActiveView {
@@ -184,12 +188,12 @@ function parseFocusedEndpointId(raw: unknown): string | null {
 function parseLiveOptions(raw: unknown): { split: boolean; timeRange: LiveTimeRange } {
   const defaults = { split: false, timeRange: '5m' as LiveTimeRange };
   if (raw === null || typeof raw !== 'object') return defaults;
-  const r = raw as Record<string, unknown>;
-  const timeRange = VALID_TIME_RANGES.has(r['timeRange'] as LiveTimeRange)
-    ? (r['timeRange'] as LiveTimeRange)
+  const rawOpts = raw as Record<string, unknown>;
+  const timeRange = VALID_TIME_RANGES.has(rawOpts['timeRange'] as LiveTimeRange)
+    ? (rawOpts['timeRange'] as LiveTimeRange)
     : defaults.timeRange;
   return {
-    split: typeof r['split'] === 'boolean' ? r['split'] : defaults.split,
+    split: typeof rawOpts['split'] === 'boolean' ? rawOpts['split'] : defaults.split,
     timeRange,
   };
 }
@@ -347,60 +351,69 @@ function normalizeV4(record: Record<string, unknown>): PersistedSettings | null 
   }
 }
 
+/** Parse an array of persisted endpoint entries, dropping malformed rows. */
+function parseEndpoints(raw: unknown): { url: string; enabled: boolean }[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((e): e is Record<string, unknown> => e !== null && typeof e === 'object')
+    .map((e) => ({
+      url: typeof e['url'] === 'string' ? e['url'] : '',
+      enabled: typeof e['enabled'] === 'boolean' ? e['enabled'] : true,
+    }));
+}
+
+/** Read the persisted settings object, defaulting unknown fields to DEFAULT_SETTINGS. */
+function parseV5Settings(rawSettings: Record<string, unknown>) {
+  const rawTimeout = rawSettings['timeout'];
+  const timeout =
+    typeof rawTimeout === 'number' && Number.isFinite(rawTimeout) && rawTimeout > 1
+      ? rawTimeout
+      : DEFAULT_SETTINGS.timeout;
+  const rawRegion: unknown = rawSettings['region'];
+  const region: Region | undefined = isValidRegion(rawRegion) ? rawRegion : undefined;
+
+  return {
+    timeout,
+    delay: typeof rawSettings['delay'] === 'number' ? rawSettings['delay'] : DEFAULT_SETTINGS.delay,
+    burstRounds: typeof rawSettings['burstRounds'] === 'number' ? rawSettings['burstRounds'] : DEFAULT_SETTINGS.burstRounds,
+    monitorDelay: typeof rawSettings['monitorDelay'] === 'number' ? rawSettings['monitorDelay'] : DEFAULT_SETTINGS.monitorDelay,
+    cap: typeof rawSettings['cap'] === 'number' ? rawSettings['cap'] : DEFAULT_SETTINGS.cap,
+    corsMode:
+      rawSettings['corsMode'] === 'cors' || rawSettings['corsMode'] === 'no-cors'
+        ? rawSettings['corsMode']
+        : DEFAULT_SETTINGS.corsMode,
+    healthThreshold: clampHealthThreshold(rawSettings['healthThreshold'], timeout),
+    ...(region !== undefined ? { region } : {}),
+  };
+}
+
+/** Parse the persisted UI object for a v5 payload. */
+function parseV5Ui(rawUi: Record<string, unknown>): PersistedSettings['ui'] {
+  const expandedCards = Array.isArray(rawUi['expandedCards'])
+    ? (rawUi['expandedCards'] as unknown[]).filter((x): x is string => typeof x === 'string')
+    : [];
+
+  return {
+    expandedCards,
+    activeView: sanitizeActiveView(rawUi['activeView']),
+    focusedEndpointId: parseFocusedEndpointId(rawUi['focusedEndpointId']),
+    liveOptions: parseLiveOptions(rawUi['liveOptions']),
+    terminalFilters: parseTerminalFilters(rawUi['terminalFilters']),
+  };
+}
+
+function readObjectField(record: Record<string, unknown>, key: string): Record<string, unknown> {
+  const value = record[key];
+  return value !== null && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+}
+
 function normalizeV5(record: Record<string, unknown>): PersistedSettings | null {
   try {
-    const rawEndpoints = Array.isArray(record['endpoints']) ? record['endpoints'] : [];
-    const endpoints = rawEndpoints
-      .filter((e): e is Record<string, unknown> => e !== null && typeof e === 'object')
-      .map((e) => ({
-        url: typeof e['url'] === 'string' ? e['url'] : '',
-        enabled: typeof e['enabled'] === 'boolean' ? e['enabled'] : true,
-      }));
-
-    const rawSettings =
-      record['settings'] !== null && typeof record['settings'] === 'object'
-        ? (record['settings'] as Record<string, unknown>)
-        : {};
-
-    const rawRegion: unknown = rawSettings['region'];
-    const region: Region | undefined = isValidRegion(rawRegion) ? rawRegion : undefined;
-
-    const timeout = typeof rawSettings['timeout'] === 'number' ? rawSettings['timeout'] : DEFAULT_SETTINGS.timeout;
-
-    const settings = {
-      timeout,
-      delay: typeof rawSettings['delay'] === 'number' ? rawSettings['delay'] : DEFAULT_SETTINGS.delay,
-      burstRounds: typeof rawSettings['burstRounds'] === 'number' ? rawSettings['burstRounds'] : DEFAULT_SETTINGS.burstRounds,
-      monitorDelay: typeof rawSettings['monitorDelay'] === 'number' ? rawSettings['monitorDelay'] : DEFAULT_SETTINGS.monitorDelay,
-      cap: typeof rawSettings['cap'] === 'number' ? rawSettings['cap'] : DEFAULT_SETTINGS.cap,
-      corsMode:
-        rawSettings['corsMode'] === 'cors' || rawSettings['corsMode'] === 'no-cors'
-          ? rawSettings['corsMode']
-          : DEFAULT_SETTINGS.corsMode,
-      healthThreshold: clampHealthThreshold(rawSettings['healthThreshold'], timeout),
-      ...(region !== undefined ? { region } : {}),
-    };
-
-    const rawUi =
-      record['ui'] !== null && typeof record['ui'] === 'object'
-        ? (record['ui'] as Record<string, unknown>)
-        : {};
-
-    const expandedCards = Array.isArray(rawUi['expandedCards'])
-      ? (rawUi['expandedCards'] as unknown[]).filter((x): x is string => typeof x === 'string')
-      : [];
-
     return {
       version: 5,
-      endpoints,
-      settings,
-      ui: {
-        expandedCards,
-        activeView: sanitizeActiveView(rawUi['activeView']),
-        focusedEndpointId: parseFocusedEndpointId(rawUi['focusedEndpointId']),
-        liveOptions: parseLiveOptions(rawUi['liveOptions']),
-        terminalFilters: parseTerminalFilters(rawUi['terminalFilters']),
-      },
+      endpoints: parseEndpoints(record['endpoints']),
+      settings: parseV5Settings(readObjectField(record, 'settings')),
+      ui: parseV5Ui(readObjectField(record, 'ui')),
     };
   } catch {
     return null;

--- a/src/lib/utils/statistics.ts
+++ b/src/lib/utils/statistics.ts
@@ -83,6 +83,7 @@ export function computeEndpointStatistics(
       ci95: { lower: 0, upper: 0, margin: 0 },
       connectionReuseDelta: null,
       tier2Averages: undefined,
+      tier2P95: undefined,
       ready,
     };
   }
@@ -129,11 +130,14 @@ export function computeEndpointStatistics(
     }
   }
 
-  // ── Tier 2 averages ───────────────────────────────────────────────────
+  // ── Tier 2 averages + p95 ─────────────────────────────────────────────
   let tier2Averages: EndpointStatistics['tier2Averages'];
+  let tier2P95: EndpointStatistics['tier2P95'];
   if (tier2Samples.length > 0) {
     const avg = (field: 'dnsLookup' | 'tcpConnect' | 'tlsHandshake' | 'ttfb' | 'contentTransfer') =>
       tier2Samples.reduce((sum, s) => sum + s.tier2[field], 0) / tier2Samples.length;
+    const p95of = (field: 'dnsLookup' | 'tcpConnect' | 'tlsHandshake' | 'ttfb' | 'contentTransfer') =>
+      percentile(tier2Samples.map(s => s.tier2[field]), 95);
 
     tier2Averages = {
       dnsLookup: avg('dnsLookup'),
@@ -141,6 +145,13 @@ export function computeEndpointStatistics(
       tlsHandshake: avg('tlsHandshake'),
       ttfb: avg('ttfb'),
       contentTransfer: avg('contentTransfer'),
+    };
+    tier2P95 = {
+      dnsLookup: p95of('dnsLookup'),
+      tcpConnect: p95of('tcpConnect'),
+      tlsHandshake: p95of('tlsHandshake'),
+      ttfb: p95of('ttfb'),
+      contentTransfer: p95of('contentTransfer'),
     };
   }
 
@@ -153,6 +164,7 @@ export function computeEndpointStatistics(
     ci95,
     connectionReuseDelta,
     tier2Averages,
+    tier2P95,
     ready,
   };
 }
@@ -181,6 +193,7 @@ export function computeEndpointStatisticsFromBuffer(
       ci95: { lower: 0, upper: 0, margin: 0 },
       connectionReuseDelta: null,
       tier2Averages: undefined,
+      tier2P95: undefined,
       ready,
     };
   }
@@ -230,11 +243,14 @@ export function computeEndpointStatisticsFromBuffer(
     }
   }
 
-  // ── Tier 2 averages ───────────────────────────────────────────────────
+  // ── Tier 2 averages + p95 ─────────────────────────────────────────────
   let tier2Averages: EndpointStatistics['tier2Averages'];
+  let tier2P95: EndpointStatistics['tier2P95'];
   if (tier2Samples.length > 0) {
     const avg = (field: 'dnsLookup' | 'tcpConnect' | 'tlsHandshake' | 'ttfb' | 'contentTransfer') =>
       tier2Samples.reduce((accum, sample) => accum + (sample.tier2?.[field] ?? 0), 0) / tier2Samples.length;
+    const p95of = (field: 'dnsLookup' | 'tcpConnect' | 'tlsHandshake' | 'ttfb' | 'contentTransfer') =>
+      percentile(tier2Samples.map(sample => sample.tier2?.[field] ?? 0), 95);
 
     tier2Averages = {
       dnsLookup: avg('dnsLookup'),
@@ -242,6 +258,13 @@ export function computeEndpointStatisticsFromBuffer(
       tlsHandshake: avg('tlsHandshake'),
       ttfb: avg('ttfb'),
       contentTransfer: avg('contentTransfer'),
+    };
+    tier2P95 = {
+      dnsLookup: p95of('dnsLookup'),
+      tcpConnect: p95of('tcpConnect'),
+      tlsHandshake: p95of('tlsHandshake'),
+      ttfb: p95of('ttfb'),
+      contentTransfer: p95of('contentTransfer'),
     };
   }
 
@@ -254,6 +277,7 @@ export function computeEndpointStatisticsFromBuffer(
     ci95,
     connectionReuseDelta,
     tier2Averages,
+    tier2P95,
     ready,
   };
 }

--- a/tests/unit/classify.test.ts
+++ b/tests/unit/classify.test.ts
@@ -110,12 +110,12 @@ describe('HEALTH_STYLES — every bucket has a style entry', () => {
 
   it('each style exposes color, glow, label, tone', () => {
     for (const key of ['healthy', 'degraded', 'unhealthy', 'unknown'] as const) {
-      const s = HEALTH_STYLES[key];
-      expect(typeof s.color).toBe('string');
-      expect(typeof s.glow).toBe('string');
-      expect(typeof s.label).toBe('string');
-      expect(typeof s.tone).toBe('string');
-      expect(s.label.length).toBeGreaterThan(0);
+      const style = HEALTH_STYLES[key];
+      expect(typeof style.color).toBe('string');
+      expect(typeof style.glow).toBe('string');
+      expect(typeof style.label).toBe('string');
+      expect(typeof style.tone).toBe('string');
+      expect(style.label.length).toBeGreaterThan(0);
     }
   });
 });

--- a/tests/unit/classify.test.ts
+++ b/tests/unit/classify.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { classify, networkQuality, HEALTH_STYLES } from '../../src/lib/utils/classify';
+import type { EndpointStatistics } from '../../src/lib/types';
+
+function mkStats(overrides: Partial<EndpointStatistics> = {}): EndpointStatistics {
+  return {
+    endpointId: 'ep-1',
+    sampleCount: 30,
+    p50: 50,
+    p95: 100,
+    p99: 120,
+    p25: 40,
+    p75: 80,
+    p90: 90,
+    min: 10,
+    max: 150,
+    stddev: 15,
+    ci95: { lower: 45, upper: 55, margin: 5 },
+    connectionReuseDelta: null,
+    ready: true,
+    ...overrides,
+  };
+}
+
+describe('classify — health bucket', () => {
+  it('returns "unknown" when stats is null', () => {
+    expect(classify(null, 120)).toBe('unknown');
+  });
+
+  it('returns "unknown" when stats.ready is false', () => {
+    expect(classify(mkStats({ ready: false }), 120)).toBe('unknown');
+  });
+
+  it('returns "healthy" when p95 <= threshold AND p50 <= threshold/2', () => {
+    // threshold=120: healthy band is p95<=120 AND p50<=60
+    expect(classify(mkStats({ p50: 50, p95: 100 }), 120)).toBe('healthy');
+    expect(classify(mkStats({ p50: 60, p95: 120 }), 120)).toBe('healthy'); // boundary
+  });
+
+  it('returns "degraded" when p95 > threshold but <= 2*threshold', () => {
+    // p95=150, threshold=120 → 150 <= 240 → degraded
+    expect(classify(mkStats({ p50: 80, p95: 150 }), 120)).toBe('degraded');
+    expect(classify(mkStats({ p50: 50, p95: 240 }), 120)).toBe('degraded'); // boundary
+  });
+
+  it('returns "degraded" when p50 <= threshold but p95 > 2*threshold (OR branch)', () => {
+    // p50=100 (<= 120) qualifies degraded even though p95 is very high
+    expect(classify(mkStats({ p50: 100, p95: 500 }), 120)).toBe('degraded');
+  });
+
+  it('returns "degraded" when p50 is between threshold/2 and threshold (healthy p95 but elevated median)', () => {
+    // p95=100<=120 but p50=80 > 60 → not healthy. 100<=240 → degraded branch.
+    expect(classify(mkStats({ p50: 80, p95: 100 }), 120)).toBe('degraded');
+  });
+
+  it('returns "unhealthy" when p95 > 2*threshold AND p50 > threshold', () => {
+    expect(classify(mkStats({ p50: 200, p95: 500 }), 120)).toBe('unhealthy');
+  });
+
+  it('treats missing p50/p95 as Infinity → unhealthy', () => {
+    // Ready but no percentiles — pathological but must not throw.
+    const stats = mkStats({ p50: undefined as unknown as number, p95: undefined as unknown as number });
+    expect(classify(stats, 120)).toBe('unhealthy');
+  });
+});
+
+describe('networkQuality — aggregate score', () => {
+  it('returns null when no endpoints are supplied', () => {
+    expect(networkQuality([], 120)).toBeNull();
+  });
+
+  it('returns null when no endpoint is ready', () => {
+    expect(networkQuality([mkStats({ ready: false }), mkStats({ ready: false })], 120)).toBeNull();
+  });
+
+  it('excludes not-ready endpoints from the denominator', () => {
+    const score = networkQuality(
+      [mkStats({ p50: 50, p95: 100 }), mkStats({ ready: false })],
+      120,
+    );
+    expect(score).toBe(100);
+  });
+
+  it('all healthy → 100', () => {
+    expect(networkQuality([mkStats(), mkStats(), mkStats()], 120)).toBe(100);
+  });
+
+  it('all unhealthy → 20', () => {
+    const bad = mkStats({ p50: 500, p95: 1000 });
+    expect(networkQuality([bad, bad], 120)).toBe(20);
+  });
+
+  it('mix healthy + unhealthy → weighted average rounded', () => {
+    // 1 healthy (100) + 1 unhealthy (20) = 120/2 = 60
+    expect(networkQuality([mkStats(), mkStats({ p50: 500, p95: 1000 })], 120)).toBe(60);
+  });
+
+  it('degraded contributes 60 to the aggregate', () => {
+    expect(networkQuality([mkStats({ p50: 80, p95: 150 })], 120)).toBe(60);
+  });
+});
+
+describe('HEALTH_STYLES — every bucket has a style entry', () => {
+  it('covers healthy, degraded, unhealthy, unknown', () => {
+    expect(HEALTH_STYLES.healthy).toBeDefined();
+    expect(HEALTH_STYLES.degraded).toBeDefined();
+    expect(HEALTH_STYLES.unhealthy).toBeDefined();
+    expect(HEALTH_STYLES.unknown).toBeDefined();
+  });
+
+  it('each style exposes color, glow, label, tone', () => {
+    for (const key of ['healthy', 'degraded', 'unhealthy', 'unknown'] as const) {
+      const s = HEALTH_STYLES[key];
+      expect(typeof s.color).toBe('string');
+      expect(typeof s.glow).toBe('string');
+      expect(typeof s.label).toBe('string');
+      expect(typeof s.tone).toBe('string');
+      expect(s.label.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/unit/format.test.ts
+++ b/tests/unit/format.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { fmt, fmtParts, fmtPct, fmtCount } from '../../src/lib/utils/format';
+
+describe('fmt — single source of truth for ms formatting', () => {
+  it('returns em-dash for nullish/non-finite input', () => {
+    expect(fmt(null)).toBe('—');
+    expect(fmt(undefined)).toBe('—');
+    expect(fmt(Number.NaN)).toBe('—');
+    expect(fmt(Number.POSITIVE_INFINITY)).toBe('—');
+    expect(fmt(Number.NEGATIVE_INFINITY)).toBe('—');
+  });
+
+  it('sub-1 ms renders with two decimal places', () => {
+    expect(fmt(0.43)).toBe('0.43');
+    expect(fmt(0.1)).toBe('0.10');
+    expect(fmt(0)).toBe('0.00');
+  });
+
+  it('sub-10 ms renders with one decimal place', () => {
+    expect(fmt(1)).toBe('1.0');
+    expect(fmt(9.94)).toBe('9.9');
+  });
+
+  it('sub-10k ms renders as rounded integer with thousands separator', () => {
+    expect(fmt(12)).toBe('12');
+    expect(fmt(127.4)).toBe('127');
+    expect(fmt(1234)).toBe('1,234');
+    expect(fmt(9999)).toBe('9,999');
+  });
+
+  it('>=10k ms renders as seconds with one decimal', () => {
+    expect(fmt(10_000)).toBe('10.0s');
+    expect(fmt(12_345)).toBe('12.3s');
+    expect(fmt(60_000)).toBe('60.0s');
+  });
+
+  it('negative (impossible-but-don\'t-throw) renders as em-dash path or signed integer', () => {
+    // Spec treats negative as "invalid" — return em-dash.
+    expect(fmt(-1)).toBe('—');
+  });
+});
+
+describe('fmtParts — split number and unit', () => {
+  it('returns em-dash + empty unit for nullish/non-finite', () => {
+    expect(fmtParts(null)).toEqual({ num: '—', unit: '' });
+    expect(fmtParts(undefined)).toEqual({ num: '—', unit: '' });
+    expect(fmtParts(Number.NaN)).toEqual({ num: '—', unit: '' });
+    expect(fmtParts(Number.POSITIVE_INFINITY)).toEqual({ num: '—', unit: '' });
+  });
+
+  it('uses ms unit under 10k', () => {
+    expect(fmtParts(127.4)).toEqual({ num: '127', unit: 'ms' });
+    expect(fmtParts(0.43)).toEqual({ num: '0.43', unit: 'ms' });
+    expect(fmtParts(9999)).toEqual({ num: '9,999', unit: 'ms' });
+  });
+
+  it('uses s unit at and above 10k', () => {
+    expect(fmtParts(10_000)).toEqual({ num: '10.0', unit: 's' });
+    expect(fmtParts(12_345)).toEqual({ num: '12.3', unit: 's' });
+  });
+});
+
+describe('fmtPct — ratio (0..1) to integer percent', () => {
+  it('rounds and suffixes %', () => {
+    expect(fmtPct(0)).toBe('0%');
+    expect(fmtPct(0.5)).toBe('50%');
+    expect(fmtPct(0.999)).toBe('100%');
+    expect(fmtPct(1)).toBe('100%');
+    expect(fmtPct(0.054)).toBe('5%');
+  });
+});
+
+describe('fmtCount — integer with locale thousands separator', () => {
+  it('renders small integers unchanged', () => {
+    expect(fmtCount(0)).toBe('0');
+    expect(fmtCount(42)).toBe('42');
+  });
+
+  it('inserts thousands separators (en-US locale default)', () => {
+    expect(fmtCount(1234)).toBe('1,234');
+    expect(fmtCount(1_000_000)).toBe('1,000,000');
+  });
+});

--- a/tests/unit/persistence-v5.test.ts
+++ b/tests/unit/persistence-v5.test.ts
@@ -121,6 +121,17 @@ describe('persistence v4 → v5 migration', () => {
     expect(migrated.settings.healthThreshold).toBeGreaterThan(0);
   });
 
+  it('maintains threshold < timeout even when persisted timeout is tiny', () => {
+    // Regression: if timeout <= DEFAULT_HEALTH_THRESHOLD (120), the old fallback
+    // returned 120 unconditionally and violated the invariant.
+    const payload = baseV4Payload();
+    (payload['settings'] as Record<string, unknown>)['timeout'] = 80;
+    delete (payload['settings'] as Record<string, unknown>)['healthThreshold'];
+    const migrated = migrateSettings(payload) as PersistedSettings;
+    expect(migrated.settings.healthThreshold).toBeLessThan(migrated.settings.timeout);
+    expect(migrated.settings.healthThreshold).toBeGreaterThan(0);
+  });
+
   it('maintains DEFAULT_SETTINGS shape invariant', () => {
     // Guards against accidental drop of healthThreshold from defaults.
     expect(DEFAULT_SETTINGS.healthThreshold).toBe(DEFAULT_HEALTH_THRESHOLD);

--- a/tests/unit/persistence-v5.test.ts
+++ b/tests/unit/persistence-v5.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { migrateSettings } from '../../src/lib/utils/persistence';
+import { DEFAULT_HEALTH_THRESHOLD, DEFAULT_SETTINGS } from '../../src/lib/types';
+import type { PersistedSettings } from '../../src/lib/types';
+
+function baseV4Payload(): Record<string, unknown> {
+  return {
+    version: 4,
+    endpoints: [{ url: 'https://example.com', enabled: true }],
+    settings: {
+      timeout: 5000,
+      delay: 0,
+      burstRounds: 50,
+      monitorDelay: 1000,
+      cap: 0,
+      corsMode: 'no-cors',
+    },
+    ui: {
+      expandedCards: ['ep-1'],
+      activeView: 'split',
+    },
+  };
+}
+
+describe('persistence v4 → v5 migration', () => {
+  it('bumps version to 5', () => {
+    const migrated = migrateSettings(baseV4Payload()) as PersistedSettings;
+    expect(migrated.version).toBe(5);
+  });
+
+  it('seeds healthThreshold default when missing', () => {
+    const migrated = migrateSettings(baseV4Payload()) as PersistedSettings;
+    expect(migrated.settings.healthThreshold).toBe(DEFAULT_HEALTH_THRESHOLD);
+  });
+
+  it('preserves an explicit healthThreshold that was already saved', () => {
+    const payload = baseV4Payload();
+    (payload['settings'] as Record<string, unknown>)['healthThreshold'] = 200;
+    const migrated = migrateSettings(payload) as PersistedSettings;
+    expect(migrated.settings.healthThreshold).toBe(200);
+  });
+
+  it('remaps deprecated activeView "split" → "lanes"', () => {
+    const migrated = migrateSettings(baseV4Payload()) as PersistedSettings;
+    expect(migrated.ui.activeView).toBe('lanes');
+  });
+
+  it('remaps deprecated activeView "timeline" → "lanes"', () => {
+    const payload = baseV4Payload();
+    (payload['ui'] as Record<string, unknown>)['activeView'] = 'timeline';
+    const migrated = migrateSettings(payload) as PersistedSettings;
+    expect(migrated.ui.activeView).toBe('lanes');
+  });
+
+  it('remaps deprecated activeView "heatmap" → "lanes"', () => {
+    const payload = baseV4Payload();
+    (payload['ui'] as Record<string, unknown>)['activeView'] = 'heatmap';
+    const migrated = migrateSettings(payload) as PersistedSettings;
+    expect(migrated.ui.activeView).toBe('lanes');
+  });
+
+  it('preserves v5 activeView values (no double-migration)', () => {
+    const v5: Record<string, unknown> = {
+      ...baseV4Payload(),
+      version: 5,
+      settings: { ...(baseV4Payload().settings as Record<string, unknown>), healthThreshold: 150 },
+      ui: { expandedCards: [], activeView: 'overview' },
+    };
+    const migrated = migrateSettings(v5) as PersistedSettings;
+    expect(migrated.version).toBe(5);
+    expect(migrated.ui.activeView).toBe('overview');
+  });
+
+  it('seeds default UI fields (focusedEndpointId, liveOptions, terminalFilters)', () => {
+    const migrated = migrateSettings(baseV4Payload()) as PersistedSettings;
+    expect(migrated.ui.focusedEndpointId).toBeNull();
+    expect(migrated.ui.liveOptions).toEqual({ split: false, timeRange: '5m' });
+    expect(migrated.ui.terminalFilters).toEqual([]);
+  });
+
+  it('preserves endpoints through migration', () => {
+    const migrated = migrateSettings(baseV4Payload()) as PersistedSettings;
+    expect(migrated.endpoints).toEqual([{ url: 'https://example.com', enabled: true }]);
+  });
+
+  it('migrates a v2 payload all the way through to v5', () => {
+    const v2 = {
+      version: 2,
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: {
+        timeout: 5000,
+        delay: 1000,
+        cap: 100,
+        corsMode: 'no-cors',
+      },
+      ui: { expandedCards: [], activeView: 'split' },
+    };
+    const migrated = migrateSettings(v2) as PersistedSettings;
+    expect(migrated.version).toBe(5);
+    expect(migrated.settings.healthThreshold).toBe(DEFAULT_HEALTH_THRESHOLD);
+    expect(migrated.settings.monitorDelay).toBe(1000);
+    expect(migrated.ui.activeView).toBe('lanes');
+  });
+
+  it('returns null for an unknown version (first-install path)', () => {
+    expect(migrateSettings({ version: 99 })).toBeNull();
+  });
+
+  it('returns null for non-object input', () => {
+    expect(migrateSettings(null)).toBeNull();
+    expect(migrateSettings('hello')).toBeNull();
+    expect(migrateSettings(42)).toBeNull();
+  });
+
+  it('clamps persisted healthThreshold >= timeout to a safe value', () => {
+    const payload = baseV4Payload();
+    (payload['settings'] as Record<string, unknown>)['healthThreshold'] = 10_000;
+    (payload['settings'] as Record<string, unknown>)['timeout'] = 5000;
+    const migrated = migrateSettings(payload) as PersistedSettings;
+    expect(migrated.settings.healthThreshold).toBeLessThan(migrated.settings.timeout);
+    expect(migrated.settings.healthThreshold).toBeGreaterThan(0);
+  });
+
+  it('maintains DEFAULT_SETTINGS shape invariant', () => {
+    // Guards against accidental drop of healthThreshold from defaults.
+    expect(DEFAULT_SETTINGS.healthThreshold).toBe(DEFAULT_HEALTH_THRESHOLD);
+  });
+});

--- a/tests/unit/persistence.test.ts
+++ b/tests/unit/persistence.test.ts
@@ -20,16 +20,16 @@ describe('persistence', () => {
     expect(loadPersistedSettings()).toBeNull();
   });
 
-  it('round-trips v3 settings correctly', () => {
+  it('round-trips v3 settings correctly (up-migrates to v5)', () => {
     const settings: PersistedSettings = {
       version: 3,
       endpoints: [{ url: 'https://example.com', enabled: true }],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors' },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
       ui: { expandedCards: [], activeView: 'timeline' },
     };
     saveSettings(settings);
     const loaded = loadPersistedSettings();
-    expect(loaded?.version).toBe(4);
+    expect(loaded?.version).toBe(5);
     expect(loaded?.endpoints[0]?.url).toBe('https://example.com');
     expect(loaded?.settings.burstRounds).toBe(50);
     expect(loaded?.settings.monitorDelay).toBe(1000);
@@ -41,30 +41,30 @@ describe('persistence', () => {
     expect(loadPersistedSettings()).toBeNull();
   });
 
-  it('migrates legacy storage key to new key', () => {
+  it('migrates legacy storage key to new key (result is v5)', () => {
     const settings: PersistedSettings = {
       version: 3,
       endpoints: [{ url: 'https://example.com', enabled: true }],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors' },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
       ui: { expandedCards: [], activeView: 'timeline' },
     };
     localStorageMock.setItem('chronoscope_v2_settings', JSON.stringify(settings));
     const loaded = loadPersistedSettings();
-    expect(loaded?.version).toBe(4);
+    expect(loaded?.version).toBe(5);
     // Legacy key should be removed, new key should exist
     expect(localStorageMock.getItem('chronoscope_v2_settings')).toBeNull();
     expect(localStorageMock.getItem('chronoscope_settings')).not.toBeNull();
   });
 
-  it('migrates v1 data to v4', () => {
+  it('migrates v1 data all the way to v5', () => {
     const v1Data = { version: 1, endpoints: [{ url: 'https://example.com' }] };
     const migrated = migrateSettings(v1Data);
-    expect(migrated?.version).toBe(4);
+    expect(migrated?.version).toBe(5);
     expect(migrated?.settings.burstRounds).toBe(50);
     expect(migrated?.settings.monitorDelay).toBe(1000);
   });
 
-  it('migrates v2 data to v4 with old delay as monitorDelay', () => {
+  it('migrates v2 data to v5 with old delay as monitorDelay', () => {
     const v2Data = {
       version: 2,
       endpoints: [{ url: 'https://example.com', enabled: true }],
@@ -72,7 +72,7 @@ describe('persistence', () => {
       ui: { expandedCards: [], activeView: 'split' },
     };
     const migrated = migrateSettings(v2Data);
-    expect(migrated?.version).toBe(4);
+    expect(migrated?.version).toBe(5);
     expect(migrated?.settings.monitorDelay).toBe(500);
     expect(migrated?.settings.burstRounds).toBe(50);
     expect(migrated?.settings.delay).toBe(0);

--- a/tests/unit/utils/persistence-migration.test.ts
+++ b/tests/unit/utils/persistence-migration.test.ts
@@ -13,8 +13,8 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('migrateSettings v3 → v4', () => {
-  it('v3 payload with no region → v4 with region = detectRegion()', () => {
+describe('migrateSettings region handling + chained up-migration', () => {
+  it('v3 payload with no region → adds region = detectRegion() and lifts to v5', () => {
     const v3 = {
       version: 3,
       endpoints: [{ url: 'https://example.com', enabled: true }],
@@ -22,12 +22,12 @@ describe('migrateSettings v3 → v4', () => {
       ui: { expandedCards: [], activeView: 'timeline' },
     };
     const result = migrateSettings(v3);
-    expect(result?.version).toBe(4);
+    expect(result?.version).toBe(5);
     expect(result?.settings.region).toBe('europe');
     expect(result?.endpoints[0]?.url).toBe('https://example.com');
   });
 
-  it('v4 payload with valid region passes through unchanged', () => {
+  it('v4 payload with valid region passes through up to v5 with region preserved', () => {
     const v4 = {
       version: 4,
       endpoints: [{ url: 'https://example.com', enabled: true }],
@@ -35,11 +35,11 @@ describe('migrateSettings v3 → v4', () => {
       ui: { expandedCards: [], activeView: 'split' },
     };
     const result = migrateSettings(v4);
-    expect(result?.version).toBe(4);
+    expect(result?.version).toBe(5);
     expect(result?.settings.region).toBe('east-asia');
   });
 
-  it('v4 payload with invalid region string strips the field', () => {
+  it('v4 payload with invalid region string strips the field (still lifts to v5)', () => {
     const v4 = {
       version: 4,
       endpoints: [],
@@ -47,7 +47,7 @@ describe('migrateSettings v3 → v4', () => {
       ui: { expandedCards: [], activeView: 'split' },
     };
     const result = migrateSettings(v4);
-    expect(result?.version).toBe(4);
+    expect(result?.version).toBe(5);
     expect(result?.settings.region).toBeUndefined();
   });
 
@@ -62,7 +62,7 @@ describe('migrateSettings v3 → v4', () => {
     expect(result?.settings.region).toBeUndefined();
   });
 
-  it('v2 payload migrates through to v4 (chain migration)', () => {
+  it('v2 payload migrates through to v5 (chain migration)', () => {
     const v2 = {
       version: 2,
       endpoints: [{ url: 'https://example.com', enabled: true }],
@@ -70,18 +70,18 @@ describe('migrateSettings v3 → v4', () => {
       ui: { expandedCards: [], activeView: 'split' },
     };
     const result = migrateSettings(v2);
-    expect(result?.version).toBe(4);
+    expect(result?.version).toBe(5);
     expect(result?.settings.burstRounds).toBe(50);
     expect(result?.settings.region).toBe('europe');
   });
 
-  it('v1 payload migrates through to v4', () => {
+  it('v1 payload migrates through to v5', () => {
     const v1 = {
       version: 1,
       endpoints: [{ url: 'https://example.com' }],
     };
     const result = migrateSettings(v1);
-    expect(result?.version).toBe(4);
+    expect(result?.version).toBe(5);
   });
 
   it('version 99 (future unknown): returns null — no forward-compat coercion', () => {


### PR DESCRIPTION
## Summary

Phase 0 of the v2 redesign per `handoff/06-implementation-plan.md`. Zero-visual-risk scaffolding that unblocks the three prototyped views (Overview / Live / Atlas) without changing any user-visible behaviour yet.

- **Tokens.** Added amber accent (glow/tone), SVG dial & scope primitives, tooltip surface fields, `typography.scale` + `tracking`, and v2 motion primitives (`handLerp`, `pulseRim`, `orbitPulse`, `traceRepaint`, `networkQualityThrottle`).
- **Types.** Extended `ActiveView` for v2 surfaces (legacy values retained for one release and remapped to `lanes` at load); added `LiveTimeRange`, `TerminalEventType`, `UIState.focusedEndpointId/liveOptions/terminalFilters`, `Settings.healthThreshold`, `EndpointStatistics.tier2P95`, and the v5 `PersistedSettings` shape.
- **New utilities.** `src/lib/utils/format.ts` (single source of truth for ms rendering) and `src/lib/utils/classify.ts` (health classifier + network-quality aggregator). These are the alignment points that will keep dial colour, rail pip, and verdict text in sync across future views.
- **Derived store.** `src/lib/stores/derived.ts#networkQualityStore` — fans out from endpoints + statistics + settings. Components must subscribe rather than recomputing inline (rule in `06-implementation-plan.md` §Cross-cutting).
- **Statistics.** Added tier-2 p95 computation to both the initial and incremental paths in `statistics.ts` — enables Atlas's upcoming P50/P95 toggle.
- **Persistence v4 → v5.** `CURRENT_VERSION` bumped; `normalizeV5` + shared `upgradeToV5` seeds `healthThreshold`, remaps deprecated `timeline/heatmap/split → lanes`, and validates `liveOptions` / `terminalFilters` from the raw record. v1–v3 payloads chain through cleanly.
- **App.svelte.** `bridgeTokensToCss` emits new CSS vars; `persist()` writes v5 payloads with the new UI fields.

### Divergences from the handoff docs (all pre-approved)

1. `svg.gridLine` kept at existing value — new `svg.gridLineMajor` added so LaneSvgChart / TimelineCanvas are not perturbed.
2. `tier2.labelText` kept at existing WCAG-AA value (white .40). A dark-on-light variant can be added if a future view needs it.
3. `glass.bgHover` / `bgStrong` kept at existing values (working visual values policy).
4. UI default `activeView` remains `'split'` in Phase 0; flipped to `'overview'` in Phase 1 when the stub view lands, so Phase 0 can ship alone without a blank screen.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — **720 / 720 passing**
  - 12 new cases in `tests/unit/format.test.ts` (edge cases for nullish / NaN / Infinity / negative / boundary breakpoints)
  - 17 new cases in `tests/unit/classify.test.ts` (100% branch coverage on `classify`; `networkQuality` aggregation + `ready`-filter)
  - 14 new cases in `tests/unit/persistence-v5.test.ts` (v4 → v5 up-migration, `healthThreshold` seeding + preservation + clamp, view remap, chained v2 → v5, unknown-version null return)
  - Existing persistence tests updated to expect `CURRENT_VERSION = 5`
- [x] No visual change at runtime — default `activeView` is still `'split'`
- [ ] Manual smoke: load a persisted v4 payload from an older build and verify it migrates to v5 cleanly (reviewer to verify locally)

## Not in this PR

Rail component, view switcher, Topbar segment, any view files — those are Phase 1+.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Network health quality scoring (0–100) across monitored endpoints.
  * New accent colors with glow/tone variants and expanded visual palette.
  * Enhanced typography scale and letter-spacing for improved UI readability.
  * Health status classification system (healthy, degraded, unhealthy) for endpoint monitoring.
  * Live view with configurable time ranges and split display options.
  * Terminal event filtering and focused endpoint tracking.
  * Tier-2 P95 performance metrics; configurable health thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->