### PR TITLE
Phase 1 — persistent rail, view switcher, topbar chrome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docs/plans/
 docs/superpowers/
 docs/specs/
 .playwright-mcp/
+screenshots/

--- a/scripts/phase-1-screenshots.mjs
+++ b/scripts/phase-1-screenshots.mjs
@@ -1,0 +1,64 @@
+// One-shot Playwright runner for the Phase 1 PR screenshots. Outputs four
+// PNGs into ./screenshots/phase-1/ at the project root. Not part of the build;
+// run manually with `node scripts/phase-1-screenshots.mjs`.
+import { chromium } from 'playwright';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+const OUT = path.resolve('screenshots/phase-1');
+await mkdir(OUT, { recursive: true });
+
+const browser = await chromium.launch();
+const context = await browser.newContext({ viewport: { width: 1440, height: 900 }, deviceScaleFactor: 2 });
+const page = await context.newPage();
+
+await page.goto('http://127.0.0.1:5173/');
+// Clear any persisted state so the friendly default endpoint labels render.
+await page.evaluate(() => { localStorage.clear(); });
+await page.reload();
+await page.waitForLoadState('networkidle');
+
+// Shot 1 — at rest (no data).
+await page.screenshot({ path: path.join(OUT, '1-at-rest.png'), type: 'png' });
+
+// Shot 2 — hover on the second rail row.
+const rows = page.locator('nav[aria-label="Endpoints"] [role="tab"]');
+await rows.nth(1).hover();
+await page.waitForTimeout(180);
+await page.screenshot({ path: path.join(OUT, '2-hover.png'), type: 'png' });
+
+// Shot 3 — click to focus the third rail row.
+await rows.nth(2).click();
+// Move pointer off the row + blur to remove hover styling so only the focused
+// state shows in the screenshot.
+await page.mouse.move(800, 500);
+await page.evaluate(() => { document.activeElement instanceof HTMLElement && document.activeElement.blur(); });
+await page.waitForTimeout(180);
+await page.screenshot({ path: path.join(OUT, '3-focused.png'), type: 'png' });
+
+// Shot 4 — degraded network state (force stats by injecting samples).
+await page.evaluate(async () => {
+  const measMod = await import('/src/lib/stores/measurements.ts');
+  const epMod   = await import('/src/lib/stores/endpoints.ts');
+  // Use the store's own subscribe to grab the current value — avoids needing
+  // to resolve the bare 'svelte/store' specifier from the browser.
+  const eps = await new Promise((resolve) => {
+    const unsub = epMod.endpointStore.subscribe((v) => { resolve(v); setTimeout(unsub, 0); });
+  });
+  const slow = Array.from({ length: 33 }, (_, i) => 950 + (i % 5) * 50);
+  const med  = Array.from({ length: 33 }, (_, i) => 180 + (i % 5) * 10);
+  const profiles = [slow, med, slow, slow];
+  for (let i = 0; i < eps.length; i++) {
+    const ep = eps[i];
+    measMod.measurementStore.initEndpoint(ep.id);
+    const lat = profiles[i] || slow;
+    for (let r = 0; r < lat.length; r++) {
+      measMod.measurementStore.addSample(ep.id, r + 1, lat[r], 'ok', Date.now() + r);
+    }
+  }
+});
+await page.waitForTimeout(300);
+await page.screenshot({ path: path.join(OUT, '4-degraded.png'), type: 'png' });
+
+await browser.close();
+console.log('Screenshots written to', OUT);

--- a/src/lib/components/App.svelte
+++ b/src/lib/components/App.svelte
@@ -103,7 +103,6 @@
     root.style.setProperty('--border-mid',          tokens.color.surface.border.mid);
     root.style.setProperty('--border-bright',       tokens.color.surface.border.bright);
     root.style.setProperty('--surface-topbar-bg',   tokens.color.surface.overlayDeep);
-    root.style.setProperty('--t4',                  tokens.color.text.t4);
 
     // v2 surface + tooltip variants
     root.style.setProperty('--surface-dial-face',    tokens.color.surface.dialFace);

--- a/src/lib/components/App.svelte
+++ b/src/lib/components/App.svelte
@@ -81,15 +81,29 @@
     root.style.setProperty('--easing-decelerate',tokens.easing.decelerate);
 
     // v2 typography scale (--ts-*) + tracking (--tr-*)
-    root.style.setProperty('--ts-xs',  tokens.typography.scale.xs);
-    root.style.setProperty('--ts-sm',  tokens.typography.scale.sm);
-    root.style.setProperty('--ts-md',  tokens.typography.scale.md);
-    root.style.setProperty('--ts-lg',  tokens.typography.scale.lg);
-    root.style.setProperty('--ts-xl',  tokens.typography.scale.xl);
-    root.style.setProperty('--ts-xxl', tokens.typography.scale.xxl);
-    root.style.setProperty('--tr-kicker', tokens.typography.tracking.kicker);
-    root.style.setProperty('--tr-label',  tokens.typography.tracking.label);
-    root.style.setProperty('--tr-body',   tokens.typography.tracking.body);
+    root.style.setProperty('--ts-xs',   tokens.typography.scale.xs);
+    root.style.setProperty('--ts-sm',   tokens.typography.scale.sm);
+    root.style.setProperty('--ts-md',   tokens.typography.scale.md);
+    root.style.setProperty('--ts-base', tokens.typography.scale.base);
+    root.style.setProperty('--ts-lg',   tokens.typography.scale.lg);
+    root.style.setProperty('--ts-xl',   tokens.typography.scale.xl);
+    root.style.setProperty('--ts-2xl',  tokens.typography.scale.xl2);
+    root.style.setProperty('--ts-3xl',  tokens.typography.scale.xl3);
+    root.style.setProperty('--ts-xxl',  tokens.typography.scale.xxl);
+    root.style.setProperty('--tr-kicker',  tokens.typography.tracking.kicker);
+    root.style.setProperty('--tr-label',   tokens.typography.tracking.label);
+    root.style.setProperty('--tr-tight',   tokens.typography.tracking.tight);
+    root.style.setProperty('--tr-display', tokens.typography.tracking.display);
+    root.style.setProperty('--tr-body',    tokens.typography.tracking.body);
+
+    // v2 structural chrome + surface border (used by topbar/rail/switcher)
+    root.style.setProperty('--topbar-height',       `${tokens.lane.topbarHeight}px`);
+    root.style.setProperty('--rail-width',          `${tokens.lane.railWidth}px`);
+    root.style.setProperty('--border-dim',          tokens.color.surface.border.dim);
+    root.style.setProperty('--border-mid',          tokens.color.surface.border.mid);
+    root.style.setProperty('--border-bright',       tokens.color.surface.border.bright);
+    root.style.setProperty('--surface-topbar-bg',   tokens.color.surface.overlayDeep);
+    root.style.setProperty('--t4',                  tokens.color.text.t4);
 
     // v2 surface + tooltip variants
     root.style.setProperty('--surface-dial-face',    tokens.color.surface.dialFace);

--- a/src/lib/components/EndpointRail.svelte
+++ b/src/lib/components/EndpointRail.svelte
@@ -21,10 +21,20 @@
 
   function handleDoubleClick(id: string): void {
     uiStore.setFocusedEndpoint(id);
+    // Drill to Lanes in Phase 1 — switch to 'live' once Phase 3 ships it.
     uiStore.setActiveView('lanes');
   }
 
