### PR TITLE
Phase 0 — foundations (tokens, utils, types, v4→v5 persistence)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,11 @@
+# CodeRabbit configuration.
+# https://docs.coderabbit.ai/guides/configure-coderabbit
+#
+# Reviews are enabled on PRs targeting both main and the v2 redesign umbrella
+# branch, so every phase PR into chronoscope-v2-redesign gets reviewed.
+reviews:
+  auto_review:
+    enabled: true
+    base_branches:
+      - main
+      - chronoscope-v2-redesign

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, chronoscope-v2-redesign]
   pull_request:
-    branches: [main]
+    branches: [main, chronoscope-v2-redesign]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/src/lib/components/App.svelte
+++ b/src/lib/components/App.svelte
@@ -39,10 +39,17 @@
     root.style.setProperty('--t5', tokens.color.text.t5);
 
     // Accent
-    root.style.setProperty('--accent-cyan',   tokens.color.accent.cyan);
-    root.style.setProperty('--accent-pink',   tokens.color.accent.pink);
-    root.style.setProperty('--accent-green',  tokens.color.accent.green);
-    root.style.setProperty('--green-glow',    tokens.color.accent.greenGlow);
+    root.style.setProperty('--accent-cyan',       tokens.color.accent.cyan);
+    root.style.setProperty('--accent-cyan-glow',  tokens.color.accent.cyanGlow);
+    root.style.setProperty('--accent-cyan-tone',  tokens.color.accent.cyanTone);
+    root.style.setProperty('--accent-pink',       tokens.color.accent.pink);
+    root.style.setProperty('--accent-pink-glow',  tokens.color.accent.pinkGlow);
+    root.style.setProperty('--accent-pink-tone',  tokens.color.accent.pinkTone);
+    root.style.setProperty('--accent-amber',      tokens.color.accent.amber);
+    root.style.setProperty('--accent-amber-glow', tokens.color.accent.amberGlow);
+    root.style.setProperty('--accent-amber-tone', tokens.color.accent.amberTone);
+    root.style.setProperty('--accent-green',      tokens.color.accent.green);
+    root.style.setProperty('--green-glow',        tokens.color.accent.greenGlow);
 
     // Glass
     root.style.setProperty('--glass-bg',        tokens.color.glass.bg);
@@ -72,6 +79,35 @@
     root.style.setProperty('--timing-fade-in',   `${tokens.timing.fadeIn}ms`);
     root.style.setProperty('--easing-standard',  tokens.easing.standard);
     root.style.setProperty('--easing-decelerate',tokens.easing.decelerate);
+
+    // v2 typography scale (--ts-*) + tracking (--tr-*)
+    root.style.setProperty('--ts-xs',  tokens.typography.scale.xs);
+    root.style.setProperty('--ts-sm',  tokens.typography.scale.sm);
+    root.style.setProperty('--ts-md',  tokens.typography.scale.md);
+    root.style.setProperty('--ts-lg',  tokens.typography.scale.lg);
+    root.style.setProperty('--ts-xl',  tokens.typography.scale.xl);
+    root.style.setProperty('--ts-xxl', tokens.typography.scale.xxl);
+    root.style.setProperty('--tr-kicker', tokens.typography.tracking.kicker);
+    root.style.setProperty('--tr-label',  tokens.typography.tracking.label);
+    root.style.setProperty('--tr-body',   tokens.typography.tracking.body);
+
+    // v2 surface + tooltip variants
+    root.style.setProperty('--surface-dial-face',    tokens.color.surface.dialFace);
+    root.style.setProperty('--surface-overlay-deep', tokens.color.surface.overlayDeep);
+    root.style.setProperty('--tooltip-bg-deep',      tokens.color.tooltip.bgDeep);
+    root.style.setProperty('--tooltip-border',       tokens.color.tooltip.border);
+    root.style.setProperty('--tooltip-text',         tokens.color.tooltip.text);
+    root.style.setProperty('--tooltip-text-dim',     tokens.color.tooltip.textDim);
+
+    // v2 rail surfaces
+    root.style.setProperty('--glass-bg-rail-hover',    tokens.color.glass.bgRailHover);
+    root.style.setProperty('--glass-bg-rail-selected', tokens.color.glass.bgRailSelected);
+
+    // v2 motion primitives
+    root.style.setProperty('--timing-hand-lerp',     String(tokens.timing.handLerp));
+    root.style.setProperty('--timing-pulse-rim',     `${tokens.timing.pulseRim}ms`);
+    root.style.setProperty('--timing-orbit-pulse',   `${tokens.timing.orbitPulse}ms`);
+    root.style.setProperty('--timing-trace-repaint', `${tokens.timing.traceRepaint}ms`);
 
     // Legacy properties (Settings/Share drawers not yet redesigned)
     root.style.setProperty('--surface-raised',   tokens.color.surface.raised);
@@ -112,12 +148,15 @@
       const endpoints = get(endpointStore);
 
       const payload: PersistedSettings = {
-        version: 4,
+        version: 5,
         endpoints: endpoints.map(ep => ({ url: ep.url, enabled: ep.enabled })),
         settings,
         ui: {
           expandedCards: [...ui.expandedCards],
           activeView: ui.activeView,
+          focusedEndpointId: ui.focusedEndpointId,
+          liveOptions: ui.liveOptions,
+          terminalFilters: [...ui.terminalFilters],
         },
       };
       saveSettings(payload);

--- a/src/lib/stores/derived.ts
+++ b/src/lib/stores/derived.ts
@@ -1,0 +1,26 @@
+// src/lib/stores/derived.ts
+// Derived stores that compose across primary stores. Centralizing these here
+// keeps downstream views (chronograph dial, verdict strip, topbar status) from
+// recomputing classify()/networkQuality() inline and drifting out of sync.
+
+import { derived, type Readable } from 'svelte/store';
+import { endpointStore } from './endpoints';
+import { statisticsStore } from './statistics';
+import { settingsStore } from './settings';
+import { networkQuality } from '../utils/classify';
+
+/**
+ * Aggregate 0–100 score across all enabled endpoints — null until at least one
+ * endpoint's statistics are `ready`. Subscribed by Topbar status and the
+ * chronograph dial's main hand.
+ */
+export const networkQualityStore: Readable<number | null> = derived(
+  [endpointStore, statisticsStore, settingsStore],
+  ([$endpoints, $stats, $settings]) => {
+    const readyStats = $endpoints
+      .filter((e) => e.enabled)
+      .map((e) => $stats[e.id])
+      .filter((s) => s !== undefined);
+    return networkQuality(readyStats, $settings.healthThreshold);
+  },
+);

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -3,10 +3,12 @@
 // and panel visibility. No side effects; all state is local to this module.
 
 import { writable } from 'svelte/store';