-  function handleAddEndpoint(): void {
+  // Keyboard parity for drill: Enter falls through to native button click
+  // (toggle), Space drills to the detail view per the rail spec.
+  function handleKeydown(event: KeyboardEvent, id: string): void {
+    if (event.key === ' ' || event.key === 'Spacebar') {
+      event.preventDefault();
+      handleDoubleClick(id);
+    }
+  }
+
+  function handleManageEndpoints(): void {
     uiStore.toggleEndpoints();
   }
 
@@ -61,6 +71,7 @@
         aria-label="{ep.label}, {ep.url}, status: {style.label}"
         onclick={() => handleClick(ep.id)}
         ondblclick={() => handleDoubleClick(ep.id)}
+        onkeydown={(e) => handleKeydown(e, ep.id)}
       >
         <span
           class="rail-pip"
@@ -81,8 +92,8 @@
   </div>
 
   <div class="rail-footer">
-    <button type="button" class="rail-add" onclick={handleAddEndpoint}>
-      + Add endpoint
+    <button type="button" class="rail-add" onclick={handleManageEndpoints}>
+      Manage endpoints
     </button>
   </div>
 </nav>

--- a/src/lib/components/EndpointRail.svelte
+++ b/src/lib/components/EndpointRail.svelte
@@ -1,0 +1,233 @@
+<!-- src/lib/components/EndpointRail.svelte -->
+<!-- Persistent left rail. Drives global endpoint focus across all v2 views.   -->
+<!-- 264px fixed width; full viewport height inside the shell-body row.        -->
+<script lang="ts">
+  import { tokens } from '$lib/tokens';
+  import { uiStore } from '$lib/stores/ui';
+  import { endpointStore } from '$lib/stores/endpoints';
+  import { statisticsStore } from '$lib/stores/statistics';
+  import { settingsStore } from '$lib/stores/settings';
+  import { classify, HEALTH_STYLES, type HealthBucket } from '$lib/utils/classify';
+  import { fmtParts } from '$lib/utils/format';
+
+  const endpoints = $derived($endpointStore);
+  const stats = $derived($statisticsStore);
+  const focusedId = $derived($uiStore.focusedEndpointId);
+  const threshold = $derived($settingsStore.healthThreshold);
+
+  function handleClick(id: string): void {
+    uiStore.toggleFocusedEndpoint(id);
+  }
+
+  function handleDoubleClick(id: string): void {
+    uiStore.setFocusedEndpoint(id);
+    uiStore.setActiveView('lanes');
+  }
+
+  function handleAddEndpoint(): void {
+    uiStore.toggleEndpoints();
+  }
+
+  function bucketFor(id: string): HealthBucket {
+    return classify(stats[id] ?? null, threshold);
+  }
+</script>
+
+<nav
+  class="rail"
+  aria-label="Endpoints"
+  style:--rail-bg="rgba(10,9,18,.5)"
+>
+  <div class="rail-header">
+    <span class="rail-title">Endpoints</span>
+    <span class="rail-count" aria-label="{endpoints.length} endpoints monitored">{endpoints.length}</span>
+  </div>
+
+  <div class="rail-list">
+    {#each endpoints as ep (ep.id)}
+      {@const bucket = bucketFor(ep.id)}
+      {@const style = HEALTH_STYLES[bucket]}
+      {@const epStats = stats[ep.id]}
+      {@const parts = epStats ? fmtParts(epStats.p50) : { num: '—', unit: 'ms' }}
+      {@const focused = focusedId === ep.id}
+      {@const epColor = ep.color || tokens.color.endpoint[0]}
+      <button
+        type="button"
+        class="rail-row"
+        class:focused
+        class:disabled={!ep.enabled}
+        role="tab"
+        aria-selected={focused}
+        aria-label="{ep.label}, {ep.url}, status: {style.label}"
+        onclick={() => handleClick(ep.id)}
+        ondblclick={() => handleDoubleClick(ep.id)}
+      >
+        <span
+          class="rail-pip"
+          style:background={style.color}
+          style:box-shadow="0 0 8px {style.color}"
+          aria-hidden="true"
+        ></span>
+        <span class="rail-row-body">
+          <span class="rail-row-label">{ep.label}</span>
+          <span class="rail-row-url">{ep.url}</span>
+        </span>
+        <span class="rail-row-metric">
+          <span class="rail-row-p50" style:color={epColor}>{parts.num}</span>
+          <span class="rail-row-unit">{parts.unit || 'ms'}</span>
+        </span>
+      </button>
+    {/each}
+  </div>
+
+  <div class="rail-footer">
+    <button type="button" class="rail-add" onclick={handleAddEndpoint}>
+      + Add endpoint
+    </button>
+  </div>
+</nav>
+
+<style>
+  .rail {
+    width: var(--rail-width);
+    flex-shrink: 0;
+    background: var(--rail-bg);
+    border-right: 1px solid var(--border-mid);
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  .rail-header {
+    padding: 14px 16px 10px;
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+  .rail-title {
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-kicker);
+    color: var(--t3);
+    text-transform: uppercase;
+  }
+  .rail-count {
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    color: var(--t4);
+    border: 1px solid var(--border-mid);
+    padding: 1px 6px;
+    border-radius: 3px;
+  }
+
+  .rail-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0 8px;
+  }
+
+  .rail-row {
+    width: 100%;
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 10px;
+    align-items: center;
+    padding: 10px;
+    margin-bottom: 3px;
+    border-radius: 7px;
+    background: transparent;
+    border: 1px solid transparent;
+    color: inherit;
+    text-align: left;
+    cursor: pointer;
+    font-family: inherit;
+    transition: background 140ms ease, border-color 140ms ease;
+  }
+  .rail-row:hover { background: var(--glass-bg-rail-hover); border-color: var(--border-mid); }
+  .rail-row.focused {
+    background: var(--glass-bg-rail-selected);
+    border-color: var(--border-bright);
+  }
+  .rail-row.disabled { opacity: 0.5; }
+  .rail-row:focus-visible {
+    outline: 1.5px solid var(--accent-cyan);
+    outline-offset: 2px;
+  }
+
+  .rail-pip {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .rail-row-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    min-width: 0;
+  }
+  .rail-row-label {
+    font-size: var(--ts-md);
+    color: var(--t1);
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .rail-row-url {
+    font-family: var(--mono);
+    font-size: var(--ts-sm);
+    color: var(--t3);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .rail-row-metric {
+    display: flex;
+    align-items: baseline;
+    gap: 2px;
+    font-family: var(--mono);
+    font-variant-numeric: tabular-nums;
+  }
+  .rail-row-p50 {
+    font-size: var(--ts-lg);
+    font-weight: 500;
+  }
+  .rail-row-unit {
+    font-size: var(--ts-xs);
+    color: var(--t4);
+    letter-spacing: var(--tr-label);
+  }
+
+  .rail-footer {
+    padding: 10px 12px;
+    border-top: 1px solid var(--border-mid);
+  }
+  .rail-add {
+    width: 100%;
+    padding: 7px;
+    border-radius: 6px;
+    background: transparent;
+    border: 1px dashed var(--border-bright);
+    color: var(--t3);
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-label);
+    cursor: pointer;
+    transition: color 160ms ease, border-color 160ms ease;
+  }
+  .rail-add:hover {
+    color: var(--t1);
+    border-color: var(--accent-cyan);
+  }
+  .rail-add:focus-visible {
+    outline: 1.5px solid var(--accent-cyan);
+    outline-offset: 2px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .rail-row, .rail-add { transition: none; }
+  }
+</style>

--- a/src/lib/components/EndpointRail.svelte
+++ b/src/lib/components/EndpointRail.svelte
@@ -48,7 +48,7 @@
       {@const bucket = bucketFor(ep.id)}
       {@const style = HEALTH_STYLES[bucket]}
       {@const epStats = stats[ep.id]}
-      {@const parts = epStats ? fmtParts(epStats.p50) : { num: '—', unit: 'ms' }}
+      {@const parts = epStats?.ready ? fmtParts(epStats.p50) : { num: '—', unit: '' }}
       {@const focused = focusedId === ep.id}
       {@const epColor = ep.color || tokens.color.endpoint[0]}
       <button
@@ -56,8 +56,8 @@
         class="rail-row"
         class:focused
         class:disabled={!ep.enabled}
-        role="tab"
-        aria-selected={focused}
+        disabled={!ep.enabled}
+        aria-pressed={focused}
         aria-label="{ep.label}, {ep.url}, status: {style.label}"
         onclick={() => handleClick(ep.id)}
         ondblclick={() => handleDoubleClick(ep.id)}
@@ -74,7 +74,7 @@
         </span>
         <span class="rail-row-metric">
           <span class="rail-row-p50" style:color={epColor}>{parts.num}</span>
-          <span class="rail-row-unit">{parts.unit || 'ms'}</span>
+          <span class="rail-row-unit">{parts.unit}</span>
         </span>
       </button>
     {/each}
@@ -143,12 +143,12 @@
     font-family: inherit;
     transition: background 140ms ease, border-color 140ms ease;
   }
-  .rail-row:hover { background: var(--glass-bg-rail-hover); border-color: var(--border-mid); }
+  .rail-row:hover:not(:disabled) { background: var(--glass-bg-rail-hover); border-color: var(--border-mid); }
   .rail-row.focused {
     background: var(--glass-bg-rail-selected);
     border-color: var(--border-bright);
   }
-  .rail-row.disabled { opacity: 0.5; }
+  .rail-row.disabled, .rail-row:disabled { opacity: 0.5; cursor: not-allowed; }
   .rail-row:focus-visible {
     outline: 1.5px solid var(--accent-cyan);
     outline-offset: 2px;

--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -1,12 +1,19 @@
 <!-- src/lib/components/Layout.svelte -->
+<!-- v2 shell. Topbar (top) | { Rail (264px) | { ViewSwitcher + main content } } | FooterBar (bottom). -->
+<!-- Routes activeView to OverviewView (Phase 1 stub) or the legacy LanesView   -->
+<!-- (which still hosts Glass Lanes + XAxisBar) for the deprecated splits.     -->
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
   import { get } from 'svelte/store';
   import { measurementStore, incrementalTimestampTracker } from '$lib/stores/measurements';
   import { endpointStore } from '$lib/stores/endpoints';
   import { settingsStore } from '$lib/stores/settings';
+  import { uiStore } from '$lib/stores/ui';
   import { tokens } from '$lib/tokens';
   import Topbar from './Topbar.svelte';
+  import EndpointRail from './EndpointRail.svelte';
+  import ViewSwitcher from './ViewSwitcher.svelte';
+  import OverviewView from './OverviewView.svelte';
   import LanesView from './LanesView.svelte';
   import XAxisBar from './XAxisBar.svelte';
   import FooterBar from './FooterBar.svelte';
@@ -30,17 +37,25 @@
   const configuredCap = $derived($settingsStore.cap > 0 ? $settingsStore.cap : Infinity);
   const currentRound = $derived($measurementStore.roundCounter);
 
-  // Sliding window: show at most CHART_WINDOW rounds
-  const visibleSpan = $derived(Math.min(CHART_WINDOW, configuredCap || CHART_WINDOW));
+  const visibleSpan  = $derived(Math.min(CHART_WINDOW, configuredCap || CHART_WINDOW));
   const visibleStart = $derived(Math.max(1, currentRound - visibleSpan + 1));
-  const visibleEnd = $derived(Math.max(visibleSpan, currentRound));
+  const visibleEnd   = $derived(Math.max(visibleSpan, currentRound));
 
-  // Earliest timestamp per round across all endpoints — O(1) read from incremental tracker.
-  // $measurementStore.roundCounter triggers reactive re-evaluation when new rounds arrive.
   const sampleTimestamps: readonly number[] = $derived.by(() => {
     void $measurementStore.roundCounter; // reactive subscription trigger
     return incrementalTimestampTracker.timestamps;
   });
+
+  // Map activeView → which content renderer to mount. The deprecated
+  // 'timeline'/'heatmap'/'split' values still arrive from non-migrated tabs;
+  // they all flow through the legacy lanes path until Phase 7 removes them.
+  const activeView = $derived($uiStore.activeView);
+  const showLegacyLanes = $derived(
+    activeView === 'lanes'
+      || activeView === 'timeline'
+      || activeView === 'heatmap'
+      || activeView === 'split'
+  );
 
   onMount(() => {
     unsubLifecycle = measurementStore.subscribe((state) => {
@@ -61,7 +76,7 @@
   onDestroy(() => { unsubLifecycle?.(); });
 </script>
 
-<a href="#lanes" class="skip-link">Skip to lanes</a>
+<a href="#main-content" class="skip-link">Skip to main content</a>
 
 <div class="bg" aria-hidden="true"></div>
 
@@ -71,12 +86,38 @@
   style:--t1={tokens.color.text.t1}
 >
   <Topbar {onStart} {onStop} />
-  <LanesView {visibleStart} {visibleEnd} />
-  <XAxisBar startRound={visibleStart} endRound={visibleEnd} {currentRound} startedAt={$measurementStore.startedAt} {sampleTimestamps} />
+
+  <div class="shell-body">
+    <EndpointRail />
+
+    <div class="shell-main-wrap">
+      <ViewSwitcher />
+
+      <main id="main-content" class="shell-main" tabindex="-1">
+        {#if showLegacyLanes}
+          <div class="legacy-stack">
+            <LanesView {visibleStart} {visibleEnd} />
+            <XAxisBar
+              startRound={visibleStart}
+              endRound={visibleEnd}
+              {currentRound}
+              startedAt={$measurementStore.startedAt}
+              {sampleTimestamps}
+            />
+          </div>
+        {:else}
+          <OverviewView />
+        {/if}
+      </main>
+    </div>
+  </div>
+
   <FooterBar />
 </div>
 
-<CrossLaneHover {visibleStart} {visibleEnd} />
+{#if showLegacyLanes}
+  <CrossLaneHover {visibleStart} {visibleEnd} />
+{/if}
 
 <div
   id="chronoscope-announcer"
@@ -89,7 +130,7 @@
 <style>
   .skip-link {
     position: absolute; top: -40px; left: 0; z-index: 9999;
-    padding: 8px 16px; background: #67e8f9; color: #0c0a14;
+    padding: 8px 16px; background: var(--accent-cyan); color: var(--bg-base);
     font-weight: 600; text-decoration: none;
     border-radius: 0 0 4px 0; transition: top 100ms ease;
   }
@@ -97,13 +138,53 @@
 
   .bg {
     position: fixed; inset: 0; z-index: 0;
-    background: #0e0c18;
+    background: var(--bg-base);
+  }
+  /* Subtle cyan/pink atmosphere — matches v2 prototype background pass.       */
+  .bg::before {
+    content: ''; position: absolute; inset: 0; pointer-events: none;
+    background:
+      radial-gradient(ellipse 70% 50% at 15% 0%,  rgba(103,232,249,.05), transparent 60%),
+      radial-gradient(ellipse 60% 45% at 90% 100%, rgba(249,168,212,.04), transparent 65%);
   }
 
   .app {
     position: relative; z-index: 1;
-    height: 100vh; display: flex; flex-direction: column;
-    overflow: hidden; color: var(--t1);
+    height: 100vh;
+    display: flex; flex-direction: column;
+    overflow: hidden;
+    color: var(--t1);
+  }
+
+  .shell-body {
+    flex: 1;
+    display: flex;
+    min-height: 0;
+  }
+
+  .shell-main-wrap {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+  }
+
+  .shell-main {
+    flex: 1;
+    overflow-y: auto;
+    overflow-x: hidden;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+  .shell-main:focus { outline: none; }
+
+  .legacy-stack {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
   }
 
   .sr-only {
@@ -111,5 +192,4 @@
     padding: 0; margin: -1px; overflow: hidden;
     clip-path: inset(50%); white-space: nowrap; border: 0;
   }
-
 </style>

--- a/src/lib/components/OverviewView.svelte
+++ b/src/lib/components/OverviewView.svelte
@@ -1,0 +1,55 @@
+<!-- src/lib/components/OverviewView.svelte -->
+<!-- Phase 1 stub. Phase 2 replaces the inner block with the chronograph dial.  -->
+<section class="overview" aria-label="Overview">
+  <div class="overview-stub">
+    <div class="overview-stub-kicker">Overview</div>
+    <h1 class="overview-stub-title">Coming soon</h1>
+    <p class="overview-stub-desc">
+      The chronograph dial lands in Phase&nbsp;2. Pick the
+      <strong>Lanes</strong> tab to use the existing visualization
+      while the v2 surfaces are built out.
+    </p>
+  </div>
+</section>
+
+<style>
+  .overview {
+    flex: 1;
+    display: grid;
+    place-items: center;
+    padding: 32px;
+    min-height: 0;
+  }
+  .overview-stub {
+    max-width: 480px;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .overview-stub-kicker {
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-kicker);
+    color: var(--accent-cyan);
+    text-transform: uppercase;
+  }
+  .overview-stub-title {
+    font-family: var(--sans);
+    font-size: var(--ts-3xl);
+    font-weight: 300;
+    letter-spacing: var(--tr-display);
+    color: var(--t1);
+    margin: 0;
+  }
+  .overview-stub-desc {
+    font-family: var(--sans);
+    font-size: var(--ts-base);
+    color: var(--t3);
+    line-height: 1.55;
+  }
+  .overview-stub-desc strong {
+    color: var(--t1);
+    font-weight: 500;
+  }
+</style>

--- a/src/lib/components/Topbar.svelte
+++ b/src/lib/components/Topbar.svelte
@@ -1,8 +1,12 @@
 <!-- src/lib/components/Topbar.svelte -->
+<!-- v2 chrome — pixel-aligned to v2/Chronoscope v2.html. Preserves every       -->
+<!-- existing control (endpoints / settings / share / start-stop) and adds the -->
+<!-- networkQualityStore-driven status pill required by the Phase 1 brief.     -->
 <script lang="ts">
   import { measurementStore } from '$lib/stores/measurements';
   import { uiStore } from '$lib/stores/ui';
-  import { tokens } from '$lib/tokens';
+  import { networkQualityStore } from '$lib/stores/derived';
+  import { LEVEL_STYLES, networkLevel } from '$lib/utils/classify';
   import type { TestLifecycleState } from '$lib/types';
 
   let { onStart, onStop }: {
@@ -10,145 +14,150 @@
     onStop?: () => void;
   } = $props();
 
-  let lifecycle: TestLifecycleState = $derived($measurementStore.lifecycle);
-  let roundCounter: number = $derived($measurementStore.roundCounter);
-  let isSharedView: boolean = $derived($uiStore.isSharedView);
+  const lifecycle: TestLifecycleState = $derived($measurementStore.lifecycle);
+  const roundCounter: number = $derived($measurementStore.roundCounter);
+  const isSharedView: boolean = $derived($uiStore.isSharedView);
 
-  let showRunStatus: boolean = $derived(
-    lifecycle === 'running' || lifecycle === 'starting' || lifecycle === 'stopping'
-  );
+  const isRunning = $derived(lifecycle === 'running');
+  const isTransitioning = $derived(lifecycle === 'starting' || lifecycle === 'stopping');
 
-  let runLabel: string = $derived.by(() => {
-    if (isSharedView) return 'Shared Results';
-    if (lifecycle === 'running') return `Round ${roundCounter}`;
-    if (lifecycle === 'starting') return 'Starting\u2026';
-    if (lifecycle === 'stopping') return 'Stopping\u2026';
-    return '';
+  const runText = $derived.by(() => {
+    if (lifecycle === 'running')  return 'Measuring';
+    if (lifecycle === 'starting') return 'Starting…';
+    if (lifecycle === 'stopping') return 'Stopping…';
+    return 'Halted';
   });
 
-  let isRunning: boolean = $derived(lifecycle === 'running');
-  let isTransitioning: boolean = $derived(lifecycle === 'starting' || lifecycle === 'stopping');
+  const tickText = $derived(`T+${String(roundCounter).padStart(4, '0')}`);
 
-  let startStopLabel: string = $derived.by(() => {
-    if (lifecycle === 'running') return 'Stop';
-    if (lifecycle === 'starting') return 'Starting\u2026';
-    if (lifecycle === 'stopping') return 'Stopping\u2026';
+  const startStopLabel = $derived.by(() => {
+    if (lifecycle === 'running') return 'Halt';
+    if (lifecycle === 'starting') return 'Starting…';
+    if (lifecycle === 'stopping') return 'Stopping…';
     return 'Start';
   });
-
-  let isStartButton: boolean = $derived(
-    lifecycle === 'idle' || lifecycle === 'stopped' || lifecycle === 'completed'
+  const isStartButton = $derived(
+    lifecycle === 'idle' || lifecycle === 'stopped' || lifecycle === 'completed',
   );
 
-  function handleStartStop(): void {
-    if (lifecycle === 'running') {
-      onStop?.();
-    } else if (lifecycle === 'idle' || lifecycle === 'stopped' || lifecycle === 'completed') {
-      onStart?.();
-    }
-  }
+  // Status pill — driven by networkQualityStore, mapped through networkLevel().
+  const score = $derived($networkQualityStore);
+  const level = $derived(networkLevel(score));
+  const pillStyle = $derived(LEVEL_STYLES[level]);
 
+  function handleStartStop(): void {
+    if (lifecycle === 'running') onStop?.();
+    else if (isStartButton) onStart?.();
+  }
   function handleRunOwn(): void {
     uiStore.clearSharedView();
     measurementStore.reset();
   }
-
-  function handleSettings(): void { uiStore.toggleSettings(); }
-  function handleShare(): void { uiStore.toggleShare(); }
+  function handleSettings():  void { uiStore.toggleSettings();  }
+  function handleShare():     void { uiStore.toggleShare();     }
   function handleEndpoints(): void { uiStore.toggleEndpoints(); }
 </script>
 
-<header
-  class="topbar"
-  style:--topbar-bg={tokens.color.topbar.bg}
-  style:--border-bright={tokens.color.surface.border.bright}
-  style:--t1={tokens.color.text.t1}
-  style:--t2={tokens.color.text.t2}
-  style:--t3={tokens.color.text.t3}
-  style:--glass-bg={tokens.color.glass.bg}
-  style:--glass-border={tokens.color.glass.border}
-  style:--glass-highlight={tokens.color.glass.highlight}
-  style:--accent-cyan={tokens.color.accent.cyan}
-  style:--accent-pink={tokens.color.accent.pink}
-  style:--accent-green={tokens.color.accent.green}
-  style:--green-glow={tokens.color.accent.greenGlow}
-  style:--cyan-bg-subtle={tokens.color.accent.cyanBgSubtle}
-  style:--cyan-border-subtle={tokens.color.accent.cyanBorderSubtle}
-  style:--cyan25={tokens.color.accent.cyan25}
-  style:--glow-cyan={tokens.color.glow.cyan}
-  style:--pink-bg-subtle={tokens.color.accent.pinkBgSubtle}
-  style:--pink-border-subtle={tokens.color.accent.pinkBorderSubtle}
-  style:--pink25={tokens.color.accent.pink25}
-  style:--glow-pink={tokens.color.glow.pink}
-  style:--mono={tokens.typography.mono.fontFamily}
-  style:--sans={tokens.typography.sans.fontFamily}
-  style:--topbar-height="{tokens.lane.topbarHeight}px"
-  style:--btn-radius="{tokens.radius.btn}px"
-  style:--timing-btn="{tokens.timing.btnHover}ms"
-  style:--timing-stat="{tokens.timing.statTransition}ms"
-  style:--timing-dot-enter="{tokens.timing.dotEntrance}ms"
-  style:--timing-dot-exit="{tokens.timing.dotExit}ms"
-  style:--easing-spring={tokens.easing.spring}
-  style:--breakpoint-small="{tokens.breakpoints.small}px"
->
-  <div class="logo" aria-label="Chronoscope">
-    <span class="logo-text">Chronoscope</span>
+<header class="topbar" data-level={level}>
+  <div class="brand">
+    <div class="brand-mark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" width="22" height="22">
+        <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="1.2" />
+        <circle cx="12" cy="12" r="1.4" fill="currentColor" />
+        <line x1="12" y1="12" x2="12" y2="4.5"  stroke="currentColor" stroke-width="1.2" stroke-linecap="round" />
+        <line x1="12" y1="12" x2="17" y2="15"   stroke="currentColor" stroke-width="1"   stroke-linecap="round" opacity="0.7" />
+      </svg>
+    </div>
+    <div class="brand-meta">
+      <div class="brand-name">Chronoscope</div>
+      <div class="brand-sub">HTTP latency diagnostic · v2</div>
+    </div>
   </div>
 
-  {#if showRunStatus}
-    <div class="run-status">
-      <div
-        class="pulse-dot"
-        class:dot-enter={isRunning}
-        class:dot-exit={!isRunning}
-        aria-hidden="true"
-      ></div>
-      <span class="run-label" aria-hidden="true">{runLabel}</span>
-    </div>
-  {/if}
+  <div class="topbar-divider" aria-hidden="true"></div>
+
+  <div
+    class="status-pill"
+    role="status"
+    aria-live="polite"
+    aria-label="Network quality: {pillStyle.label}{score !== null ? `, score ${score}` : ''}"
+    style:--pill-color={pillStyle.color}
+    style:--pill-glow={pillStyle.glow}
+  >
+    <span class="status-dot" class:on={isRunning && level !== 'unknown'}></span>
+    <span class="status-label">{pillStyle.label}</span>
+    <span class="status-tick">{tickText}</span>
+  </div>
+
+  <div class="topbar-divider" aria-hidden="true"></div>
+
+  <div class="run-state">
+    <span class="run-state-label">{runText}</span>
+  </div>
 
   <div class="spacer"></div>
 
   <nav class="actions" aria-label="Test controls">
     {#if isSharedView}
-      <button type="button" class="btn btn-ghost" aria-label="Share results" aria-expanded={$uiStore.showShare} aria-controls="share-popover" onclick={handleShare}>
-        <svg class="btn-icon" width="20" height="20" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <button
+        type="button" class="icon-btn"
+        aria-label="Share results" aria-expanded={$uiStore.showShare} aria-controls="share-popover"
+        onclick={handleShare}
+      >
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
           <path d="M4 10V12.5C4 13.052 4.448 13.5 5 13.5H11C11.552 13.5 12 13.052 12 12.5V10" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
           <path d="M8 2.5V10M8 2.5L5.5 5M8 2.5L10.5 5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
       </button>
-      <button type="button" class="btn btn-start-stop start" aria-label="Run your own test" onclick={handleRunOwn}>Run Your Own Test</button>
+      <button type="button" class="run-btn start" aria-label="Run your own test" onclick={handleRunOwn}>
+        Run Your Own Test
+      </button>
     {:else}
-      <button type="button" class="btn btn-ghost" aria-label="Add or remove endpoints" aria-expanded={$uiStore.showEndpoints} aria-controls="endpoint-drawer" onclick={handleEndpoints}>
-        <svg class="btn-icon" width="20" height="20" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <button
+        type="button" class="icon-btn"
+        aria-label="Add or remove endpoints" aria-expanded={$uiStore.showEndpoints} aria-controls="endpoint-drawer"
+        onclick={handleEndpoints}
+      >
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
           <circle cx="8" cy="8" r="6.5" stroke="currentColor" stroke-width="1.3"/>
           <path d="M8 5V11M5 8H11" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
         </svg>
       </button>
-      <button type="button" class="btn btn-ghost" aria-label="Open settings" aria-expanded={$uiStore.showSettings} aria-controls="settings-drawer" onclick={handleSettings}>
-        <svg class="btn-icon" width="20" height="20" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <button
+        type="button" class="icon-btn"
+        aria-label="Open settings" aria-expanded={$uiStore.showSettings} aria-controls="settings-drawer"
+        onclick={handleSettings}
+      >
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
           <path d="M2 4H10.5M13.5 4H14M2 8H5M8 8H14M2 12H8M11 12H14" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
-          <circle cx="12" cy="4" r="1.5" stroke="currentColor" stroke-width="1.3"/>
-          <circle cx="6.5" cy="8" r="1.5" stroke="currentColor" stroke-width="1.3"/>
+          <circle cx="12"  cy="4"  r="1.5" stroke="currentColor" stroke-width="1.3"/>
+          <circle cx="6.5" cy="8"  r="1.5" stroke="currentColor" stroke-width="1.3"/>
           <circle cx="9.5" cy="12" r="1.5" stroke="currentColor" stroke-width="1.3"/>
         </svg>
       </button>
-      <button type="button" class="btn btn-ghost" aria-label="Share results" aria-expanded={$uiStore.showShare} aria-controls="share-popover" onclick={handleShare}>
-        <svg class="btn-icon" width="20" height="20" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <button
+        type="button" class="icon-btn"
+        aria-label="Share results" aria-expanded={$uiStore.showShare} aria-controls="share-popover"
+        onclick={handleShare}
+      >
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
           <path d="M4 10V12.5C4 13.052 4.448 13.5 5 13.5H11C11.552 13.5 12 13.052 12 12.5V10" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
           <path d="M8 2.5V10M8 2.5L5.5 5M8 2.5L10.5 5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
       </button>
       <button
         type="button"
-        class="btn btn-start-stop"
+        class="run-btn"
         class:start={isStartButton}
-        class:stop={!isStartButton && lifecycle === 'running'}
+        class:stop={isRunning}
         disabled={isTransitioning}
         aria-disabled={isTransitioning}
         aria-label={startStopLabel}
         onclick={handleStartStop}
-      >{startStopLabel}</button>
+      >
+        <span class="run-btn-icon" aria-hidden="true">{isRunning ? '■' : '▶'}</span>
+        <span>{startStopLabel}</span>
+      </button>
     {/if}
   </nav>
 </header>
@@ -156,152 +165,149 @@
 <style>
   .topbar {
     height: var(--topbar-height);
+    padding: 0 18px;
     display: flex;
     align-items: center;
-    padding: 0 20px;
-    gap: 14px;
+    gap: 12px;
     flex-shrink: 0;
-    background: var(--topbar-bg);
-    border-bottom: 1px solid var(--border-bright);
-    backdrop-filter: blur(30px) saturate(1.3);
-    -webkit-backdrop-filter: blur(30px) saturate(1.3);
-    position: relative;
+    background: var(--surface-topbar-bg);
+    backdrop-filter: blur(16px) saturate(1.3);
+    -webkit-backdrop-filter: blur(16px) saturate(1.3);
+    border-bottom: 1px solid var(--border-mid);
+    color: var(--t1);
   }
-  .topbar::after {
-    content: '';
-    position: absolute;
-    top: 0; left: 20%; right: 20%;
-    height: 1px;
-    background: linear-gradient(90deg, transparent, var(--glass-highlight), transparent);
-    pointer-events: none;
+
+  .brand { display: flex; align-items: center; gap: 10px; }
+  .brand-mark {
+    width: 32px; height: 32px;
+    border-radius: 8px;
+    background: linear-gradient(135deg, rgba(103,232,249,.15), rgba(249,168,212,.10));
+    border: 1px solid var(--border-bright);
+    display: grid; place-items: center;
+    color: var(--accent-cyan);
+    flex-shrink: 0;
   }
-  .logo { display: flex; align-items: center; }
-  .logo-text {
+  .brand-meta { display: flex; flex-direction: column; gap: 1px; }
+  .brand-name {
     font-family: var(--sans);
-    font-weight: 700;
-    font-size: 17px;
-    letter-spacing: -0.02em;
-    background: linear-gradient(135deg, var(--accent-cyan), var(--accent-pink));
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    white-space: nowrap;
+    font-weight: 600;
+    font-size: var(--ts-lg);
+    letter-spacing: var(--tr-tight);
+    color: var(--t1);
   }
-  .run-status {
-    display: flex; align-items: center; gap: 8px;
-    font-family: var(--mono); font-size: 11px; font-weight: 300; color: var(--t2);
+  .brand-sub {
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    color: var(--t3);
+    letter-spacing: var(--tr-kicker);
+    text-transform: uppercase;
   }
-  .pulse-dot {
-    width: 6px; height: 6px; border-radius: 50%;
-    background: var(--accent-green);
-    box-shadow: 0 0 8px var(--green-glow);
-    animation: pulse 2s ease-in-out infinite;
+
+  .topbar-divider {
+    width: 1px; height: 28px;
+    background: var(--border-mid);
     flex-shrink: 0;
-    transform: scale(0);
   }
-  .dot-enter {
-    animation: dot-entrance var(--timing-dot-enter) var(--easing-spring) forwards, pulse 2s ease-in-out infinite var(--timing-dot-enter);
+
+  .status-pill {
+    display: inline-flex; align-items: center; gap: 8px;
+    padding: 6px 10px; border-radius: 999px;
+    background: rgba(255,255,255,.03);
+    border: 1px solid var(--border-mid);
+    font-family: var(--mono);
+    font-size: var(--ts-sm);
+    color: var(--t2);
+    letter-spacing: var(--tr-label);
+    text-transform: uppercase;
   }
-  .dot-exit {
-    animation: dot-exit-anim var(--timing-dot-exit) ease-out forwards;
+  .status-dot {
+    width: 7px; height: 7px;
+    border-radius: 50%;
+    background: var(--pill-color);
+    box-shadow: 0 0 8px var(--pill-glow);
+    transition: background 200ms ease, box-shadow 200ms ease;
   }
-  @keyframes dot-entrance {
-    from { transform: scale(0); }
-    to { transform: scale(1); }
-  }
-  @keyframes dot-exit-anim {
-    from { transform: scale(1); opacity: 1; }
-    to { transform: scale(0); opacity: 0; }
-  }
+  .status-dot.on { animation: pulse 1.8s ease-in-out infinite; }
   @keyframes pulse {
-    0%, 100% { opacity: 1; transform: scale(1); }
-    50% { opacity: .4; transform: scale(.85); }
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.45; }
   }
-  .run-label { color: var(--t2); }
+  .status-label { color: var(--t2); }
+  .status-tick {
+    color: var(--t3);
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0;
+  }
+
+  .run-state { display: flex; align-items: center; }
+  .run-state-label {
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    color: var(--t3);
+    letter-spacing: var(--tr-label);
+    text-transform: uppercase;
+  }
+
   .spacer { flex: 1; }
+
   .actions { display: flex; align-items: center; gap: 8px; }
-  .btn {
-    font-family: var(--sans); font-size: 11px; font-weight: 500;
-    letter-spacing: 0.01em; padding: 7px 16px;
-    border-radius: var(--btn-radius);
-    border: 1px solid transparent;
+
+  .icon-btn {
+    width: 32px; height: 32px;
+    border-radius: 8px;
     background: transparent;
-    color: var(--t2); cursor: pointer;
-    transition: background var(--timing-stat) ease,
-                border-color var(--timing-stat) ease,
-                color var(--timing-stat) ease,
-                box-shadow var(--timing-stat) ease,
-                transform 100ms ease;
-    white-space: nowrap; min-height: 44px;
-    display: flex; align-items: center; justify-content: center;
+    border: 1px solid var(--border-mid);
+    color: var(--t2);
+    display: grid; place-items: center;
+    cursor: pointer;
+    transition: color 160ms ease, border-color 160ms ease, background 160ms ease;
+  }
+  .icon-btn:hover {
+    color: var(--t1);
+    border-color: var(--border-bright);
+    background: rgba(255,255,255,.03);
+  }
+  .icon-btn:focus-visible {
+    outline: 1.5px solid var(--accent-cyan);
+    outline-offset: 2px;
   }
 
-  /* Ghost buttons — secondary actions */
-  .btn-ghost {
-    background: transparent;
-    border-color: transparent;
-    color: var(--t1);
+  .run-btn {
+    font-family: var(--sans);
+    font-size: var(--ts-md);
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    padding: 8px 16px;
+    border-radius: 8px;
+    background: rgba(134,239,172,.12);
+    border: 1px solid rgba(134,239,172,.30);
+    color: var(--accent-green);
+    display: inline-flex; align-items: center; gap: 6px;
+    cursor: pointer;
+    transition: filter 160ms ease;
   }
-  .btn-ghost:hover:not(:disabled) {
-    background: var(--glass-bg);
-    border-color: transparent;
-    color: var(--t1);
-  }
-
-  /* Start/Stop — single node, class toggles for CSS crossfade */
-  .btn-start-stop {
-    background: var(--cyan-bg-subtle);
-    border-color: var(--cyan-border-subtle);
-    color: var(--accent-cyan);
-  }
-  .btn-start-stop.stop {
-    background: var(--pink-bg-subtle);
-    border-color: var(--pink-border-subtle);
+  .run-btn.stop {
+    background: rgba(249,168,212,.10);
+    border-color: rgba(249,168,212,.30);
     color: var(--accent-pink);
   }
-  .btn-start-stop:hover:not(:disabled) {
-    background: var(--cyan25);
-    border-color: var(--cyan-border-subtle);
-    box-shadow: 0 0 12px var(--glow-cyan);
-    color: var(--accent-cyan);
+  .run-btn:hover:not(:disabled) { filter: brightness(1.15); }
+  .run-btn:disabled { opacity: 0.55; cursor: not-allowed; }
+  .run-btn:focus-visible {
+    outline: 1.5px solid var(--accent-cyan);
+    outline-offset: 2px;
   }
-  .btn-start-stop.stop:hover:not(:disabled) {
-    background: var(--pink25);
-    border-color: var(--pink-border-subtle);
-    box-shadow: 0 0 12px var(--glow-pink);
-    color: var(--accent-pink);
-  }
-
-  .btn:active:not(:disabled) {
-    transform: scale(0.97);
-    transition-duration: 50ms;
-  }
-
-  .btn:disabled { opacity: 0.5; cursor: not-allowed; }
-
-  .btn-icon { display: block; flex-shrink: 0; }
+  .run-btn-icon { font-size: var(--ts-xs); }
 
   @media (prefers-reduced-motion: reduce) {
-    .btn, .pulse-dot, .dot-enter {
-      transition-duration: 0s !important;
-      animation-duration: 0s !important;
-    }
+    .status-dot, .icon-btn, .run-btn { animation: none !important; transition: none; }
   }
 
+  /* Mobile narrow: collapse the run-state label and brand-sub to keep the topbar
+     usable below 768px. Status pill + action icons stay visible.            */
   @media (max-width: 767px) {
-    .topbar { padding: 0 12px; gap: 8px; }
-    .btn-ghost { padding: 7px; min-width: 44px; }
-  }
-
-  @media (min-width: 768px) {
-    .btn-ghost { min-width: 44px; }
-  }
-
-  @media (max-width: 479px) {
-    .logo-text {
-      max-width: 80px;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
+    .brand-sub, .run-state, .topbar-divider:nth-of-type(2) { display: none; }
+    .topbar { gap: 8px; padding: 0 12px; }
+    .status-pill { padding: 6px 8px; }
   }
 </style>

--- a/src/lib/components/Topbar.svelte
+++ b/src/lib/components/Topbar.svelte
@@ -74,7 +74,7 @@
     </div>
   </div>
 
-  <div class="topbar-divider" aria-hidden="true"></div>
+  <div class="topbar-divider brand-divider" aria-hidden="true"></div>
 
   <div
     class="status-pill"
@@ -86,10 +86,10 @@
   >
     <span class="status-dot" class:on={isRunning && level !== 'unknown'}></span>
     <span class="status-label">{pillStyle.label}</span>
-    <span class="status-tick">{tickText}</span>
+    <span class="status-tick" aria-hidden="true">{tickText}</span>
   </div>
 
-  <div class="topbar-divider" aria-hidden="true"></div>
+  <div class="topbar-divider run-divider" aria-hidden="true"></div>
 
   <div class="run-state">
     <span class="run-state-label">{runText}</span>
@@ -304,9 +304,11 @@
   }
 
   /* Mobile narrow: collapse the run-state label and brand-sub to keep the topbar
-     usable below 768px. Status pill + action icons stay visible.            */
+     usable below 768px. Status pill + action icons stay visible.
+     Hides .run-divider explicitly — selector is class-based because the brand
+     element is also a <div> and `:nth-of-type(2)` would match the wrong one.  */
   @media (max-width: 767px) {
-    .brand-sub, .run-state, .topbar-divider:nth-of-type(2) { display: none; }
+    .brand-sub, .run-state, .run-divider { display: none; }
     .topbar { gap: 8px; padding: 0 12px; }
     .status-pill { padding: 6px 8px; }
   }

--- a/src/lib/components/ViewSwitcher.svelte
+++ b/src/lib/components/ViewSwitcher.svelte
@@ -1,0 +1,193 @@
+<!-- src/lib/components/ViewSwitcher.svelte -->
+<!-- Six-tab view picker. Sits below the topbar, above the main content area. -->
+<!-- Phase 1 ships only Overview + Lanes as enabled tabs; the four "in-flight" -->
+<!-- views are present-but-disabled so the chrome shape is final.              -->
+<script lang="ts">
+  import { uiStore } from '$lib/stores/ui';
+  import type { ActiveView } from '$lib/types';
+
+  interface ViewDef {
+    readonly id: ActiveView;
+    readonly key: string;
+    readonly label: string;
+    readonly hint: string;
+    readonly enabled: boolean;
+  }
+
+  // Visible label list. Order matches the prototype's left-to-right reading.
+  // Lanes stays enabled in Phase 1 so the legacy Glass Lanes view remains
+  // reachable until Phase 7 retires it (per the v2 redesign non-negotiable
+  // "keep all 6 legacy views working until Phase 7").
+  const VIEWS: readonly ViewDef[] = [
+    { id: 'overview', key: '1', label: 'Overview', hint: 'At a glance',         enabled: true  },
+    { id: 'live',     key: '2', label: 'Live',     hint: 'Real-time scope',     enabled: false },
+    { id: 'atlas',    key: '3', label: 'Atlas',    hint: 'Phase breakdown',     enabled: false },
+    { id: 'strata',   key: '4', label: 'Strata',   hint: 'Distribution',        enabled: false },
+    { id: 'terminal', key: '5', label: 'Terminal', hint: 'Event log',           enabled: false },
+    { id: 'lanes',    key: '6', label: 'Lanes',    hint: 'Glass lanes · legacy',enabled: true  },
+  ];
+
+  const DISABLED_TOOLTIP = 'Prototype in progress — not yet available.';
+
+  const activeView = $derived($uiStore.activeView);
+
+  // Deprecated activeView strings (timeline/heatmap/split) all render through
+  // the Lanes view, so highlight the Lanes tab when those land here.
+  function isActive(id: ActiveView): boolean {
+    if (id === 'lanes') {
+      return activeView === 'lanes' || activeView === 'timeline' || activeView === 'heatmap' || activeView === 'split';
+    }
+    return activeView === id;
+  }
+
+  function selectView(view: ViewDef): void {
+    if (!view.enabled) return;
+    uiStore.setActiveView(view.id);
+  }
+</script>
+
+<nav class="view-switcher" aria-label="Views">
+  {#each VIEWS as view (view.id)}
+    {@const active = isActive(view.id)}
+    <button
+      type="button"
+      class="view-tab"
+      class:active
+      class:disabled={!view.enabled}
+      role="tab"
+      aria-selected={active}
+      aria-disabled={!view.enabled}
+      title={view.enabled ? '' : DISABLED_TOOLTIP}
+      tabindex={view.enabled ? 0 : -1}
+      onclick={() => selectView(view)}
+    >
+      <span class="view-tab-key" aria-hidden="true">{view.key}</span>
+      <span class="view-tab-body">
+        <span class="view-tab-label">{view.label}</span>
+        <span class="view-tab-sub">{view.hint}</span>
+      </span>
+    </button>
+  {/each}
+  <div class="view-switcher-trailing" aria-hidden="true">
+    <span class="kbd">⌨ 1·2·3·4·5·6</span>
+  </div>
+</nav>
+
+<style>
+  .view-switcher {
+    display: flex;
+    gap: 3px;
+    padding: 10px 18px 0;
+    align-items: stretch;
+    border-bottom: 1px solid var(--border-mid);
+    background: rgba(10, 9, 18, 0.3);
+    flex-shrink: 0;
+  }
+  .view-tab {
+    background: transparent;
+    border: none;
+    padding: 8px 10px 12px 8px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    border-radius: 6px 6px 0 0;
+    position: relative;
+    transition: background 160ms ease, color 160ms ease;
+    color: var(--t3);
+    font-family: var(--sans);
+    cursor: pointer;
+    flex-shrink: 1;
+    min-width: 0;
+  }
+  .view-tab::after {
+    content: '';
+    position: absolute;
+    bottom: -1px;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: transparent;
+    transition: background 200ms ease, box-shadow 200ms ease;
+  }
+  .view-tab:hover:not(.disabled) {
+    color: var(--t1);
+    background: rgba(255, 255, 255, 0.02);
+  }
+  .view-tab.active {
+    color: var(--t1);
+    background: rgba(103, 232, 249, 0.05);
+  }
+  .view-tab.active::after {
+    background: var(--accent-cyan);
+    box-shadow: 0 0 10px var(--glow-cyan);
+  }
+  .view-tab.disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+  }
+  .view-tab:focus-visible {
+    outline: 1.5px solid var(--accent-cyan);
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+
+  .view-tab-key {
+    width: 22px;
+    height: 22px;
+    display: grid;
+    place-items: center;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid var(--border-mid);
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    color: var(--t3);
+  }
+  .view-tab.active .view-tab-key {
+    background: rgba(103, 232, 249, 0.15);
+    border-color: rgba(103, 232, 249, 0.3);
+    color: var(--accent-cyan);
+  }
+
+  .view-tab-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    text-align: left;
+    min-width: 0;
+  }
+  .view-tab-label {
+    font-size: var(--ts-md);
+    font-weight: 500;
+    white-space: nowrap;
+  }
+  .view-tab-sub {
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    color: var(--t4);
+    letter-spacing: var(--tr-label);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .view-tab.active .view-tab-sub { color: var(--t3); }
+
+  .view-switcher-trailing {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    padding-right: 4px;
+    flex-shrink: 0;
+  }
+  .kbd {
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    color: var(--t4);
+    letter-spacing: var(--tr-label);
+    white-space: nowrap;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .view-tab, .view-tab::after { transition: none; }
+  }
+</style>

--- a/src/lib/components/ViewSwitcher.svelte
+++ b/src/lib/components/ViewSwitcher.svelte
@@ -46,7 +46,7 @@
   }
 </script>
 
-<nav class="view-switcher" aria-label="Views">
+<nav class="view-switcher" role="group" aria-label="Views">
   {#each VIEWS as view (view.id)}
     {@const active = isActive(view.id)}
     <button
@@ -54,8 +54,8 @@
       class="view-tab"
       class:active
       class:disabled={!view.enabled}
-      role="tab"
-      aria-selected={active}
+      aria-current={active ? 'page' : undefined}
+      aria-pressed={active}
       aria-disabled={!view.enabled}
       title={view.enabled ? '' : DISABLED_TOOLTIP}
       tabindex={view.enabled ? 0 : -1}

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -331,19 +331,26 @@ export const tokens = {
     label:   { size: 11, weight: 500, opacity: 0.58, letterSpacing: '0.06em' },
     body:    { size: 14, weight: 400, opacity: 0.94, letterSpacing: '0' },
 
-    // v2 named scale — chip labels, rail url, rail metric, triptych values, verdict title.
+    // v2 named scale — aligned to the prototype (`v2/Chronoscope v2.html`), which
+    // is the pixel-fidelity source of truth. Half-pixel sizes from the earlier
+    // handoff spec were reconciled to the prototype's integer-px scale.
     scale: {
-      xs:  '9px',     // chip labels, metadata kickers
-      sm:  '10px',    // rail url, axis labels, severity chips
-      md:  '11.5px',  // rail label, segment labels
-      lg:  '14px',    // rail metric, sub-metric numbers
-      xl:  '18px',    // verdict title
-      xxl: '32px',    // overview triptych values
+      xs:   '10px',  // micro labels, all-caps only
+      sm:   '11px',  // mono metadata, urls
+      md:   '12px',  // controls, chip text
+      base: '13px',  // body copy, chips
+      lg:   '14px',  // rail metrics, brand name, sub-metric numbers
+      xl:   '17px',  // subsection titles, logo
+      xl2:  '20px',  // section titles
+      xl3:  '24px',  // page titles
+      xxl:  '32px',  // reserved for Overview triptych values
     },
     tracking: {
-      kicker: '0.18em',
-      label:  '0.08em',
-      body:   '0',
+      kicker:  '0.22em',
+      label:   '0.14em',
+      tight:   '-0.01em',
+      display: '-0.03em',
+      body:    '0',
     },
   },
 
@@ -425,7 +432,8 @@ export const tokens = {
     ringInitialR:    7,
     ringFinalR:     14,
     chartWindow:    60,   // max visible rounds in SVG chart (sliding window)
-    topbarHeight:   54,
+    topbarHeight:   58,   // px — bumped from 54 to match v2 prototype chrome
+    railWidth:     264,   // px — v2 persistent endpoint rail, fixed column width
     xAxisHeight:    30,
     footerHeight:   38,
     minHeight:           120,   // px — minimum lane height before 2-col triggers (AC3)

--- a/src/lib/utils/classify.ts
+++ b/src/lib/utils/classify.ts
@@ -88,3 +88,39 @@ export function networkQuality(
   }
   return Math.round(total / ready.length);
 }
+
+export type NetworkLevel = 'unknown' | 'healthy' | 'warning' | 'degraded' | 'critical';
+
+/**
+ * Map a 0–100 networkQuality score to a named pill state for the topbar.
+ * Buckets are spaced so mixes of classify() outcomes land in distinct pills
+ * even though the underlying aggregate emits {100, 60, 20} for uniform fleets.
+ *
+ *   null   → unknown
+ *   ≥ 90   → healthy
+ *   ≥ 60   → warning
+ *   ≥ 30   → degraded
+ *   <  30  → critical
+ */
+export function networkLevel(score: number | null): NetworkLevel {
+  if (score === null) return 'unknown';
+  if (score >= 90) return 'healthy';
+  if (score >= 60) return 'warning';
+  if (score >= 30) return 'degraded';
+  return 'critical';
+}
+
+export interface LevelStyle {
+  readonly color: string;
+  readonly glow:  string;
+  readonly label: string;
+}
+
+// CSS-var-backed palette so every level chip agrees with bridgeTokensToCss.
+export const LEVEL_STYLES: Record<NetworkLevel, LevelStyle> = {
+  unknown:  { color: 'var(--t4)',                glow: 'transparent',              label: 'No data'  },
+  healthy:  { color: 'var(--accent-green)',      glow: 'var(--green-glow)',        label: 'Healthy'  },
+  warning:  { color: 'var(--accent-amber)',      glow: 'var(--accent-amber-glow)', label: 'Warning'  },
+  degraded: { color: 'var(--accent-amber-tone)', glow: 'var(--accent-amber-glow)', label: 'Degraded' },
+  critical: { color: 'var(--accent-pink)',       glow: 'var(--accent-pink-glow)',  label: 'Critical' },
+};

--- a/tests/unit/classify.test.ts
+++ b/tests/unit/classify.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { classify, networkQuality, HEALTH_STYLES } from '../../src/lib/utils/classify';
+import {
+  classify,
+  networkQuality,
+  networkLevel,
+  HEALTH_STYLES,
+  LEVEL_STYLES,
+} from '../../src/lib/utils/classify';
 import type { EndpointStatistics } from '../../src/lib/types';
 
 function makeStats(over: Partial<EndpointStatistics> = {}): EndpointStatistics {
@@ -100,5 +106,44 @@ describe('HEALTH_STYLES', () => {
     for (const bucket of ['healthy', 'degraded', 'unhealthy', 'unknown'] as const) {
       expect(HEALTH_STYLES[bucket].color).toMatch(/^var\(--/);
     }
+  });
+});
+
+describe('networkLevel()', () => {
+  it('returns "unknown" for null score', () => {
+    expect(networkLevel(null)).toBe('unknown');
+  });
+  it('returns "healthy" at 90 and above', () => {
+    expect(networkLevel(100)).toBe('healthy');
+    expect(networkLevel(90)).toBe('healthy');
+  });
+  it('returns "warning" between 60 and 89', () => {
+    expect(networkLevel(89)).toBe('warning');
+    expect(networkLevel(60)).toBe('warning');
+  });
+  it('returns "degraded" between 30 and 59', () => {
+    expect(networkLevel(59)).toBe('degraded');
+    expect(networkLevel(30)).toBe('degraded');
+  });
+  it('returns "critical" below 30', () => {
+    expect(networkLevel(29)).toBe('critical');
+    expect(networkLevel(0)).toBe('critical');
+  });
+});
+
+describe('LEVEL_STYLES', () => {
+  it('defines a style entry for every level', () => {
+    for (const level of ['unknown', 'healthy', 'warning', 'degraded', 'critical'] as const) {
+      expect(LEVEL_STYLES[level].color).toBeTruthy();
+      expect(LEVEL_STYLES[level].label).toBeTruthy();
+    }
+  });
+  it('references CSS custom properties bridged from tokens', () => {
+    for (const level of ['healthy', 'warning', 'degraded', 'critical'] as const) {
+      expect(LEVEL_STYLES[level].color).toMatch(/^var\(--/);
+    }
+  });
+  it('keeps the "unknown" label distinguishable for screen readers', () => {
+    expect(LEVEL_STYLES.unknown.label).toBe('No data');
   });
 });

--- a/tests/unit/tokens.test.ts
+++ b/tests/unit/tokens.test.ts
@@ -286,16 +286,30 @@ describe('v2 foundation tokens (Phase 0)', () => {
     expect(tokens.color.tooltip.textDim).toBe('rgba(255,255,255,.55)');
   });
 
-  it('exposes typography scale (xs → xxl) and tracking', () => {
-    expect(tokens.typography.scale.xs).toBe('9px');
-    expect(tokens.typography.scale.sm).toBe('10px');
-    expect(tokens.typography.scale.md).toBe('11.5px');
+  it('exposes typography scale matching the v2 prototype', () => {
+    // Source of truth: v2/Chronoscope v2.html CSS variable block.
+    expect(tokens.typography.scale.xs).toBe('10px');
+    expect(tokens.typography.scale.sm).toBe('11px');
+    expect(tokens.typography.scale.md).toBe('12px');
+    expect(tokens.typography.scale.base).toBe('13px');
     expect(tokens.typography.scale.lg).toBe('14px');
-    expect(tokens.typography.scale.xl).toBe('18px');
+    expect(tokens.typography.scale.xl).toBe('17px');
+    expect(tokens.typography.scale.xl2).toBe('20px');
+    expect(tokens.typography.scale.xl3).toBe('24px');
     expect(tokens.typography.scale.xxl).toBe('32px');
-    expect(tokens.typography.tracking.kicker).toBe('0.18em');
-    expect(tokens.typography.tracking.label).toBe('0.08em');
+  });
+
+  it('exposes tracking tokens matching the v2 prototype', () => {
+    expect(tokens.typography.tracking.kicker).toBe('0.22em');
+    expect(tokens.typography.tracking.label).toBe('0.14em');
+    expect(tokens.typography.tracking.tight).toBe('-0.01em');
+    expect(tokens.typography.tracking.display).toBe('-0.03em');
     expect(tokens.typography.tracking.body).toBe('0');
+  });
+
+  it('exposes lane.topbarHeight=58 and lane.railWidth=264 per v2 chrome', () => {
+    expect(tokens.lane.topbarHeight).toBe(58);
+    expect(tokens.lane.railWidth).toBe(264);
   });
 
   it('exposes v2 motion primitives', () => {


### PR DESCRIPTION
## Summary

Visual chrome for v2 — endpoint rail, six-tab view switcher, redesigned topbar with `networkQualityStore`-driven status pill. No view content is replaced (Overview is a stub; Lanes wraps the existing Glass Lanes view exactly as before). Legacy views remain reachable via the Lanes tab so the "keep all 6 legacy views working until Phase 7" non-negotiable holds.

## Screenshots

Attached in the first comment below — 4 states at 1440 × 900 @ 2× DPI:

1. **At rest** — fresh load, no data, status pill `NO DATA`.
2. **Hover** — Edge row hover background + border.
3. **Focused** — AWS row clicked → `bgRailSelected` background + `border-bright` border, persists in `uiStore.focusedEndpointId`.
4. **Degraded** — sample injection forces 3/4 endpoints unhealthy → status pill flips to `DEGRADED` (amber), per-row pips show pink/amber bucket, p50 metrics colored by endpoint palette.

## What shipped

| File | Change |
|---|---|
| `src/lib/tokens.ts` | Reconcile typography scale to prototype values (10/11/12/13/14/17/20/24/32 px), add `tracking.tight`/`display`, bump `topbarHeight` 54 → 58, add `railWidth: 264`. |
| `src/lib/components/App.svelte` | Bridge new tokens to CSS custom properties (`--ts-*`, `--tr-*`, `--topbar-height`, `--rail-width`, `--border-{dim,mid,bright}`, `--surface-topbar-bg`, `--t4`). |
| `src/lib/utils/classify.ts` | Add `networkLevel(score)` + `LEVEL_STYLES` palette. |
| `src/lib/components/EndpointRail.svelte` | **NEW** — persistent left rail. |
| `src/lib/components/ViewSwitcher.svelte` | **NEW** — six-tab picker. |
| `src/lib/components/OverviewView.svelte` | **NEW** — Phase 1 stub. |
| `src/lib/components/Topbar.svelte` | Rewrite to v2 chrome (brand block + status pill + lifecycle + actions). All existing controls preserved. |
| `src/lib/components/Layout.svelte` | Reorganize into Topbar / { Rail | ViewSwitcher + content } / FooterBar. |
| `tests/unit/{tokens,classify}.test.ts` | New scale assertions, `networkLevel` + `LEVEL_STYLES` coverage (7 net-new tests; 733 total pass). |
| `scripts/phase-1-screenshots.mjs` | Tooling — Playwright-based screenshot generator. Reusable for later phases. |

## Bundle size

| | JS gzip | CSS gzip |
|---|---:|---:|
| Pre-Phase-1 baseline | 57.49 KB | 8.54 KB |
| Phase 1 | **59.88 KB** | **9.57 KB** |
| Delta | **+2.39 KB** | **+1.03 KB** |

Total **+3.42 KB gzip**, well under the +15 KB Phase 1 budget.

## Ship checkpoint

- [x] Topbar + Rail render without regressing legacy views — Lanes tab still wraps the existing `LanesView` + `XAxisBar`.
- [x] Status pill reflects `networkQualityStore` in all four states (healthy/warning/degraded/critical) — verified by unit tests on `networkLevel()` and visually in shots 1 (unknown) and 4 (degraded).
- [x] Rail click toggles `focusedEndpointId` (shot 3); Phase 0 persistence covers reload survival.
- [x] Disabled switcher buttons (`Live`/`Atlas`/`Strata`/`Terminal`) — `tabindex=-1`, `aria-disabled`, tooltip *"Prototype in progress — not yet available."*, dimmed visually.
- [x] `npm run typecheck` / `npm run lint` / `npm run test` (733 pass) / `npm run build` all green.
- [x] Bundle delta < +15 KB gzip (+3.42 KB).
- [x] 4 screenshots attached.

## Deviation from spec

- **5 disabled, not 4.** The Phase 1 brief said "5 disabled, only Overview enabled." I left **Lanes** enabled because the Phase 0 v4→v5 migration rewrites every legacy `activeView` (`timeline`/`heatmap`/`split`) to `'lanes'`; users who upgrade would otherwise have no UI path to the Glass Lanes view that holds all existing functionality. The "keep all 6 legacy views working until Phase 7" non-negotiable trumps the 5-vs-4 count. If you want strict 5-disabled, one-line change in `ViewSwitcher.svelte`'s `VIEWS` array.

## Test plan

- [ ] CI: typecheck / lint / unit / build all green.
- [ ] DeepSource: same Category-A noise as Phase 0 (logged to `PHASE_NOTES.md`); no new substantive findings expected.
- [ ] CodeRabbit: should run automatically on this PR (the `.coderabbit.yaml` widening landed in Phase 0 — this is the test the PHASE_NOTES.md item described).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Network-quality status pill in the top bar
  * Persistent endpoints rail showing health and latency
  * View switcher with tabs for Overview and Lanes
  * New Overview placeholder for Phase 2

* **Chores**
  * Updated typography and layout tokens for v2 styling
  * Added a screenshot capture script and ignored the screenshots directory
  * Tests updated to cover new network-level styling and token expectations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->