-import type { UIState } from '../types';
+import type { LiveTimeRange, TerminalEventType, UIState } from '../types';
 
 const initialState = (): UIState => ({
-  activeView: 'split',
+  // 'overview' is the v2 default; v4 persisted payloads are migrated in
+  // persistence.ts so 'split'/'timeline'/'heatmap' never land here directly.
+  activeView: 'overview',
   expandedCards: new Set<string>(),
   hoverTarget: null,
   selectedTarget: null,
@@ -20,6 +22,12 @@ const initialState = (): UIState => ({
   laneHoverY: null,
   heatmapTooltip: null,
   showEndpoints: false,
+  focusedEndpointId: null,
+  liveOptions: {
+    split: false,
+    timeRange: '5m',
+  },
+  terminalFilters: new Set<TerminalEventType>(),
 });
 
 function createUiStore() {
@@ -75,6 +83,32 @@ function createUiStore() {
     },
     toggleEndpoints(): void {
       update((s) => ({ ...s, showEndpoints: !s.showEndpoints }));
+    },
+    setFocusedEndpoint(id: string | null): void {
+      update((s) => ({ ...s, focusedEndpointId: id }));
+    },
+    toggleFocusedEndpoint(id: string): void {
+      update((s) => ({
+        ...s,
+        focusedEndpointId: s.focusedEndpointId === id ? null : id,
+      }));
+    },
+    setLiveSplit(split: boolean): void {
+      update((s) => ({ ...s, liveOptions: { ...s.liveOptions, split } }));
+    },
+    setLiveTimeRange(range: LiveTimeRange): void {
+      update((s) => ({ ...s, liveOptions: { ...s.liveOptions, timeRange: range } }));
+    },
+    toggleTerminalFilter(type: TerminalEventType): void {
+      update((s) => {
+        const next = new Set(s.terminalFilters);
+        if (next.has(type)) next.delete(type);
+        else next.add(type);
+        return { ...s, terminalFilters: next };
+      });
+    },
+    clearTerminalFilters(): void {
+      update((s) => ({ ...s, terminalFilters: new Set<TerminalEventType>() }));
     },
     reset(): void {
       set(initialState());

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -38,6 +38,14 @@ const primitive = {
   pink15:     'rgba(249,168,212,.15)',
   pink25:     'rgba(249,168,212,.25)',
   amber:      '#fbbf24',
+  amberGlow:  'rgba(251,191,36,.33)',   // #fbbf2455 — chronograph degraded glow
+  amberTone:  '#b38410',                // darker amber for arcs/borders
+
+  // Accent glow/tone companions (Phase 0 — v2 views)
+  cyanGlow: 'rgba(103,232,249,.33)',    // #67e8f955
+  cyanTone: '#3aa7b8',
+  pinkGlow: 'rgba(249,168,212,.33)',    // #f9a8d455
+  pinkTone: '#b0628a',
 
   green:     '#86efac',
   greenGlow: 'rgba(134,239,172,.5)',
@@ -86,6 +94,32 @@ const primitive = {
   nowDotPink: '#fbcfe8',
   thresholdStroke: '#f9a8d4',
 
+  // Chronograph dial face / scope canvas background (Phase 0 — v2 views)
+  bgDialFace: '#141021',
+
+  // Overlay layer used by v2 share/settings sheets (deeper than legacy overlay)
+  overlayDeep: 'rgba(11,8,20,.85)',
+
+  // Rail row surfaces (Phase 0 — v2 endpoint rail)
+  glassBgRailHover:    'rgba(255,255,255,.06)',
+  glassBgRailSelected: 'rgba(255,255,255,.10)',
+
+  // SVG primitives used by dial, orbit ring, scope grid (Phase 0 — v2 views)
+  svgGridCyan:   'rgba(103,232,249,.05)',
+  svgGridMajor:  'rgba(255,255,255,.06)',
+  svgTickMinor:  'rgba(255,255,255,.18)',
+  svgTickMajor:  'rgba(255,255,255,.50)',
+  svgHandStroke: '#ffffff',
+  svgDialRim:    'rgba(255,255,255,.14)',
+  svgOrbitTrack: 'rgba(255,255,255,.06)',
+  svgOrbitEdge:  'rgba(255,255,249,.10)',
+
+  // Tooltip surface for scope crosshair (Phase 0 — v2 Live view)
+  tooltipBgDeep:  'rgba(10,9,18,.92)',
+  tooltipBorder:  'rgba(255,255,255,.10)',
+  tooltipText:    'rgba(255,255,255,.95)',
+  tooltipTextDim: 'rgba(255,255,255,.55)',
+
   // Orb layers (for App.svelte CSS)
   orbCyan:   'rgba(103,232,249,.045)',
   orbPink:   'rgba(249,168,212,.04)',
@@ -110,6 +144,9 @@ export const tokens = {
       raised:   primitive.bgMid,
       elevated: primitive.bgDeep,
       overlay:  'rgba(0, 0, 0, 0.6)',
+      // Chronograph dial face + scope canvas background (v2 views).
+      dialFace:    primitive.bgDialFace,
+      overlayDeep: primitive.overlayDeep,
       border: {
         dim:    primitive.borderDim,
         mid:    primitive.borderMid,
@@ -140,18 +177,25 @@ export const tokens = {
       cyan20:     primitive.cyan20,
       cyan12:     primitive.cyan12,
       cyan06:     primitive.cyan06,
+      cyanGlow:   primitive.cyanGlow,
+      cyanTone:   primitive.cyanTone,
       pink:       primitive.pink,
       pinkBright: primitive.pinkBright,
       pink40:     primitive.pink40,
       pink20:     primitive.pink20,
       pink12:     primitive.pink12,
       pink06:     primitive.pink06,
+      pinkGlow:   primitive.pinkGlow,
+      pinkTone:   primitive.pinkTone,
       cyan25:           primitive.cyan25,
       cyanBgSubtle:     primitive.cyan15,
       cyanBorderSubtle: primitive.cyan25,
       pink25:           primitive.pink25,
       pinkBgSubtle:     primitive.pink15,
       pinkBorderSubtle: primitive.pink25,
+      amber:      primitive.amber,
+      amberGlow:  primitive.amberGlow,
+      amberTone:  primitive.amberTone,
       green:      primitive.green,
       greenGlow:  primitive.greenGlow,
     },
@@ -165,6 +209,10 @@ export const tokens = {
       bg:          primitive.glassBg,
       bgStrong:    'rgba(255,255,255,.045)',
       bgHover:     'rgba(255,255,255,.07)',
+      // Rail-scoped glass surfaces (v2 endpoint rail). Distinct from bgHover/bgStrong
+      // above to preserve existing-component visuals (see Phase 0 handoff notes).
+      bgRailHover:    primitive.glassBgRailHover,
+      bgRailSelected: primitive.glassBgRailSelected,
       border:      primitive.glassBorder,
       borderHover: primitive.glassHighlight,
       highlight:      primitive.glassHighlight,
@@ -188,6 +236,11 @@ export const tokens = {
 
     tooltip: {
       bg: primitive.tooltipBg,
+      // Deep tooltip surface for v2 scope crosshair.
+      bgDeep:  primitive.tooltipBgDeep,
+      border:  primitive.tooltipBorder,
+      text:    primitive.tooltipText,
+      textDim: primitive.tooltipTextDim,
     },
 
     svg: {
@@ -196,6 +249,15 @@ export const tokens = {
       nowDotCyan:      primitive.nowDotCyan,
       nowDotPink:      primitive.nowDotPink,
       thresholdStroke: primitive.thresholdStroke,
+      // v2 chronograph + scope primitives.
+      gridLineCyan:  primitive.svgGridCyan,
+      gridLineMajor: primitive.svgGridMajor,
+      tickMinor:     primitive.svgTickMinor,
+      tickMajor:     primitive.svgTickMajor,
+      handStroke:    primitive.svgHandStroke,
+      dialRim:       primitive.svgDialRim,
+      orbitTrack:    primitive.svgOrbitTrack,
+      orbitEdge:     primitive.svgOrbitEdge,
     },
 
     heatmap: {
@@ -268,6 +330,21 @@ export const tokens = {
     caption: { size: 9,  weight: 400, opacity: 0.5,  letterSpacing: '0.04em' },
     label:   { size: 11, weight: 500, opacity: 0.58, letterSpacing: '0.06em' },
     body:    { size: 14, weight: 400, opacity: 0.94, letterSpacing: '0' },
+
+    // v2 named scale — chip labels, rail url, rail metric, triptych values, verdict title.
+    scale: {
+      xs:  '9px',     // chip labels, metadata kickers
+      sm:  '10px',    // rail url, axis labels, severity chips
+      md:  '11.5px',  // rail label, segment labels
+      lg:  '14px',    // rail metric, sub-metric numbers
+      xl:  '18px',    // verdict title
+      xxl: '32px',    // overview triptych values
+    },
+    tracking: {
+      kicker: '0.18em',
+      label:  '0.08em',
+      body:   '0',
+    },
   },
 
   spacing: {
@@ -307,6 +384,12 @@ export const tokens = {
     dotExit:         150,
     loadingPulse:         2400,
     loadingRingDuration:  1800,
+
+    // v2 motion primitives.
+    handLerp:     0.15,   // dial hand smoothing factor (per-frame)
+    pulseRim:      400,   // ms — dial rim pulse on threshold cross
+    orbitPulse:   1400,   // ms — orbit pip pulse when over threshold
+    traceRepaint:   16,   // ms — scope canvas repaint throttle
   },
 
   easing: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -160,6 +160,16 @@ export interface EndpointStatistics {
     ttfb: number;
     contentTransfer: number;
   };
+  // Per-phase p95 — fed by the same cadence as tier2Averages. Needed for
+  // Atlas view's P50/P95 toggle. Optional to mirror tier2Averages semantics
+  // (absent when no tier-2 samples have been captured yet).
+  readonly tier2P95?: {
+    dnsLookup: number;
+    tcpConnect: number;
+    tlsHandshake: number;
+    ttfb: number;
+    contentTransfer: number;
+  };
   readonly ready: boolean;
 }
 
@@ -174,6 +184,10 @@ export interface Settings {
   cap: number;
   corsMode: 'no-cors' | 'cors';
   region?: Region;
+  // Latency alarm threshold in ms — distinct from `timeout` (which is the hard
+  // request abort). Drives classify()/networkQuality() and the chronograph dial.
+  // Must be strictly less than `timeout`; callers enforce.
+  healthThreshold: number;
 }
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -183,10 +197,35 @@ export const DEFAULT_SETTINGS: Settings = {
   monitorDelay: 1000,
   cap: 0,
   corsMode: 'no-cors',
+  healthThreshold: 120,
 };
 
 // ── UI store ───────────────────────────────────────────────────────────────
-export type ActiveView = 'timeline' | 'heatmap' | 'split';
+// v2 view union. Old labels ('timeline' | 'heatmap' | 'split') are kept so
+// persisted settings can round-trip through migration; they're rewritten to
+// 'lanes' by the v4→v5 migration in persistence.ts.
+export type ActiveView =
+  | 'overview'
+  | 'live'
+  | 'atlas'
+  | 'strata'
+  | 'terminal'
+  | 'lanes'
+  | 'timeline'
+  | 'heatmap'
+  | 'split';
+
+export type LiveTimeRange = '1m' | '5m' | '15m' | '1h' | '24h';
+
+export type TerminalEventType =
+  | 'timeout'
+  | 'error'
+  | 'threshold_up'
+  | 'threshold_down'
+  | 'freeze'
+  | 'endpoint_added'
+  | 'endpoint_removed'
+  | 'reuse_change';
 
 export interface HoverTarget {
   readonly endpointId: string;
@@ -213,6 +252,20 @@ export interface UIState {
   laneHoverY: number | null;
   heatmapTooltip: { text: string; x: number; y: number } | null;
   showEndpoints: boolean;
+
+  // Globally focused endpoint — drives rail selection and per-view focus.
+  // null = unfocused (rail shows aggregate). Persisted across sessions; on
+  // rehydration the id is cleared silently if the endpoint no longer exists.
+  focusedEndpointId: string | null;
+
+  // Live view layout options (split scopes vs unified overlay + window).
+  liveOptions: {
+    split: boolean;
+    timeRange: LiveTimeRange;
+  };
+
+  // Terminal view filter set. Empty = show all event types.
+  terminalFilters: Set<TerminalEventType>;
 }
 
 // ── Lane hover ─────────────────────────────────────────────────────────────
@@ -256,13 +309,22 @@ export interface SharePayload {
 }
 
 // ── Persistence schema ─────────────────────────────────────────────────────
+// v5 adds `healthThreshold` (settings) and `focusedEndpointId`, `liveOptions`,
+// `terminalFilters` (ui). Older versions migrate forward via persistence.ts.
+// Sets serialize as arrays on disk; `ui.terminalFilters` round-trips accordingly.
 export interface PersistedSettings {
-  version: 2 | 3 | 4;
+  version: 2 | 3 | 4 | 5;
   endpoints: { url: string; enabled: boolean }[];
   settings: Settings;
   ui: {
     expandedCards: string[];
     activeView: ActiveView;
+    focusedEndpointId?: string | null;
+    liveOptions?: {
+      split: boolean;
+      timeRange: LiveTimeRange;
+    };
+    terminalFilters?: TerminalEventType[];
   };
 }
 

--- a/src/lib/utils/apply-persisted-settings.ts
+++ b/src/lib/utils/apply-persisted-settings.ts
@@ -2,6 +2,9 @@
 // Applies a loaded PersistedSettings payload to the runtime stores.
 // Always replaces the endpoint store (including with empty array) so persisted
 // state — including explicit "no endpoints" — is faithfully restored.
+//
+// Shape migration belongs in persistence.ts; this file only hydrates the runtime
+// stores from an already-shaped v5 payload.
 
 import { get } from 'svelte/store';
 import { endpointStore } from '../stores/endpoints';
@@ -31,6 +34,28 @@ export function applyPersistedSettings(persisted: PersistedSettings): void {
   for (const cardId of persisted.ui.expandedCards) {
     if (!get(uiStore).expandedCards.has(cardId)) {
       uiStore.toggleCard(cardId);
+    }
+  }
+
+  // v5: focusedEndpointId — drop silently if the id no longer resolves, since
+  // the user may have deleted that endpoint between sessions.
+  const storedFocus = persisted.ui.focusedEndpointId ?? null;
+  if (storedFocus !== null) {
+    const exists = get(endpointStore).some((e) => e.id === storedFocus);
+    uiStore.setFocusedEndpoint(exists ? storedFocus : null);
+  }
+
+  // v5: liveOptions
+  if (persisted.ui.liveOptions) {
+    uiStore.setLiveSplit(persisted.ui.liveOptions.split);
+    uiStore.setLiveTimeRange(persisted.ui.liveOptions.timeRange);
+  }
+
+  // v5: terminalFilters (serialized as array → runtime Set)
+  if (persisted.ui.terminalFilters && persisted.ui.terminalFilters.length > 0) {
+    uiStore.clearTerminalFilters();
+    for (const type of persisted.ui.terminalFilters) {
+      uiStore.toggleTerminalFilter(type);
     }
   }
 }

--- a/src/lib/utils/classify.ts
+++ b/src/lib/utils/classify.ts
@@ -1,0 +1,90 @@
+// src/lib/utils/classify.ts
+// Health classification for endpoint latency. Pure functions — single source of
+// truth so the chronograph dial, rail pip color, and causal verdict cannot drift
+// apart. No store imports; callers pass stats + threshold explicitly.
+
+import type { EndpointStatistics } from '../types';
+
+export type HealthBucket = 'healthy' | 'degraded' | 'unhealthy' | 'unknown';
+
+export interface HealthStyle {
+  readonly color: string;
+  readonly glow:  string;
+  readonly label: string;
+  readonly tone:  string;
+}
+
+// CSS custom property names bridged from tokens.ts via App.svelte#bridgeTokensToCss.
+// All callers render through var(--…) so dark-mode / future theming stays live.
+export const HEALTH_STYLES: Record<HealthBucket, HealthStyle> = {
+  healthy: {
+    color: 'var(--accent-cyan)',
+    glow:  'var(--accent-cyan-glow)',
+    label: 'Healthy',
+    tone:  'var(--accent-cyan-tone)',
+  },
+  degraded: {
+    color: 'var(--accent-amber)',
+    glow:  'var(--accent-amber-glow)',
+    label: 'Degraded',
+    tone:  'var(--accent-amber-tone)',
+  },
+  unhealthy: {
+    color: 'var(--accent-pink)',
+    glow:  'var(--accent-pink-glow)',
+    label: 'Unhealthy',
+    tone:  'var(--accent-pink-tone)',
+  },
+  unknown: {
+    color: 'var(--t4)',
+    glow:  'transparent',
+    label: 'No data',
+    tone:  'var(--t4)',
+  },
+};
+
+/**
+ * Classify an endpoint's current health from its rolling statistics.
+ *
+ *   healthy:   p95 ≤ threshold AND p50 ≤ threshold/2
+ *   degraded:  p95 ≤ 2×threshold OR p50 ≤ threshold  (but not healthy)
+ *   unhealthy: everything worse
+ *   unknown:   stats missing or not yet ready
+ */
+export function classify(
+  stats: EndpointStatistics | null | undefined,
+  threshold: number,
+): HealthBucket {
+  if (!stats || !stats.ready) return 'unknown';
+
+  const p50 = Number.isFinite(stats.p50) ? stats.p50 : Infinity;
+  const p95 = Number.isFinite(stats.p95) ? stats.p95 : Infinity;
+
+  if (p95 <= threshold && p50 <= threshold / 2) return 'healthy';
+  if (p95 <= threshold * 2 || p50 <= threshold) return 'degraded';
+  return 'unhealthy';
+}
+
+/**
+ * Aggregate network health as a 0–100 score. Not-ready endpoints are excluded
+ * from the denominator rather than dragging the score toward zero.
+ *
+ *   healthy   → 100
+ *   degraded  →  60
+ *   unhealthy →  20
+ *   all not-ready → null
+ */
+export function networkQuality(
+  stats: readonly (EndpointStatistics | null | undefined)[],
+  threshold: number,
+): number | null {
+  const ready = stats.filter((s): s is EndpointStatistics => Boolean(s && s.ready));
+  if (ready.length === 0) return null;
+
+  let total = 0;
+  for (const s of ready) {
+    const bucket = classify(s, threshold);
+    total += bucket === 'healthy' ? 100 : bucket === 'degraded' ? 60 : 20;
+  }
+  return Math.round(total / ready.length);
+}

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -1,0 +1,59 @@
+// src/lib/utils/format.ts
+// Pure formatting helpers for latency, counts, and ratios.
+// Single source of truth for on-screen numeric displays across the v2 views —
+// every rendered ms/count/percent routes through these so tabular numerals and
+// precision rules stay consistent. No store imports, no side effects.
+
+/**
+ * Format a latency value in milliseconds for display.
+ *
+ *   fmt(0.43)    → "0.43"
+ *   fmt(9.87)    → "9.9"
+ *   fmt(127.4)   → "127"
+ *   fmt(1234)    → "1,234"
+ *   fmt(12500)   → "12.5s"
+ *   fmt(null)    → "—"
+ *   fmt(-1)      → "—"   (non-finite/negative renders as no-data)
+ */
+export function fmt(ms: number | null | undefined): string {
+  if (ms == null || !Number.isFinite(ms) || ms < 0) return '—';
+  if (ms < 1) return ms.toFixed(2);
+  if (ms < 10) return ms.toFixed(1);
+  if (ms < 10000) return Math.round(ms).toLocaleString();
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+/**
+ * Split a latency into numeric part and unit label — for layouts where the
+ * number and unit style independently (rail metric, overview triptych).
+ *
+ *   fmtParts(127.4)  → { num: "127",  unit: "ms" }
+ *   fmtParts(12500)  → { num: "12.5", unit: "s"  }
+ *   fmtParts(null)   → { num: "—",    unit: ""   }
+ */
+export function fmtParts(ms: number | null | undefined): { num: string; unit: string } {
+  if (ms == null || !Number.isFinite(ms) || ms < 0) return { num: '—', unit: '' };
+  if (ms < 10000) return { num: fmt(ms), unit: 'ms' };
+  return { num: (ms / 1000).toFixed(1), unit: 's' };
+}
+
+/**
+ * Format a 0–1 ratio (or slight overshoot) as a rounded integer percent.
+ *
+ *   fmtPct(0.5)    → "50%"
+ *   fmtPct(0.996)  → "100%"
+ *   fmtPct(1.234)  → "123%"
+ */
+export function fmtPct(ratio: number): string {
+  return `${Math.round(ratio * 100)}%`;
+}
+
+/**
+ * Format an integer count with a locale-aware thousands separator.
+ *
+ *   fmtCount(1234)    → "1,234"
+ *   fmtCount(1000000) → "1,000,000"
+ */
+export function fmtCount(n: number): string {
+  return n.toLocaleString();
+}

--- a/src/lib/utils/persistence.ts
+++ b/src/lib/utils/persistence.ts
@@ -1,14 +1,42 @@
 // src/lib/utils/persistence.ts
 // Versioned localStorage persistence with forward-only migration support.
+//
+// Migration chain: v1 → v2 → v3 → v4 → v5 (current). Each normalizeVN shapes a
+// payload at version N; migrateSettings threads older payloads through the
+// chain up to CURRENT_VERSION. Never re-read a newer version in an older build.
 
 import { DEFAULT_SETTINGS } from '../types';
 import { detectRegion, isValidRegion } from '../regional-defaults';
-import type { PersistedSettings, ActiveView } from '../types';
+import type {
+  ActiveView,
+  LiveTimeRange,
+  PersistedSettings,
+  Settings,
+  TerminalEventType,
+} from '../types';
 import type { Region } from '../regional-defaults';
 
 const STORAGE_KEY = 'chronoscope_settings'; // skipcq: JS-0860 — localStorage key, not a credential
 const LEGACY_STORAGE_KEY = 'chronoscope_v2_settings'; // skipcq: JS-0860 — localStorage key, not a credential
-const CURRENT_VERSION = 4;
+const CURRENT_VERSION = 5;
+
+// v2-era labels that v5 rewrites to 'lanes' (the legacy escape hatch).
+const LEGACY_VIEWS: ReadonlySet<string> = new Set(['timeline', 'heatmap', 'split']);
+
+const V5_VIEWS: ReadonlySet<ActiveView> = new Set<ActiveView>([
+  'overview', 'live', 'atlas', 'strata', 'terminal', 'lanes',
+  // Deprecated but still valid on the union until Phase 7 removes them.
+  'timeline', 'heatmap', 'split',
+]);
+
+const V5_TIME_RANGES: ReadonlySet<LiveTimeRange> = new Set<LiveTimeRange>([
+  '1m', '5m', '15m', '1h', '24h',
+]);
+
+const V5_TERMINAL_EVENTS: ReadonlySet<TerminalEventType> = new Set<TerminalEventType>([
+  'timeout', 'error', 'threshold_up', 'threshold_down',
+  'freeze', 'endpoint_added', 'endpoint_removed', 'reuse_change',
+]);
 
 export function loadPersistedSettings(): PersistedSettings | null {
   try {
@@ -48,21 +76,22 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
   const record = data as Record<string, unknown>;
   const version = typeof record['version'] === 'number' ? record['version'] : 0;
 
-  if (version === CURRENT_VERSION) {
-    return normalizeV4(record);
+  if (version === CURRENT_VERSION) return normalizeV5(record);
+
+  if (version === 4) {
+    const v4 = normalizeV4(record);
+    return v4 ? stepV4toV5(v4, record) : null;
   }
 
   if (version === 3) {
     const v3 = normalizeV3(record);
     if (!v3) return null;
-    return {
+    const v4: PersistedSettings = {
       ...v3,
       version: 4,
-      settings: {
-        ...v3.settings,
-        region: detectRegion(),
-      },
+      settings: { ...v3.settings, region: detectRegion() },
     };
+    return stepV4toV5(v4, record);
   }
 
   if (version === 2) {
@@ -79,14 +108,12 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
         monitorDelay: oldDelay >= 0 ? oldDelay : DEFAULT_SETTINGS.monitorDelay,
       },
     };
-    return {
+    const v4: PersistedSettings = {
       ...v3,
       version: 4,
-      settings: {
-        ...v3.settings,
-        region: detectRegion(),
-      },
+      settings: { ...v3.settings, region: detectRegion() },
     };
+    return stepV4toV5(v4, record);
   }
 
   if (version === 1) {
@@ -98,22 +125,175 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
         enabled: typeof e['enabled'] === 'boolean' ? e['enabled'] : true,
       }));
 
-    return {
+    const v4: PersistedSettings = {
       version: 4,
       endpoints,
       settings: { ...DEFAULT_SETTINGS, region: detectRegion() },
-      ui: {
-        expandedCards: [],
-        activeView: 'split' as ActiveView,
-      },
+      ui: { expandedCards: [], activeView: 'split' as ActiveView },
     };
+    return stepV4toV5(v4, record);
   }
 
-  // Unknown version — return null (triggers first-install path).
-  // Spec §5: we deliberately do NOT coerce unknown versions through normalizeV4,
-  // because that silently drops shape changes to existing fields.
+  // Unknown version — return null (triggers first-install path). We deliberately
+  // do NOT coerce through the current normalizer; that would silently drop
+  // future shape changes we don't understand yet.
   return null;
 }
+
+// ── v4 → v5 step ─────────────────────────────────────────────────────────────
+// Seeds healthThreshold + new UI fields, rewrites deprecated activeView values
+// to 'lanes', and coerces unknown activeView strings to the v5 default.
+function stepV4toV5(v4: PersistedSettings, rawRecord: Record<string, unknown>): PersistedSettings {
+  const rawUi =
+    rawRecord['ui'] !== null && typeof rawRecord['ui'] === 'object'
+      ? (rawRecord['ui'] as Record<string, unknown>)
+      : {};
+
+  // activeView: read from the raw payload so normalizeV4's 'split' fallback
+  // doesn't mask unknown strings — those should become the v5 default
+  // ('overview'), not be silently rewritten to 'lanes'.
+  const rawView = typeof rawUi['activeView'] === 'string' ? rawUi['activeView'] : '';
+  const activeView: ActiveView = LEGACY_VIEWS.has(rawView)
+    ? 'lanes'
+    : V5_VIEWS.has(rawView as ActiveView)
+      ? (rawView as ActiveView)
+      : 'overview';
+
+  // focusedEndpointId — v4 never had this. Accept a string if present; else null.
+  const rawFocus = rawUi['focusedEndpointId'];
+  const focusedEndpointId = typeof rawFocus === 'string' ? rawFocus : null;
+
+  // liveOptions — seed defaults. Accept well-typed partial if present.
+  const rawLiveOpts =
+    rawUi['liveOptions'] !== null && typeof rawUi['liveOptions'] === 'object'
+      ? (rawUi['liveOptions'] as Record<string, unknown>)
+      : undefined;
+  const split =
+    rawLiveOpts && typeof rawLiveOpts['split'] === 'boolean' ? rawLiveOpts['split'] : false;
+  const timeRangeCandidate = rawLiveOpts?.['timeRange'];
+  const timeRange: LiveTimeRange =
+    typeof timeRangeCandidate === 'string' && V5_TIME_RANGES.has(timeRangeCandidate as LiveTimeRange)
+      ? (timeRangeCandidate as LiveTimeRange)
+      : '5m';
+
+  // terminalFilters — seed empty array; filter any unknown entries.
+  const rawFilters = Array.isArray(rawUi['terminalFilters']) ? rawUi['terminalFilters'] : [];
+  const terminalFilters = (rawFilters as unknown[]).filter(
+    (x): x is TerminalEventType => typeof x === 'string' && V5_TERMINAL_EVENTS.has(x as TerminalEventType),
+  );
+
+  return {
+    version: 5,
+    endpoints: v4.endpoints,
+    settings: {
+      ...v4.settings,
+      healthThreshold:
+        typeof v4.settings.healthThreshold === 'number'
+          ? v4.settings.healthThreshold
+          : DEFAULT_SETTINGS.healthThreshold,
+    },
+    ui: {
+      expandedCards: v4.ui.expandedCards,
+      activeView,
+      focusedEndpointId,
+      liveOptions: { split, timeRange },
+      terminalFilters,
+    },
+  };
+}
+
+// ── v5 normalizer ────────────────────────────────────────────────────────────
+function normalizeV5(record: Record<string, unknown>): PersistedSettings | null {
+  try {
+    const rawEndpoints = Array.isArray(record['endpoints']) ? record['endpoints'] : [];
+    const endpoints = rawEndpoints
+      .filter((e): e is Record<string, unknown> => e !== null && typeof e === 'object')
+      .map((e) => ({
+        url: typeof e['url'] === 'string' ? e['url'] : '',
+        enabled: typeof e['enabled'] === 'boolean' ? e['enabled'] : true,
+      }));
+
+    const rawSettings =
+      record['settings'] !== null && typeof record['settings'] === 'object'
+        ? (record['settings'] as Record<string, unknown>)
+        : {};
+
+    const rawRegion: unknown = rawSettings['region'];
+    const region: Region | undefined = isValidRegion(rawRegion) ? rawRegion : undefined;
+
+    const settings: Settings = {
+      timeout: typeof rawSettings['timeout'] === 'number' ? rawSettings['timeout'] : DEFAULT_SETTINGS.timeout,
+      delay: typeof rawSettings['delay'] === 'number' ? rawSettings['delay'] : DEFAULT_SETTINGS.delay,
+      burstRounds: typeof rawSettings['burstRounds'] === 'number' ? rawSettings['burstRounds'] : DEFAULT_SETTINGS.burstRounds,
+      monitorDelay: typeof rawSettings['monitorDelay'] === 'number' ? rawSettings['monitorDelay'] : DEFAULT_SETTINGS.monitorDelay,
+      cap: typeof rawSettings['cap'] === 'number' ? rawSettings['cap'] : DEFAULT_SETTINGS.cap,
+      corsMode:
+        rawSettings['corsMode'] === 'cors' || rawSettings['corsMode'] === 'no-cors'
+          ? rawSettings['corsMode']
+          : DEFAULT_SETTINGS.corsMode,
+      healthThreshold:
+        typeof rawSettings['healthThreshold'] === 'number'
+          ? rawSettings['healthThreshold']
+          : DEFAULT_SETTINGS.healthThreshold,
+      ...(region !== undefined ? { region } : {}),
+    };
+
+    const rawUi =
+      record['ui'] !== null && typeof record['ui'] === 'object'
+        ? (record['ui'] as Record<string, unknown>)
+        : {};
+
+    const expandedCards = Array.isArray(rawUi['expandedCards'])
+      ? (rawUi['expandedCards'] as unknown[]).filter((x): x is string => typeof x === 'string')
+      : [];
+
+    const rawView = rawUi['activeView'];
+    const activeView: ActiveView =
+      typeof rawView === 'string' && V5_VIEWS.has(rawView as ActiveView)
+        ? (rawView as ActiveView)
+        : 'overview';
+
+    const rawFocus = rawUi['focusedEndpointId'];
+    const focusedEndpointId = typeof rawFocus === 'string' ? rawFocus : null;
+
+    const rawLiveOpts =
+      rawUi['liveOptions'] !== null && typeof rawUi['liveOptions'] === 'object'
+        ? (rawUi['liveOptions'] as Record<string, unknown>)
+        : undefined;
+    const split =
+      rawLiveOpts && typeof rawLiveOpts['split'] === 'boolean' ? rawLiveOpts['split'] : false;
+    const timeRangeCandidate = rawLiveOpts?.['timeRange'];
+    const timeRange: LiveTimeRange =
+      typeof timeRangeCandidate === 'string' && V5_TIME_RANGES.has(timeRangeCandidate as LiveTimeRange)
+        ? (timeRangeCandidate as LiveTimeRange)
+        : '5m';
+
+    const rawFilters = Array.isArray(rawUi['terminalFilters']) ? rawUi['terminalFilters'] : [];
+    const terminalFilters = (rawFilters as unknown[]).filter(
+      (x): x is TerminalEventType => typeof x === 'string' && V5_TERMINAL_EVENTS.has(x as TerminalEventType),
+    );
+
+    return {
+      version: 5,
+      endpoints,
+      settings,
+      ui: {
+        expandedCards,
+        activeView,
+        focusedEndpointId,
+        liveOptions: { split, timeRange },
+        terminalFilters,
+      },
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ── Legacy normalizers (v2/v3/v4) ────────────────────────────────────────────
+// Each produces a payload tagged with its own version; migrateSettings threads
+// them forward. healthThreshold defaults are seeded here so downstream steps
+// can treat Settings as fully-formed.
 
 function normalizeV2(record: Record<string, unknown>): PersistedSettings | null {
   try {
@@ -130,7 +310,7 @@ function normalizeV2(record: Record<string, unknown>): PersistedSettings | null 
         ? (record['settings'] as Record<string, unknown>)
         : {};
 
-    const settings = {
+    const settings: Settings = {
       timeout: typeof rawSettings['timeout'] === 'number' ? rawSettings['timeout'] : DEFAULT_SETTINGS.timeout,
       delay: typeof rawSettings['delay'] === 'number' ? rawSettings['delay'] : DEFAULT_SETTINGS.delay,
       burstRounds: DEFAULT_SETTINGS.burstRounds,
@@ -140,6 +320,7 @@ function normalizeV2(record: Record<string, unknown>): PersistedSettings | null 
         rawSettings['corsMode'] === 'cors' || rawSettings['corsMode'] === 'no-cors'
           ? rawSettings['corsMode']
           : DEFAULT_SETTINGS.corsMode,
+      healthThreshold: DEFAULT_SETTINGS.healthThreshold,
     };
 
     const rawUi =
@@ -177,7 +358,7 @@ function normalizeV3(record: Record<string, unknown>): PersistedSettings | null 
         ? (record['settings'] as Record<string, unknown>)
         : {};
 
-    const settings = {
+    const settings: Settings = {
       timeout: typeof rawSettings['timeout'] === 'number' ? rawSettings['timeout'] : DEFAULT_SETTINGS.timeout,
       delay: typeof rawSettings['delay'] === 'number' ? rawSettings['delay'] : DEFAULT_SETTINGS.delay,
       burstRounds: typeof rawSettings['burstRounds'] === 'number' ? rawSettings['burstRounds'] : DEFAULT_SETTINGS.burstRounds,
@@ -187,6 +368,7 @@ function normalizeV3(record: Record<string, unknown>): PersistedSettings | null 
         rawSettings['corsMode'] === 'cors' || rawSettings['corsMode'] === 'no-cors'
           ? rawSettings['corsMode']
           : DEFAULT_SETTINGS.corsMode,
+      healthThreshold: DEFAULT_SETTINGS.healthThreshold,
     };
 
     const rawUi =
@@ -227,7 +409,7 @@ function normalizeV4(record: Record<string, unknown>): PersistedSettings | null 
     const rawRegion: unknown = rawSettings['region'];
     const region: Region | undefined = isValidRegion(rawRegion) ? rawRegion : undefined;
 
-    const settings = {
+    const settings: Settings = {
       timeout: typeof rawSettings['timeout'] === 'number' ? rawSettings['timeout'] : DEFAULT_SETTINGS.timeout,
       delay: typeof rawSettings['delay'] === 'number' ? rawSettings['delay'] : DEFAULT_SETTINGS.delay,
       burstRounds: typeof rawSettings['burstRounds'] === 'number' ? rawSettings['burstRounds'] : DEFAULT_SETTINGS.burstRounds,
@@ -237,6 +419,11 @@ function normalizeV4(record: Record<string, unknown>): PersistedSettings | null 
         rawSettings['corsMode'] === 'cors' || rawSettings['corsMode'] === 'no-cors'
           ? rawSettings['corsMode']
           : DEFAULT_SETTINGS.corsMode,
+      // v4 storage never wrote healthThreshold; default is seeded forward.
+      healthThreshold:
+        typeof rawSettings['healthThreshold'] === 'number'
+          ? rawSettings['healthThreshold']
+          : DEFAULT_SETTINGS.healthThreshold,
       ...(region !== undefined ? { region } : {}),
     };
 

--- a/src/lib/utils/persistence.ts
+++ b/src/lib/utils/persistence.ts
@@ -203,86 +203,91 @@ function stepV4toV5(v4: PersistedSettings, rawRecord: Record<string, unknown>): 
 }
 
 // ── v5 normalizer ────────────────────────────────────────────────────────────
+// normalizeV5 is a linear assembly of per-field helpers so the function itself
+// stays under the CC threshold DeepSource flags. Each helper is file-local and
+// exercised end-to-end through the normalizeV5 tests; they're the narrow,
+// type-aware extractors that insulate the main function from validation noise.
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' ? (value as Record<string, unknown>) : null;
+}
+
+function readEndpointsField(record: Record<string, unknown>): { url: string; enabled: boolean }[] {
+  const raw = Array.isArray(record['endpoints']) ? record['endpoints'] : [];
+  return raw
+    .filter((e): e is Record<string, unknown> => asRecord(e) !== null)
+    .map((e) => ({
+      url: typeof e['url'] === 'string' ? e['url'] : '',
+      enabled: typeof e['enabled'] === 'boolean' ? e['enabled'] : true,
+    }));
+}
+
+function readSettingsField(record: Record<string, unknown>): Settings {
+  const raw = asRecord(record['settings']) ?? {};
+  const region: Region | undefined = isValidRegion(raw['region']) ? raw['region'] : undefined;
+  const corsMode =
+    raw['corsMode'] === 'cors' || raw['corsMode'] === 'no-cors'
+      ? raw['corsMode']
+      : DEFAULT_SETTINGS.corsMode;
+  return {
+    timeout:         typeof raw['timeout']         === 'number' ? raw['timeout']         : DEFAULT_SETTINGS.timeout,
+    delay:           typeof raw['delay']           === 'number' ? raw['delay']           : DEFAULT_SETTINGS.delay,
+    burstRounds:     typeof raw['burstRounds']     === 'number' ? raw['burstRounds']     : DEFAULT_SETTINGS.burstRounds,
+    monitorDelay:    typeof raw['monitorDelay']    === 'number' ? raw['monitorDelay']    : DEFAULT_SETTINGS.monitorDelay,
+    cap:             typeof raw['cap']             === 'number' ? raw['cap']             : DEFAULT_SETTINGS.cap,
+    healthThreshold: typeof raw['healthThreshold'] === 'number' ? raw['healthThreshold'] : DEFAULT_SETTINGS.healthThreshold,
+    corsMode,
+    ...(region !== undefined ? { region } : {}),
+  };
+}
+
+function readExpandedCards(rawUi: Record<string, unknown>): string[] {
+  return Array.isArray(rawUi['expandedCards'])
+    ? (rawUi['expandedCards'] as unknown[]).filter((x): x is string => typeof x === 'string')
+    : [];
+}
+
+function readActiveView(rawUi: Record<string, unknown>): ActiveView {
+  const raw = rawUi['activeView'];
+  if (typeof raw === 'string' && V5_VIEWS.has(raw as ActiveView)) return raw as ActiveView;
+  return 'overview';
+}
+
+function readFocusedEndpointId(rawUi: Record<string, unknown>): string | null {
+  return typeof rawUi['focusedEndpointId'] === 'string' ? rawUi['focusedEndpointId'] : null;
+}
+
+function readLiveOptions(rawUi: Record<string, unknown>): { split: boolean; timeRange: LiveTimeRange } {
+  const raw = asRecord(rawUi['liveOptions']);
+  const split = raw !== null && typeof raw['split'] === 'boolean' ? raw['split'] : false;
+  const candidate = raw?.['timeRange'];
+  const timeRange: LiveTimeRange =
+    typeof candidate === 'string' && V5_TIME_RANGES.has(candidate as LiveTimeRange)
+      ? (candidate as LiveTimeRange)
+      : '5m';
+  return { split, timeRange };
+}
+
+function readTerminalFilters(rawUi: Record<string, unknown>): TerminalEventType[] {
+  const raw = Array.isArray(rawUi['terminalFilters']) ? rawUi['terminalFilters'] : [];
+  return (raw as unknown[]).filter(
+    (x): x is TerminalEventType => typeof x === 'string' && V5_TERMINAL_EVENTS.has(x as TerminalEventType),
+  );
+}
+
 function normalizeV5(record: Record<string, unknown>): PersistedSettings | null {
   try {
-    const rawEndpoints = Array.isArray(record['endpoints']) ? record['endpoints'] : [];
-    const endpoints = rawEndpoints
-      .filter((e): e is Record<string, unknown> => e !== null && typeof e === 'object')
-      .map((e) => ({
-        url: typeof e['url'] === 'string' ? e['url'] : '',
-        enabled: typeof e['enabled'] === 'boolean' ? e['enabled'] : true,
-      }));
-
-    const rawSettings =
-      record['settings'] !== null && typeof record['settings'] === 'object'
-        ? (record['settings'] as Record<string, unknown>)
-        : {};
-
-    const rawRegion: unknown = rawSettings['region'];
-    const region: Region | undefined = isValidRegion(rawRegion) ? rawRegion : undefined;
-
-    const settings: Settings = {
-      timeout: typeof rawSettings['timeout'] === 'number' ? rawSettings['timeout'] : DEFAULT_SETTINGS.timeout,
-      delay: typeof rawSettings['delay'] === 'number' ? rawSettings['delay'] : DEFAULT_SETTINGS.delay,
-      burstRounds: typeof rawSettings['burstRounds'] === 'number' ? rawSettings['burstRounds'] : DEFAULT_SETTINGS.burstRounds,
-      monitorDelay: typeof rawSettings['monitorDelay'] === 'number' ? rawSettings['monitorDelay'] : DEFAULT_SETTINGS.monitorDelay,
-      cap: typeof rawSettings['cap'] === 'number' ? rawSettings['cap'] : DEFAULT_SETTINGS.cap,
-      corsMode:
-        rawSettings['corsMode'] === 'cors' || rawSettings['corsMode'] === 'no-cors'
-          ? rawSettings['corsMode']
-          : DEFAULT_SETTINGS.corsMode,
-      healthThreshold:
-        typeof rawSettings['healthThreshold'] === 'number'
-          ? rawSettings['healthThreshold']
-          : DEFAULT_SETTINGS.healthThreshold,
-      ...(region !== undefined ? { region } : {}),
-    };
-
-    const rawUi =
-      record['ui'] !== null && typeof record['ui'] === 'object'
-        ? (record['ui'] as Record<string, unknown>)
-        : {};
-
-    const expandedCards = Array.isArray(rawUi['expandedCards'])
-      ? (rawUi['expandedCards'] as unknown[]).filter((x): x is string => typeof x === 'string')
-      : [];
-
-    const rawView = rawUi['activeView'];
-    const activeView: ActiveView =
-      typeof rawView === 'string' && V5_VIEWS.has(rawView as ActiveView)
-        ? (rawView as ActiveView)
-        : 'overview';
-
-    const rawFocus = rawUi['focusedEndpointId'];
-    const focusedEndpointId = typeof rawFocus === 'string' ? rawFocus : null;
-
-    const rawLiveOpts =
-      rawUi['liveOptions'] !== null && typeof rawUi['liveOptions'] === 'object'
-        ? (rawUi['liveOptions'] as Record<string, unknown>)
-        : undefined;
-    const split =
-      rawLiveOpts && typeof rawLiveOpts['split'] === 'boolean' ? rawLiveOpts['split'] : false;
-    const timeRangeCandidate = rawLiveOpts?.['timeRange'];
-    const timeRange: LiveTimeRange =
-      typeof timeRangeCandidate === 'string' && V5_TIME_RANGES.has(timeRangeCandidate as LiveTimeRange)
-        ? (timeRangeCandidate as LiveTimeRange)
-        : '5m';
-
-    const rawFilters = Array.isArray(rawUi['terminalFilters']) ? rawUi['terminalFilters'] : [];
-    const terminalFilters = (rawFilters as unknown[]).filter(
-      (x): x is TerminalEventType => typeof x === 'string' && V5_TERMINAL_EVENTS.has(x as TerminalEventType),
-    );
-
+    const rawUi = asRecord(record['ui']) ?? {};
     return {
       version: 5,
-      endpoints,
-      settings,
+      endpoints: readEndpointsField(record),
+      settings: readSettingsField(record),
       ui: {
-        expandedCards,
-        activeView,
-        focusedEndpointId,
-        liveOptions: { split, timeRange },
-        terminalFilters,
+        expandedCards:     readExpandedCards(rawUi),
+        activeView:        readActiveView(rawUi),
+        focusedEndpointId: readFocusedEndpointId(rawUi),
+        liveOptions:       readLiveOptions(rawUi),
+        terminalFilters:   readTerminalFilters(rawUi),
       },
     };
   } catch {

--- a/src/lib/utils/statistics.ts
+++ b/src/lib/utils/statistics.ts
@@ -129,11 +129,17 @@ export function computeEndpointStatistics(
     }
   }
 
-  // ── Tier 2 averages ───────────────────────────────────────────────────
+  // ── Tier 2 averages + p95 ─────────────────────────────────────────────
   let tier2Averages: EndpointStatistics['tier2Averages'];
+  let tier2P95:      EndpointStatistics['tier2P95'];
   if (tier2Samples.length > 0) {
     const avg = (field: 'dnsLookup' | 'tcpConnect' | 'tlsHandshake' | 'ttfb' | 'contentTransfer') =>
       tier2Samples.reduce((sum, s) => sum + s.tier2[field], 0) / tier2Samples.length;
+
+    const p95Of = (field: 'dnsLookup' | 'tcpConnect' | 'tlsHandshake' | 'ttfb' | 'contentTransfer') => {
+      const sortedField = tier2Samples.map(s => s.tier2[field]).sort((a, b) => a - b);
+      return percentileSorted(sortedField, 95);
+    };
 
     tier2Averages = {
       dnsLookup: avg('dnsLookup'),
@@ -141,6 +147,13 @@ export function computeEndpointStatistics(
       tlsHandshake: avg('tlsHandshake'),
       ttfb: avg('ttfb'),
       contentTransfer: avg('contentTransfer'),
+    };
+    tier2P95 = {
+      dnsLookup: p95Of('dnsLookup'),
+      tcpConnect: p95Of('tcpConnect'),
+      tlsHandshake: p95Of('tlsHandshake'),
+      ttfb: p95Of('ttfb'),
+      contentTransfer: p95Of('contentTransfer'),
     };
   }
 
@@ -153,6 +166,7 @@ export function computeEndpointStatistics(
     ci95,
     connectionReuseDelta,
     tier2Averages,
+    tier2P95,
     ready,
   };
 }
@@ -230,11 +244,19 @@ export function computeEndpointStatisticsFromBuffer(
     }
   }
 
-  // ── Tier 2 averages ───────────────────────────────────────────────────
+  // ── Tier 2 averages + p95 ─────────────────────────────────────────────
   let tier2Averages: EndpointStatistics['tier2Averages'];
+  let tier2P95:      EndpointStatistics['tier2P95'];
   if (tier2Samples.length > 0) {
     const avg = (field: 'dnsLookup' | 'tcpConnect' | 'tlsHandshake' | 'ttfb' | 'contentTransfer') =>
       tier2Samples.reduce((accum, sample) => accum + (sample.tier2?.[field] ?? 0), 0) / tier2Samples.length;
+
+    const p95Of = (field: 'dnsLookup' | 'tcpConnect' | 'tlsHandshake' | 'ttfb' | 'contentTransfer') => {
+      const sortedField = tier2Samples
+        .map(s => s.tier2?.[field] ?? 0)
+        .sort((a, b) => a - b);
+      return percentileSorted(sortedField, 95);
+    };
 
     tier2Averages = {
       dnsLookup: avg('dnsLookup'),
@@ -242,6 +264,13 @@ export function computeEndpointStatisticsFromBuffer(
       tlsHandshake: avg('tlsHandshake'),
       ttfb: avg('ttfb'),
       contentTransfer: avg('contentTransfer'),
+    };
+    tier2P95 = {
+      dnsLookup: p95Of('dnsLookup'),
+      tcpConnect: p95Of('tcpConnect'),
+      tlsHandshake: p95Of('tlsHandshake'),
+      ttfb: p95Of('ttfb'),
+      contentTransfer: p95Of('contentTransfer'),
     };
   }
 
@@ -254,6 +283,7 @@ export function computeEndpointStatisticsFromBuffer(
     ci95,
     connectionReuseDelta,
     tier2Averages,
+    tier2P95,
     ready,
   };
 }

--- a/tests/unit/classify.test.ts
+++ b/tests/unit/classify.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { classify, networkQuality, HEALTH_STYLES } from '../../src/lib/utils/classify';
+import type { EndpointStatistics } from '../../src/lib/types';
+
+function makeStats(over: Partial<EndpointStatistics> = {}): EndpointStatistics {
+  return {
+    endpointId: over.endpointId ?? 'ep-test',
+    sampleCount: 50,
+    p50: 0, p95: 0, p99: 0, p25: 0, p75: 0, p90: 0,
+    min: 0, max: 0, stddev: 0,
+    ci95: { lower: 0, upper: 0, margin: 0 },
+    connectionReuseDelta: null,
+    ready: true,
+    ...over,
+  };
+}
+
+describe('classify()', () => {
+  it('returns "unknown" when stats is null', () => {
+    expect(classify(null, 120)).toBe('unknown');
+  });
+
+  it('returns "unknown" when stats.ready is false', () => {
+    expect(classify(makeStats({ ready: false, p50: 10, p95: 20 }), 120)).toBe('unknown');
+  });
+
+  it('returns "healthy" when p95 ≤ threshold AND p50 ≤ threshold/2', () => {
+    expect(classify(makeStats({ p50: 60, p95: 120 }), 120)).toBe('healthy');
+    expect(classify(makeStats({ p50: 10, p95: 30 }),  120)).toBe('healthy');
+  });
+
+  it('returns "degraded" when p95 crosses threshold but stays ≤ 2x', () => {
+    expect(classify(makeStats({ p50: 100, p95: 180 }), 120)).toBe('degraded');
+    expect(classify(makeStats({ p50: 120, p95: 240 }), 120)).toBe('degraded');
+  });
+
+  it('returns "degraded" when p50 ≤ threshold even if p95 is healthy-but-over-half-threshold', () => {
+    // p50=100 ≤ 120, p95=120 ≤ 120, BUT p50 > threshold/2=60 so not healthy.
+    // Falls through to degraded predicate: p95 ≤ 2*threshold OR p50 ≤ threshold → true.
+    expect(classify(makeStats({ p50: 100, p95: 120 }), 120)).toBe('degraded');
+  });
+
+  it('returns "unhealthy" when p95 > 2x threshold AND p50 > threshold', () => {
+    expect(classify(makeStats({ p50: 200, p95: 500 }), 120)).toBe('unhealthy');
+  });
+
+  it('handles zero threshold as a pathological edge (never healthy, never degraded)', () => {
+    // p95=0, p50=0 → p95 ≤ 0 AND p50 ≤ 0 — healthy.
+    expect(classify(makeStats({ p50: 0, p95: 0 }), 0)).toBe('healthy');
+    // Any positive latency under threshold=0 → unhealthy.
+    expect(classify(makeStats({ p50: 1, p95: 1 }), 0)).toBe('unhealthy');
+  });
+});
+
+describe('networkQuality()', () => {
+  it('returns null when no endpoint is ready', () => {
+    expect(networkQuality([], 120)).toBeNull();
+    expect(networkQuality([makeStats({ ready: false })], 120)).toBeNull();
+  });
+
+  it('returns 100 when every endpoint is healthy', () => {
+    const a = makeStats({ endpointId: 'a', p50: 10, p95: 30 });
+    const b = makeStats({ endpointId: 'b', p50: 20, p95: 60 });
+    expect(networkQuality([a, b], 120)).toBe(100);
+  });
+
+  it('returns 20 when every endpoint is unhealthy', () => {
+    const a = makeStats({ endpointId: 'a', p50: 500, p95: 900 });
+    expect(networkQuality([a], 120)).toBe(20);
+  });
+
+  it('returns 60 when every endpoint is degraded', () => {
+    const a = makeStats({ endpointId: 'a', p50: 130, p95: 200 });
+    expect(networkQuality([a], 120)).toBe(60);
+  });
+
+  it('weights equally across ready endpoints (average of bucket scores)', () => {
+    // one healthy (100), one unhealthy (20) → mean 60, rounded.
+    const healthy  = makeStats({ endpointId: 'a', p50: 10,  p95: 30 });
+    const broken   = makeStats({ endpointId: 'b', p50: 500, p95: 900 });
+    expect(networkQuality([healthy, broken], 120)).toBe(60);
+  });
+
+  it('excludes not-ready endpoints from the denominator', () => {
+    const healthy  = makeStats({ endpointId: 'a', p50: 10, p95: 30 });
+    const pending  = makeStats({ endpointId: 'b', ready: false });
+    expect(networkQuality([healthy, pending], 120)).toBe(100);
+  });
+});
+
+describe('HEALTH_STYLES', () => {
+  it('defines a style entry for every bucket', () => {
+    expect(HEALTH_STYLES.healthy.color).toBeTruthy();
+    expect(HEALTH_STYLES.degraded.color).toBeTruthy();
+    expect(HEALTH_STYLES.unhealthy.color).toBeTruthy();
+    expect(HEALTH_STYLES.unknown.color).toBeTruthy();
+  });
+
+  it('references CSS custom properties bridged from tokens (no raw hex)', () => {
+    for (const bucket of ['healthy', 'degraded', 'unhealthy', 'unknown'] as const) {
+      expect(HEALTH_STYLES[bucket].color).toMatch(/^var\(--/);
+    }
+  });
+});

--- a/tests/unit/derived.test.ts
+++ b/tests/unit/derived.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import { networkQualityStore } from '../../src/lib/stores/derived';
+import { endpointStore } from '../../src/lib/stores/endpoints';
+import { measurementStore } from '../../src/lib/stores/measurements';
+import { settingsStore } from '../../src/lib/stores/settings';
+import { DEFAULT_SETTINGS } from '../../src/lib/types';
+
+function pushOkSamples(endpointId: string, latencies: number[]): void {
+  measurementStore.initEndpoint(endpointId);
+  for (let i = 0; i < latencies.length; i++) {
+    measurementStore.addSample(endpointId, i + 1, latencies[i], 'ok', Date.now() + i);
+  }
+}
+
+describe('networkQualityStore', () => {
+  beforeEach(() => {
+    endpointStore.setEndpoints([]);
+    measurementStore.reset();
+    settingsStore.set({ ...DEFAULT_SETTINGS });
+  });
+
+  it('yields null when no endpoint has ready stats', () => {
+    expect(get(networkQualityStore)).toBeNull();
+  });
+
+  it('yields 100 when the only endpoint is healthy', () => {
+    const id = endpointStore.addEndpoint('https://a.example', 'a');
+    endpointStore.updateEndpoint(id, { enabled: true });
+    // 30+ samples trips `ready`; keep all latencies safely below healthThreshold/2.
+    pushOkSamples(id, Array(40).fill(20));
+    expect(get(networkQualityStore)).toBe(100);
+  });
+
+  it('excludes disabled endpoints from the aggregate', () => {
+    const healthy = endpointStore.addEndpoint('https://ok.example', 'ok');
+    const broken  = endpointStore.addEndpoint('https://bad.example', 'bad');
+    endpointStore.updateEndpoint(healthy, { enabled: true });
+    endpointStore.updateEndpoint(broken,  { enabled: false });
+    pushOkSamples(healthy, Array(40).fill(20));
+    pushOkSamples(broken,  Array(40).fill(999));
+    // broken is disabled → excluded; healthy alone → 100
+    expect(get(networkQualityStore)).toBe(100);
+  });
+
+  it('recomputes when healthThreshold changes', () => {
+    const id = endpointStore.addEndpoint('https://a.example', 'a');
+    endpointStore.updateEndpoint(id, { enabled: true });
+    pushOkSamples(id, Array(40).fill(100)); // p50=p95=100
+    // With default threshold=120: p95(100) ≤ 120, p50(100) > 60 → degraded (60)
+    expect(get(networkQualityStore)).toBe(60);
+    // Raise threshold so p50 falls into the healthy half.
+    settingsStore.update((s) => ({ ...s, healthThreshold: 250 }));
+    expect(get(networkQualityStore)).toBe(100);
+  });
+});

--- a/tests/unit/format.test.ts
+++ b/tests/unit/format.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { fmt, fmtParts, fmtPct, fmtCount } from '../../src/lib/utils/format';
+
+describe('fmt()', () => {
+  it('returns "—" for null/undefined/NaN/Infinity/negative', () => {
+    expect(fmt(null)).toBe('—');
+    expect(fmt(undefined)).toBe('—');
+    expect(fmt(NaN)).toBe('—');
+    expect(fmt(Infinity)).toBe('—');
+    expect(fmt(-Infinity)).toBe('—');
+    expect(fmt(-1)).toBe('—');
+  });
+
+  it('uses 2 fraction digits below 1ms (inclusive of boundary)', () => {
+    expect(fmt(0)).toBe('0.00');
+    expect(fmt(0.43)).toBe('0.43');
+    // 0.999 stays in the <1 branch; tenths-of-milli precision is kept.
+    expect(fmt(0.999)).toBe('1.00');
+  });
+
+  it('uses 1 fraction digit between 1 and 10ms', () => {
+    expect(fmt(1)).toBe('1.0');
+    expect(fmt(9.87)).toBe('9.9');
+  });
+
+  it('rounds to integer between 10 and 10000ms and inserts thousands separator', () => {
+    expect(fmt(12)).toBe('12');
+    expect(fmt(127.4)).toBe('127');
+    expect(fmt(1234)).toBe('1,234');
+    expect(fmt(9999.9)).toBe('10,000');
+  });
+
+  it('switches to seconds with 1 fraction digit at 10000ms and above', () => {
+    expect(fmt(10000)).toBe('10.0s');
+    expect(fmt(12500)).toBe('12.5s');
+    expect(fmt(60000)).toBe('60.0s');
+  });
+});
+
+describe('fmtParts()', () => {
+  it('returns em-dash + empty unit for null/Infinity', () => {
+    expect(fmtParts(null)).toEqual({ num: '—', unit: '' });
+    expect(fmtParts(undefined)).toEqual({ num: '—', unit: '' });
+    expect(fmtParts(Infinity)).toEqual({ num: '—', unit: '' });
+    expect(fmtParts(NaN)).toEqual({ num: '—', unit: '' });
+  });
+
+  it('returns ms unit for values under 10s', () => {
+    expect(fmtParts(127.4)).toEqual({ num: '127', unit: 'ms' });
+    expect(fmtParts(0.43)).toEqual({ num: '0.43', unit: 'ms' });
+    expect(fmtParts(9999)).toEqual({ num: '9,999', unit: 'ms' });
+  });
+
+  it('switches to s unit at 10000ms', () => {
+    expect(fmtParts(10000)).toEqual({ num: '10.0', unit: 's' });
+    expect(fmtParts(12500)).toEqual({ num: '12.5', unit: 's' });
+  });
+});
+
+describe('fmtPct()', () => {
+  it('rounds to the nearest integer percent', () => {
+    expect(fmtPct(0)).toBe('0%');
+    expect(fmtPct(0.5)).toBe('50%');
+    expect(fmtPct(0.996)).toBe('100%');
+    expect(fmtPct(1)).toBe('100%');
+  });
+
+  it('handles values above 1 (for overshoot indicators)', () => {
+    expect(fmtPct(1.234)).toBe('123%');
+  });
+});
+
+describe('fmtCount()', () => {
+  it('formats integers with thousands separator', () => {
+    expect(fmtCount(0)).toBe('0');
+    expect(fmtCount(42)).toBe('42');
+    expect(fmtCount(1234)).toBe('1,234');
+    expect(fmtCount(1000000)).toBe('1,000,000');
+  });
+});

--- a/tests/unit/persistence.test.ts
+++ b/tests/unit/persistence.test.ts
@@ -20,19 +20,22 @@ describe('persistence', () => {
     expect(loadPersistedSettings()).toBeNull();
   });
 
-  it('round-trips v3 settings correctly', () => {
-    const settings: PersistedSettings = {
+  it('round-trips v3 settings into current v5 shape', () => {
+    const settings = {
       version: 3,
       endpoints: [{ url: 'https://example.com', enabled: true }],
       settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors' },
       ui: { expandedCards: [], activeView: 'timeline' },
     };
-    saveSettings(settings);
+    // Cast because the on-disk v3 payload pre-dates healthThreshold — migration
+    // is expected to seed the field forward.
+    saveSettings(settings as unknown as PersistedSettings);
     const loaded = loadPersistedSettings();
-    expect(loaded?.version).toBe(4);
+    expect(loaded?.version).toBe(5);
     expect(loaded?.endpoints[0]?.url).toBe('https://example.com');
     expect(loaded?.settings.burstRounds).toBe(50);
     expect(loaded?.settings.monitorDelay).toBe(1000);
+    expect(loaded?.settings.healthThreshold).toBe(120);
   });
 
   it('returns null for corrupt data', () => {
@@ -42,7 +45,7 @@ describe('persistence', () => {
   });
 
   it('migrates legacy storage key to new key', () => {
-    const settings: PersistedSettings = {
+    const settings = {
       version: 3,
       endpoints: [{ url: 'https://example.com', enabled: true }],
       settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors' },
@@ -50,21 +53,22 @@ describe('persistence', () => {
     };
     localStorageMock.setItem('chronoscope_v2_settings', JSON.stringify(settings));
     const loaded = loadPersistedSettings();
-    expect(loaded?.version).toBe(4);
-    // Legacy key should be removed, new key should exist
+    expect(loaded?.version).toBe(5);
     expect(localStorageMock.getItem('chronoscope_v2_settings')).toBeNull();
     expect(localStorageMock.getItem('chronoscope_settings')).not.toBeNull();
   });
 
-  it('migrates v1 data to v4', () => {
+  it('migrates v1 data all the way to v5', () => {
     const v1Data = { version: 1, endpoints: [{ url: 'https://example.com' }] };
     const migrated = migrateSettings(v1Data);
-    expect(migrated?.version).toBe(4);
+    expect(migrated?.version).toBe(5);
     expect(migrated?.settings.burstRounds).toBe(50);
     expect(migrated?.settings.monitorDelay).toBe(1000);
+    expect(migrated?.settings.healthThreshold).toBe(120);
+    expect(migrated?.ui.activeView).toBe('overview');
   });
 
-  it('migrates v2 data to v4 with old delay as monitorDelay', () => {
+  it('migrates v2 data to v5 with old delay as monitorDelay', () => {
     const v2Data = {
       version: 2,
       endpoints: [{ url: 'https://example.com', enabled: true }],
@@ -72,9 +76,104 @@ describe('persistence', () => {
       ui: { expandedCards: [], activeView: 'split' },
     };
     const migrated = migrateSettings(v2Data);
-    expect(migrated?.version).toBe(4);
+    expect(migrated?.version).toBe(5);
     expect(migrated?.settings.monitorDelay).toBe(500);
     expect(migrated?.settings.burstRounds).toBe(50);
     expect(migrated?.settings.delay).toBe(0);
+    expect(migrated?.settings.healthThreshold).toBe(120);
+    // 'split' is a deprecated view that migrates to 'lanes'.
+    expect(migrated?.ui.activeView).toBe('lanes');
+  });
+
+  describe('v4 → v5 migration', () => {
+    it('seeds healthThreshold default on a real v4 payload', () => {
+      const v4: unknown = {
+        version: 4,
+        endpoints: [{ url: 'https://cloudflare-dns.com', enabled: true }],
+        settings: {
+          timeout: 5000,
+          delay: 0,
+          burstRounds: 50,
+          monitorDelay: 1000,
+          cap: 0,
+          corsMode: 'no-cors',
+          region: 'north-america',
+        },
+        ui: { expandedCards: ['ep-1'], activeView: 'split' },
+      };
+      const migrated = migrateSettings(v4);
+      expect(migrated?.version).toBe(5);
+      expect(migrated?.settings.healthThreshold).toBe(120);
+      expect(migrated?.settings.region).toBe('north-america');
+    });
+
+    it('rewrites deprecated activeView values to "lanes"', () => {
+      for (const view of ['timeline', 'heatmap', 'split'] as const) {
+        const v4 = {
+          version: 4,
+          endpoints: [],
+          settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors' },
+          ui: { expandedCards: [], activeView: view },
+        };
+        const migrated = migrateSettings(v4);
+        expect(migrated?.ui.activeView).toBe('lanes');
+      }
+    });
+
+    it('seeds focusedEndpointId as null, liveOptions defaults, empty terminalFilters', () => {
+      const v4 = {
+        version: 4,
+        endpoints: [],
+        settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors' },
+        ui: { expandedCards: [], activeView: 'split' },
+      };
+      const migrated = migrateSettings(v4);
+      expect(migrated?.ui.focusedEndpointId).toBeNull();
+      expect(migrated?.ui.liveOptions).toEqual({ split: false, timeRange: '5m' });
+      expect(migrated?.ui.terminalFilters).toEqual([]);
+    });
+
+    it('preserves expandedCards through migration', () => {
+      const v4 = {
+        version: 4,
+        endpoints: [],
+        settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors' },
+        ui: { expandedCards: ['a', 'b'], activeView: 'split' },
+      };
+      const migrated = migrateSettings(v4);
+      expect(migrated?.ui.expandedCards).toEqual(['a', 'b']);
+    });
+
+    it('round-trips a v5 payload unchanged (already current)', () => {
+      const v5: PersistedSettings = {
+        version: 5,
+        endpoints: [{ url: 'https://a.example', enabled: true }],
+        settings: {
+          timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000,
+          cap: 0, corsMode: 'no-cors', healthThreshold: 200,
+        },
+        ui: {
+          expandedCards: [],
+          activeView: 'overview',
+          focusedEndpointId: 'ep-1',
+          liveOptions: { split: true, timeRange: '15m' },
+          terminalFilters: ['timeout', 'error'],
+        },
+      };
+      saveSettings(v5);
+      const loaded = loadPersistedSettings();
+      expect(loaded).toEqual(v5);
+    });
+
+    it('coerces an unknown activeView value to the default "overview"', () => {
+      const v4 = {
+        version: 4,
+        endpoints: [],
+        settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors' },
+        ui: { expandedCards: [], activeView: 'garbage-string' },
+      };
+      const migrated = migrateSettings(v4);
+      expect(migrated?.ui.activeView).toBe('overview');
+    });
   });
 });

--- a/tests/unit/statistics.test.ts
+++ b/tests/unit/statistics.test.ts
@@ -202,6 +202,37 @@ describe('computeEndpointStatistics', () => {
     expect(stats.tier2Averages?.tcpConnect).toBeCloseTo(22.5, 5);
   });
 
+  it('computes tier2P95 alongside tier2Averages (nearest-rank on each phase)', () => {
+    const samples: MeasurementSample[] = Array.from({ length: 20 }, (_, i) => ({
+      round: i + 1,
+      latency: 100 + i,
+      status: 'ok' as const,
+      timestamp: 1000 + i,
+      tier2: {
+        total: 100 + i,
+        dnsLookup:   i + 1,    // 1..20
+        tcpConnect:  2 * i,    // 0..38
+        tlsHandshake: i,       // 0..19
+        ttfb:        40 + i,   // 40..59
+        contentTransfer: 5,
+      },
+    }));
+    const stats = computeEndpointStatistics('ep1', samples);
+    expect(stats.tier2P95).toBeDefined();
+    // nearest-rank p95 of 20 values → index ceil(0.95*20)-1 = 18
+    expect(stats.tier2P95?.dnsLookup).toBe(19);       // sorted[18] of 1..20
+    expect(stats.tier2P95?.tcpConnect).toBe(36);      // sorted[18] of 0,2,4,…,38
+    expect(stats.tier2P95?.tlsHandshake).toBe(18);    // sorted[18] of 0..19
+    expect(stats.tier2P95?.ttfb).toBe(58);            // sorted[18] of 40..59
+    expect(stats.tier2P95?.contentTransfer).toBe(5);  // all identical
+  });
+
+  it('omits tier2P95 when no tier2 samples exist', () => {
+    const stats = computeEndpointStatistics('ep1', makeSamples([100, 90, 80]));
+    expect(stats.tier2Averages).toBeUndefined();
+    expect(stats.tier2P95).toBeUndefined();
+  });
+
   it('includes the endpointId in the result', () => {
     const stats = computeEndpointStatistics('my-endpoint', makeSamples([50]));
     expect(stats.endpointId).toBe('my-endpoint');

--- a/tests/unit/tokens.test.ts
+++ b/tests/unit/tokens.test.ts
@@ -240,3 +240,68 @@ describe('visual-polish-v3 tokens (AC1 + AC2)', () => {
     expect(bright - mid).toBeGreaterThanOrEqual(0.04);
   });
 });
+
+describe('v2 foundation tokens (Phase 0)', () => {
+  it('exposes amber accent tri (color + glow + tone)', () => {
+    expect(tokens.color.accent.amber).toBe('#fbbf24');
+    expect(tokens.color.accent.amberGlow).toBe('rgba(251,191,36,.33)');
+    expect(tokens.color.accent.amberTone).toBe('#b38410');
+  });
+
+  it('exposes cyan and pink glow + tone companions', () => {
+    expect(tokens.color.accent.cyanGlow).toBe('rgba(103,232,249,.33)');
+    expect(tokens.color.accent.cyanTone).toBe('#3aa7b8');
+    expect(tokens.color.accent.pinkGlow).toBe('rgba(249,168,212,.33)');
+    expect(tokens.color.accent.pinkTone).toBe('#b0628a');
+  });
+
+  it('exposes dial-face surface + deep overlay', () => {
+    expect(tokens.color.surface.dialFace).toBe('#141021');
+    expect(tokens.color.surface.overlayDeep).toBe('rgba(11,8,20,.85)');
+  });
+
+  it('exposes rail-scoped glass surfaces distinct from existing bgHover/bgStrong', () => {
+    expect(tokens.color.glass.bgRailHover).toBe('rgba(255,255,255,.06)');
+    expect(tokens.color.glass.bgRailSelected).toBe('rgba(255,255,255,.10)');
+    // preserve existing consumer values
+    expect(tokens.color.glass.bgHover).toBe('rgba(255,255,255,.07)');
+    expect(tokens.color.glass.bgStrong).toBe('rgba(255,255,255,.045)');
+  });
+
+  it('exposes SVG primitives for dial, orbit ring, scope grid', () => {
+    expect(tokens.color.svg.gridLineCyan).toBe('rgba(103,232,249,.05)');
+    expect(tokens.color.svg.gridLineMajor).toBe('rgba(255,255,255,.06)');
+    expect(tokens.color.svg.tickMinor).toBe('rgba(255,255,255,.18)');
+    expect(tokens.color.svg.tickMajor).toBe('rgba(255,255,255,.50)');
+    expect(tokens.color.svg.handStroke).toBe('#ffffff');
+    expect(tokens.color.svg.dialRim).toBe('rgba(255,255,255,.14)');
+    expect(tokens.color.svg.orbitTrack).toBe('rgba(255,255,255,.06)');
+    expect(tokens.color.svg.orbitEdge).toBe('rgba(255,255,249,.10)');
+  });
+
+  it('exposes tooltip deep variant + border/text tokens', () => {
+    expect(tokens.color.tooltip.bgDeep).toBe('rgba(10,9,18,.92)');
+    expect(tokens.color.tooltip.border).toBe('rgba(255,255,255,.10)');
+    expect(tokens.color.tooltip.text).toBe('rgba(255,255,255,.95)');
+    expect(tokens.color.tooltip.textDim).toBe('rgba(255,255,255,.55)');
+  });
+
+  it('exposes typography scale (xs → xxl) and tracking', () => {
+    expect(tokens.typography.scale.xs).toBe('9px');
+    expect(tokens.typography.scale.sm).toBe('10px');
+    expect(tokens.typography.scale.md).toBe('11.5px');
+    expect(tokens.typography.scale.lg).toBe('14px');
+    expect(tokens.typography.scale.xl).toBe('18px');
+    expect(tokens.typography.scale.xxl).toBe('32px');
+    expect(tokens.typography.tracking.kicker).toBe('0.18em');
+    expect(tokens.typography.tracking.label).toBe('0.08em');
+    expect(tokens.typography.tracking.body).toBe('0');
+  });
+
+  it('exposes v2 motion primitives', () => {
+    expect(tokens.timing.handLerp).toBe(0.15);
+    expect(tokens.timing.pulseRim).toBe(400);
+    expect(tokens.timing.orbitPulse).toBe(1400);
+    expect(tokens.timing.traceRepaint).toBe(16);
+  });
+});

--- a/tests/unit/utils/persistence-migration.test.ts
+++ b/tests/unit/utils/persistence-migration.test.ts
@@ -13,8 +13,8 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('migrateSettings v3 → v4', () => {
-  it('v3 payload with no region → v4 with region = detectRegion()', () => {
+describe('migrateSettings — full chain through v5', () => {
+  it('v3 payload with no region → v5 with region = detectRegion() and healthThreshold default', () => {
     const v3 = {
       version: 3,
       endpoints: [{ url: 'https://example.com', enabled: true }],
@@ -22,12 +22,15 @@ describe('migrateSettings v3 → v4', () => {
       ui: { expandedCards: [], activeView: 'timeline' },
     };
     const result = migrateSettings(v3);
-    expect(result?.version).toBe(4);
+    expect(result?.version).toBe(5);
     expect(result?.settings.region).toBe('europe');
+    expect(result?.settings.healthThreshold).toBe(120);
     expect(result?.endpoints[0]?.url).toBe('https://example.com');
+    // 'timeline' is a v2-era view that rewrites to 'lanes'.
+    expect(result?.ui.activeView).toBe('lanes');
   });
 
-  it('v4 payload with valid region passes through unchanged', () => {
+  it('v4 payload with valid region migrates to v5 with region preserved', () => {
     const v4 = {
       version: 4,
       endpoints: [{ url: 'https://example.com', enabled: true }],
@@ -35,8 +38,9 @@ describe('migrateSettings v3 → v4', () => {
       ui: { expandedCards: [], activeView: 'split' },
     };
     const result = migrateSettings(v4);
-    expect(result?.version).toBe(4);
+    expect(result?.version).toBe(5);
     expect(result?.settings.region).toBe('east-asia');
+    expect(result?.settings.healthThreshold).toBe(120);
   });
 
   it('v4 payload with invalid region string strips the field', () => {
@@ -47,7 +51,7 @@ describe('migrateSettings v3 → v4', () => {
       ui: { expandedCards: [], activeView: 'split' },
     };
     const result = migrateSettings(v4);
-    expect(result?.version).toBe(4);
+    expect(result?.version).toBe(5);
     expect(result?.settings.region).toBeUndefined();
   });
 
@@ -62,7 +66,7 @@ describe('migrateSettings v3 → v4', () => {
     expect(result?.settings.region).toBeUndefined();
   });
 
-  it('v2 payload migrates through to v4 (chain migration)', () => {
+  it('v2 payload migrates through to v5 (chain migration)', () => {
     const v2 = {
       version: 2,
       endpoints: [{ url: 'https://example.com', enabled: true }],
@@ -70,22 +74,24 @@ describe('migrateSettings v3 → v4', () => {
       ui: { expandedCards: [], activeView: 'split' },
     };
     const result = migrateSettings(v2);
-    expect(result?.version).toBe(4);
+    expect(result?.version).toBe(5);
     expect(result?.settings.burstRounds).toBe(50);
     expect(result?.settings.region).toBe('europe');
+    expect(result?.settings.healthThreshold).toBe(120);
   });
 
-  it('v1 payload migrates through to v4', () => {
+  it('v1 payload migrates through to v5', () => {
     const v1 = {
       version: 1,
       endpoints: [{ url: 'https://example.com' }],
     };
     const result = migrateSettings(v1);
-    expect(result?.version).toBe(4);
+    expect(result?.version).toBe(5);
+    // v1 has no ui block → v5 default view is 'overview'.
+    expect(result?.ui.activeView).toBe('overview');
   });
 
   it('version 99 (future unknown): returns null — no forward-compat coercion', () => {
-    // Spec §5: migrateSettings returns null for unknown versions.
     const future = {
       version: 99,
       endpoints: [{ url: 'https://example.com', enabled: true }],


### PR DESCRIPTION
## Summary

Zero-visual-risk plumbing that unblocks the rest of the Chronoscope v2 redesign. Phase 0 of the handoff package in `/handoff` (see `06-implementation-plan.md` §Phase 0).

- **Tokens** — amber accent tri, cyan/pink glow+tone, `surface.dialFace`, `glass.bgRailHover`/`bgRailSelected`, SVG primitives for dial/orbit/scope, deep tooltip surface, named typography scale + tracking, four motion primitives (`handLerp`/`pulseRim`/`orbitPulse`/`traceRepaint`). All bridged to CSS custom properties in `App.svelte#bridgeTokensToCss`.
- **Utils** — `classify.ts` (health bucketing + `networkQuality` aggregate + `HEALTH_STYLES`) and `format.ts` (`fmt`/`fmtParts`/`fmtPct`/`fmtCount`). Pure, exhaustively tested.
- **Types + stores** — `ActiveView` union extended to the 6 v2 views; `UIState.focusedEndpointId`/`liveOptions`/`terminalFilters`; `Settings.healthThreshold` (120ms default); `EndpointStatistics.tier2P95`. `uiStore` gains focus/live/terminal setters. New `networkQualityStore` derived from endpoints + stats + settings.
- **Statistics** — `tier2P95` computed on the same cadence as `tier2Averages` (both array and buffer paths). Nearest-rank per phase.
- **Persistence** — `CURRENT_VERSION 4 → 5`. `stepV4toV5` seeds the new settings/ui fields, rewrites deprecated `activeView` labels (`timeline`/`heatmap`/`split`) to `'lanes'`, and coerces unknown strings to `'overview'`. `applyPersistedSettings` silently drops `focusedEndpointId` when the id no longer resolves.

## Deviations from spec (approved)

1. Rail-scoped glass tokens shipped as `bgRailHover`/`bgRailSelected` instead of overloading existing `bgHover`/`bgStrong` (which have live consumers).
2. `surface.deep` preserved at existing value; handoff's `#141021` lives on new `surface.dialFace`.
3. Unknown `activeView` strings coerce to `'overview'` (v5 default). Known-deprecated labels still rewrite to `'lanes'`.
4. `tier2P95` typed as optional (`?`) to mirror `tier2Averages` semantics.
5. Path drift on `App.svelte` (real path is `src/lib/components/App.svelte`) resolved silently.

## Bundle size

| | JS (raw) | JS (gzip) | CSS (gzip) |
|---|---:|---:|---:|
| Before | 176.82 KB | **55.67 KB** | 8.54 KB |
| After | 184.27 KB | **57.32 KB** | 8.54 KB |
| Delta | +7.45 KB | **+1.65 KB** | 0 |

Well under the +10 KB gzip Phase 0 budget.

## Test plan
- [ ] `npm run typecheck` clean
- [ ] `npm run lint` clean
- [ ] `npm run test` — 723 tests pass (46 net-new across tokens / format / classify / statistics / persistence / derived)
- [ ] `npm run build` succeeds; bundle delta < +10 KB gzip
- [ ] A real v4 persisted payload migrates to v5 (covered by `persistence.test.ts` v4 → v5 suite)
- [ ] No visual change — the app renders its legacy views identically; new tokens and stores have no component consumers yet