### PR TITLE
Phase 2 — chronograph dial + Overview composition

### DIFF
--- a/PATTERNS.md
+++ b/PATTERNS.md
@@ -1,0 +1,28 @@
+# Patterns — Chronoscope v2 redesign
+
+Cross-phase rules that generalize out of CodeRabbit / DeepSource findings.
+Appended to as new generalizable findings land. Future self-reviews on
+MEDIUM- or HIGH-risk PRs consult this file as a checklist.
+
+Format: numbered entries, each with one-sentence rule, one-sentence why,
+originating PR, and a concrete check for the adversarial self-review pass.
+
+---
+
+## 1. Merge `$effect`s that share writable state
+**Rule:** If two `$effect`s read or write the same flag, merge them into one — sibling effects have no ordering guarantee in Svelte 5.
+**Why:** One effect can write the shared flag before the other reads it, silently skipping logic that gated on the prior value (e.g. dropping a screen-reader announcement for the current tick).
+**Found in:** PR #46 (Phase 2 ChronographDial threshold-cross effects).
+**Check in self-review:** Grep the file for `$effect`. For every pair, list each flag they touch. If any flag appears in two or more effects, merge or justify.
+
+## 2. Gate every motion surface behind `prefers-reduced-motion`
+**Rule:** Every animation — CSS keyframes, SVG `<animate>`, and JS-driven (rAF / setInterval / tween) — must respect the user's reduced-motion preference. Cover all three surfaces, not just one.
+**Why:** Skipping any single surface lets animation leak through for users who explicitly disabled it. WCAG 2.3.3 applies to all motion equally.
+**Found in:** PR #46 (Phase 2 ChronographDial — CSS pulse was gated, SVG `<animate>` pip and rAF hand lerp were not).
+**Check in self-review:** For every animated element in the PR, confirm the gate lives on the right surface — `@media (prefers-reduced-motion: reduce)` for CSS, a reactive `prefersReducedMotion` boolean driven by a **live** `matchMedia` listener (not just an initial read) for SVG and JS. The listener must be installed inside `$effect` with `return () => mq.removeEventListener(...)` for cleanup.
+
+## 3. User-facing aggregates go through `monitoredEndpoints`, not raw `endpointStore`
+**Rule:** Any derivation that feeds a displayed score, verdict, metric, rank, or live visualization (dial orbit, racing strip row, event feed filter, baseline window, …) must iterate `monitoredEndpointsStore`, not `$endpointStore`. Raw iteration is reserved for chrome that intentionally lists every endpoint regardless of status (the rail, management drawers).
+**Why:** `networkQualityStore` already filters disabled endpoints. If downstream views iterate the raw store, a disabled endpoint with stale samples can become the "worst endpoint", inflate counts, move the median, and contradict the score on the same screen.
+**Found in:** PR #46 (Phase 2 OverviewView — live median, worst-endpoint, over-count, total-samples, dial orbit all iterated raw).
+**Check in self-review:** Grep the PR for `endpointStore` subscriptions and `$endpoints` iterations. For each, ask: "does this feed a number or a mark the user sees?" If yes, switch to `$monitoredEndpointsStore`. If no (chrome listing), add a comment explaining why the raw store is intentional.

--- a/scripts/phase-2-screenshots.mjs
+++ b/scripts/phase-2-screenshots.mjs
@@ -1,0 +1,70 @@
+// Playwright runner for the Phase 2 PR screenshots. Outputs four PNGs into
+// ./screenshots/phase-2/ covering the four dial states:
+//   1. at rest      — no data, "Awaiting samples" verdict
+//   2. healthy      — all endpoints under threshold
+//   3. mixed        — one degraded, others healthy
+//   4. critical     — majority over threshold, pulse + pink verdict
+import { chromium } from 'playwright';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+const OUT = path.resolve('screenshots/phase-2');
+await mkdir(OUT, { recursive: true });
+
+const browser = await chromium.launch();
+try {
+  const context = await browser.newContext({ viewport: { width: 1440, height: 900 }, deviceScaleFactor: 2 });
+  const page = await context.newPage();
+
+  await page.goto('http://127.0.0.1:5173/');
+  await page.evaluate(() => { localStorage.clear(); });
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+  await page.evaluate(async () => { await document.fonts.ready; });
+
+  // Shot 1 — at rest (no data).
+  await page.screenshot({ path: path.join(OUT, '1-at-rest.png'), type: 'png' });
+
+  // Helper: get the current endpoint list once (synchronous read pattern).
+  async function seedSamples(profiles) {
+    await page.evaluate(async (profiles) => {
+      const measMod = await import('/src/lib/stores/measurements.ts');
+      const epMod = await import('/src/lib/stores/endpoints.ts');
+      const eps = await new Promise((resolve) => {
+        let unsub;
+        unsub = epMod.endpointStore.subscribe((v) => { resolve(v); queueMicrotask(() => unsub?.()); });
+      });
+      // Reset before reseeding so repeated runs don't compound samples.
+      measMod.measurementStore.reset();
+      for (let i = 0; i < eps.length; i++) {
+        const ep = eps[i];
+        const lat = profiles[i] || profiles[profiles.length - 1];
+        measMod.measurementStore.initEndpoint(ep.id);
+        for (let r = 0; r < lat.length; r++) {
+          measMod.measurementStore.addSample(ep.id, r + 1, lat[r], 'ok', Date.now() + r);
+        }
+      }
+    }, profiles);
+    await page.waitForTimeout(300);
+  }
+
+  const fast = Array.from({ length: 35 }, (_, i) => 25 + (i % 5) * 2);   // ~29ms p50
+  const mid  = Array.from({ length: 35 }, (_, i) => 180 + (i % 5) * 10); // ~200ms p50 (over)
+  const slow = Array.from({ length: 35 }, (_, i) => 950 + (i % 5) * 50); // ~1000ms p50
+
+  // Shot 2 — healthy (all endpoints under threshold).
+  await seedSamples([fast, fast, fast, fast]);
+  await page.screenshot({ path: path.join(OUT, '2-healthy.png'), type: 'png' });
+
+  // Shot 3 — mixed (two healthy, two degraded).
+  await seedSamples([fast, mid, fast, mid]);
+  await page.screenshot({ path: path.join(OUT, '3-mixed.png'), type: 'png' });
+
+  // Shot 4 — critical (three slow + one mid → unhealthy aggregate).
+  await seedSamples([slow, mid, slow, slow]);
+  await page.screenshot({ path: path.join(OUT, '4-critical.png'), type: 'png' });
+
+  console.log('Screenshots written to', OUT);
+} finally {
+  await browser.close();
+}

--- a/src/lib/components/App.svelte
+++ b/src/lib/components/App.svelte
@@ -112,6 +112,17 @@
     root.style.setProperty('--tooltip-text',         tokens.color.tooltip.text);
     root.style.setProperty('--tooltip-text-dim',     tokens.color.tooltip.textDim);
 
+    // v2 SVG primitives (dial, orbit ring, scope)
+    root.style.setProperty('--svg-grid-cyan',  tokens.color.svg.gridLineCyan);
+    root.style.setProperty('--svg-grid-major', tokens.color.svg.gridLineMajor);
+    root.style.setProperty('--svg-tick-minor', tokens.color.svg.tickMinor);
+    root.style.setProperty('--svg-tick-major', tokens.color.svg.tickMajor);
+    root.style.setProperty('--svg-hand-stroke', tokens.color.svg.handStroke);
+    root.style.setProperty('--svg-dial-rim',   tokens.color.svg.dialRim);
+    root.style.setProperty('--svg-orbit-track', tokens.color.svg.orbitTrack);
+    root.style.setProperty('--svg-orbit-edge', tokens.color.svg.orbitEdge);
+    root.style.setProperty('--svg-threshold',  tokens.color.svg.thresholdStroke);
+
     // v2 rail surfaces
     root.style.setProperty('--glass-bg-rail-hover',    tokens.color.glass.bgRailHover);
     root.style.setProperty('--glass-bg-rail-selected', tokens.color.glass.bgRailSelected);

--- a/src/lib/components/App.svelte
+++ b/src/lib/components/App.svelte
@@ -128,10 +128,11 @@
     root.style.setProperty('--glass-bg-rail-selected', tokens.color.glass.bgRailSelected);
 
     // v2 motion primitives
-    root.style.setProperty('--timing-hand-lerp',     String(tokens.timing.handLerp));
-    root.style.setProperty('--timing-pulse-rim',     `${tokens.timing.pulseRim}ms`);
-    root.style.setProperty('--timing-orbit-pulse',   `${tokens.timing.orbitPulse}ms`);
-    root.style.setProperty('--timing-trace-repaint', `${tokens.timing.traceRepaint}ms`);
+    root.style.setProperty('--timing-hand-lerp',        String(tokens.timing.handLerp));
+    root.style.setProperty('--timing-pulse-rim',        `${tokens.timing.pulseRim}ms`);
+    root.style.setProperty('--timing-pulse-dial-glow',  `${tokens.timing.pulseDialGlow}ms`);
+    root.style.setProperty('--timing-orbit-pulse',      `${tokens.timing.orbitPulse}ms`);
+    root.style.setProperty('--timing-trace-repaint',    `${tokens.timing.traceRepaint}ms`);
 
     // Legacy properties (Settings/Share drawers not yet redesigned)
     root.style.setProperty('--surface-raised',   tokens.color.surface.raised);

--- a/src/lib/components/ChronographDial.svelte
+++ b/src/lib/components/ChronographDial.svelte
@@ -101,6 +101,15 @@
   $effect(() => {
     const target = targetAng;
     const lerp = tokens.timing.handLerp;
+    // Reduced-motion users get the target snap — no smooth lerp. Covers the
+    // third motion surface alongside the CSS rim pulse and the SVG <animate>
+    // pip ring.
+    if (prefersReducedMotion) {
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      rafId = null;
+      displayAng = target;
+      return;
+    }
     const stepFn = (): void => {
       const diff = target - displayAng;
       if (Math.abs(diff) < 0.1) {

--- a/src/lib/components/ChronographDial.svelte
+++ b/src/lib/components/ChronographDial.svelte
@@ -1,0 +1,384 @@
+<!-- src/lib/components/ChronographDial.svelte -->
+<!-- v2 Overview hero. Minimal 520×520 analog dial — fixed geometry, live hand -->
+<!-- with rAF lerp interpolation, endpoint orbit ring outside the scale, and a -->
+<!-- rim pulse when the aggregate median crosses the health threshold.         -->
+<script lang="ts">
+  import { tokens } from '$lib/tokens';
+  import { VERDICT_STYLES, overviewVerdict, type OverviewVerdict } from '$lib/utils/classify';
+  import { fmt } from '$lib/utils/format';
+  import type { Endpoint } from '$lib/types';
+
+  interface Props {
+    score: number | null;
+    liveMedian: number | null;
+    threshold: number;
+    endpoints: readonly Endpoint[];
+    lastLatencies: Record<string, number | null>;
+    /** True only after the user has explicitly stopped a previously-running test
+     *  (lifecycle 'stopped' or 'completed'). 'idle' / 'starting' do not paint
+     *  the PAUSED badge — there's nothing to be paused from. */
+    paused: boolean;
+  }
+
+  let { score, liveMedian, threshold, endpoints, lastLatencies, paused }: Props = $props();
+
+  // ── Geometry constants ─────────────────────────────────────────────────────
+  const SIZE = 520;
+  const CX = SIZE / 2;
+  const CY = SIZE / 2;
+  const OUTER_R = 240;
+  const ORBIT_R = OUTER_R + 4;
+  const BAR_INNER = ORBIT_R - 3;
+  const BAR_OUTER = ORBIT_R + 3;
+  const PIP_R_REST = 2.2;
+  const PIP_R_OVER = 3;
+
+  const START_ANG = -135;
+  const END_ANG = 135;
+  const MAX_MS = 300;
+
+  function clamp01(t: number): number { return t < 0 ? 0 : t > 1 ? 1 : t; }
+  function latToAng(ms: number): number {
+    return START_ANG + clamp01(ms / MAX_MS) * (END_ANG - START_ANG);
+  }
+
+  // SVG arc helper for the threshold zone (from threshold → MAX_MS).
+  function arcPath(cx: number, cy: number, r: number, startDeg: number, endDeg: number): string {
+    const a0 = (startDeg * Math.PI) / 180;
+    const a1 = (endDeg   * Math.PI) / 180;
+    const x0 = cx + Math.cos(a0) * r;
+    const y0 = cy + Math.sin(a0) * r;
+    const x1 = cx + Math.cos(a1) * r;
+    const y1 = cy + Math.sin(a1) * r;
+    const largeArc = Math.abs(endDeg - startDeg) > 180 ? 1 : 0;
+    const sweep = endDeg > startDeg ? 1 : 0;
+    return `M ${x0} ${y0} A ${r} ${r} 0 ${largeArc} ${sweep} ${x1} ${y1}`;
+  }
+
+  // ── Precomputed static layers ──────────────────────────────────────────────
+  // Tick marks every 15ms; every 60ms is a major tick. Major/minor geometry
+  // differs slightly (deeper inset + thicker stroke for major).
+  interface Tick { ms: number; major: boolean; x1: number; y1: number; x2: number; y2: number; }
+  const ticks: readonly Tick[] = (() => {
+    const out: Tick[] = [];
+    for (let ms = 0; ms <= MAX_MS; ms += 15) {
+      const major = ms % 60 === 0;
+      const a = (latToAng(ms) * Math.PI) / 180;
+      const r1 = OUTER_R - (major ? 16 : 8);
+      const r2 = OUTER_R - 2;
+      out.push({
+        ms,
+        major,
+        x1: CX + Math.cos(a) * r1, y1: CY + Math.sin(a) * r1,
+        x2: CX + Math.cos(a) * r2, y2: CY + Math.sin(a) * r2,
+      });
+    }
+    return out;
+  })();
+
+  interface Label { ms: number; x: number; y: number; }
+  const NUMERIC_LABELS: readonly Label[] = [0, 60, 120, 180, 240, 300].map((ms) => {
+    const a = (latToAng(ms) * Math.PI) / 180;
+    const r = OUTER_R - 30;
+    return { ms, x: CX + Math.cos(a) * r, y: CY + Math.sin(a) * r + 3 };
+  });
+
+  // ── Reactive derivations ───────────────────────────────────────────────────
+  const threshAngDeg = $derived(latToAng(threshold));
+  const threshArcD = $derived(arcPath(CX, CY, OUTER_R - 4, threshAngDeg, END_ANG));
+  const verdict: OverviewVerdict = $derived(overviewVerdict(score));
+  const verdictStyle = $derived(VERDICT_STYLES[verdict]);
+  const overThreshold = $derived(liveMedian != null && liveMedian > threshold);
+  const endpointCount = $derived(endpoints.length);
+  const scoreDisplay = $derived(score == null ? '—' : String(score));
+
+  // ── Live hand: rAF lerp toward the target angle ────────────────────────────
+  const targetAng = $derived(latToAng(liveMedian ?? 0));
+  let displayAng = $state(targetAng);
+  let rafId: number | null = null;
+
+  $effect(() => {
+    const target = targetAng;
+    const lerp = tokens.timing.handLerp;
+    const stepFn = (): void => {
+      const diff = target - displayAng;
+      if (Math.abs(diff) < 0.1) {
+        displayAng = target;
+        rafId = null;
+        return;
+      }
+      displayAng = displayAng + diff * lerp;
+      rafId = requestAnimationFrame(stepFn);
+    };
+    if (rafId !== null) cancelAnimationFrame(rafId);
+    rafId = requestAnimationFrame(stepFn);
+    return () => { if (rafId !== null) cancelAnimationFrame(rafId); rafId = null; };
+  });
+
+  // ── Threshold-cross rim pulse ─────────────────────────────────────────────
+  // Edge-triggered: pulse when the median transitions from under → over. Fires
+  // for `tokens.timing.pulseRim` ms, then resets. An $effect reads the current
+  // overThreshold and compares to the tracked "previously-over" state.
+  let pulsing = $state(false);
+  let wasOver = false;
+  let pulseTimer: ReturnType<typeof setTimeout> | null = null;
+
+  $effect(() => {
+    const over = overThreshold;
+    if (over && !wasOver) {
+      pulsing = true;
+      if (pulseTimer !== null) clearTimeout(pulseTimer);
+      pulseTimer = setTimeout(() => { pulsing = false; pulseTimer = null; }, tokens.timing.pulseRim + 500);
+    }
+    wasOver = over;
+    return () => {
+      if (pulseTimer !== null) { clearTimeout(pulseTimer); pulseTimer = null; }
+    };
+  });
+
+  // ── SR live-region text (throttled via a signal tick) ──────────────────────
+  // Announces threshold crossings only. Cleared after a short dwell so the
+  // message doesn't linger in the reader buffer.
+  let crossingAnnouncement = $state('');
+  let announceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  $effect(() => {
+    if (overThreshold && !wasOver) {
+      const msg = liveMedian == null
+        ? 'Median latency crossed threshold.'
+        : `Median latency crossed threshold — now ${Math.round(liveMedian)}ms, threshold ${threshold}ms.`;
+      crossingAnnouncement = msg;
+      if (announceTimer !== null) clearTimeout(announceTimer);
+      announceTimer = setTimeout(() => { crossingAnnouncement = ''; announceTimer = null; }, 2000);
+    }
+    return () => {
+      if (announceTimer !== null) { clearTimeout(announceTimer); announceTimer = null; }
+    };
+  });
+
+  // ── Hand geometry ──────────────────────────────────────────────────────────
+  const handTip = $derived.by(() => {
+    const a = (displayAng * Math.PI) / 180;
+    const tipR = OUTER_R - 10;
+    const tailR = 24;
+    return {
+      x1: CX - Math.cos(a) * tailR,
+      y1: CY - Math.sin(a) * tailR,
+      x2: CX + Math.cos(a) * tipR,
+      y2: CY + Math.sin(a) * tipR,
+    };
+  });
+
+  // ── Orbit markers ──────────────────────────────────────────────────────────
+  interface OrbitMarker { id: string; color: string; x1: number; y1: number; x2: number; y2: number; pipX: number; pipY: number; over: boolean; }
+  const orbitMarkers: readonly OrbitMarker[] = $derived.by(() => {
+    const result: OrbitMarker[] = [];
+    for (const ep of endpoints) {
+      const lat = lastLatencies[ep.id];
+      if (lat == null || !Number.isFinite(lat)) continue;
+      const a = (latToAng(lat) * Math.PI) / 180;
+      const over = lat > threshold;
+      result.push({
+        id: ep.id,
+        color: ep.color || tokens.color.endpoint[0],
+        x1: CX + Math.cos(a) * BAR_INNER,
+        y1: CY + Math.sin(a) * BAR_INNER,
+        x2: CX + Math.cos(a) * BAR_OUTER,
+        y2: CY + Math.sin(a) * BAR_OUTER,
+        pipX: CX + Math.cos(a) * (BAR_OUTER + 4),
+        pipY: CY + Math.sin(a) * (BAR_OUTER + 4),
+        over,
+      });
+    }
+    return result;
+  });
+
+  // ── Accessibility label ────────────────────────────────────────────────────
+  const ariaLabel = $derived.by(() => {
+    const scorePart = score == null ? 'no data' : `${score} percent healthy`;
+    const medianPart = liveMedian == null ? 'unknown median' : `median ${Math.round(liveMedian)} milliseconds`;
+    const countPart = `${endpointCount} endpoint${endpointCount === 1 ? '' : 's'} monitored`;
+    return `Network health dial — ${scorePart}, ${medianPart}, ${countPart}.`;
+  });
+</script>
+
+<div class="dial-wrap" class:paused>
+  <svg
+    class="dial"
+    class:pulsing
+    viewBox="0 0 {SIZE} {SIZE}"
+    preserveAspectRatio="xMidYMid meet"
+    role="img"
+    aria-label={ariaLabel}
+  >
+      <defs>
+        <radialGradient id="dial-face-bg" cx="50%" cy="40%">
+          <stop offset="0%"   stop-color="var(--surface-raised)" />
+          <stop offset="60%"  stop-color="var(--bg-base)" />
+          <stop offset="100%" stop-color="#030207" />
+        </radialGradient>
+        <filter id="dial-hand-glow">
+          <feGaussianBlur stdDeviation="3" result="b" />
+          <feMerge><feMergeNode in="b" /><feMergeNode in="SourceGraphic" /></feMerge>
+        </filter>
+      </defs>
+
+      <!-- 1. Outer structural hairline. -->
+      <circle cx={CX} cy={CY} r={OUTER_R + 8} fill="none" stroke="var(--border-mid)" stroke-width="1" />
+
+      <!-- 2. Dial face with a radial fill for depth. -->
+      <circle cx={CX} cy={CY} r={OUTER_R} fill="url(#dial-face-bg)"
+              stroke="var(--svg-dial-rim)" stroke-width="1" />
+
+      <!-- 3. Inner rim — stroke swaps to verdict color while pulsing. -->
+      <circle cx={CX} cy={CY} r={OUTER_R - 4} fill="none"
+              stroke={pulsing ? verdictStyle.color : 'var(--svg-grid-major)'}
+              stroke-width={pulsing ? 2 : 1}
+              style:transition="stroke var(--timing-pulse-rim, 400ms) ease" />
+
+      <!-- 4. Decorative concentric guides. -->
+      <circle cx={CX} cy={CY} r={OUTER_R - 36} fill="none" stroke="var(--svg-grid-cyan)" stroke-width="0.5" />
+      <circle cx={CX} cy={CY} r={60}           fill="none" stroke="var(--svg-grid-cyan)" stroke-width="0.5" />
+
+      <!-- 5. Threshold arc (over-threshold zone). -->
+      <path d={threshArcD} fill="none" stroke="var(--svg-threshold)" stroke-width="2" stroke-linecap="round" />
+
+      <!-- 6. Tick marks. -->
+      {#each ticks as t (t.ms)}
+        <line
+          x1={t.x1} y1={t.y1} x2={t.x2} y2={t.y2}
+          stroke={t.major ? 'var(--svg-tick-major)' : 'var(--svg-tick-minor)'}
+          stroke-width={t.major ? 1.3 : 0.8}
+        />
+      {/each}
+
+      <!-- 7. Numeric labels. -->
+      {#each NUMERIC_LABELS as l (l.ms)}
+        <text
+          x={l.x} y={l.y}
+          text-anchor="middle"
+          font-size="10"
+          font-family={tokens.typography.mono.fontFamily}
+          fill="var(--t3)"
+          letter-spacing="0.1em"
+        >{l.ms}</text>
+      {/each}
+
+      <!-- 8. Center readouts. Kicker / score / verdict / live-median. -->
+      <text x={CX} y={CY - 94} text-anchor="middle" font-size="10"
+            font-family={tokens.typography.mono.fontFamily} fill="var(--t3)" letter-spacing="0.3em">QUALITY</text>
+      <text x={CX} y={CY - 8} text-anchor="middle" font-size="120" font-weight="200"
+            fill="var(--t1)" font-family={tokens.typography.sans.fontFamily}
+            style="letter-spacing: -0.05em; font-variant-numeric: tabular-nums;">{scoreDisplay}</text>
+      <text x={CX} y={CY + 38} text-anchor="middle" font-size="11"
+            font-family={tokens.typography.mono.fontFamily} fill={verdictStyle.color} letter-spacing="0.28em">
+        {verdictStyle.kicker}
+      </text>
+      <text x={CX} y={CY + 64} text-anchor="middle" font-size="10"
+            font-family={tokens.typography.mono.fontFamily} fill="var(--t4)" letter-spacing="0.18em">
+        LIVE {fmt(liveMedian).toUpperCase()} · {endpointCount} {endpointCount === 1 ? 'LINK' : 'LINKS'}
+      </text>
+
+      <!-- 9. Endpoint orbit ring. -->
+      <g aria-hidden="true">
+        <circle cx={CX} cy={CY} r={ORBIT_R} fill="none" stroke="var(--svg-orbit-track)" stroke-width="6" />
+        <circle cx={CX} cy={CY} r={ORBIT_R} fill="none" stroke="var(--svg-orbit-edge)"  stroke-width="0.8" />
+        {#each orbitMarkers as m (m.id)}
+          <g>
+            <line
+              x1={m.x1} y1={m.y1} x2={m.x2} y2={m.y2}
+              stroke={m.color} stroke-width="2.5" stroke-linecap="round"
+              opacity={m.over ? 1 : 0.9}
+            />
+            <circle
+              cx={m.pipX} cy={m.pipY}
+              r={m.over ? PIP_R_OVER : PIP_R_REST}
+              fill={m.color}
+              stroke={m.over ? 'var(--accent-pink-glow)' : 'var(--bg-base)'}
+              stroke-width={m.over ? 2 : 0.5}
+            >
+              {#if m.over}
+                <animate attributeName="r" values="{PIP_R_REST};4;{PIP_R_REST}" dur="1.4s" repeatCount="indefinite" />
+              {/if}
+            </circle>
+          </g>
+        {/each}
+      </g>
+
+      <!-- 10. Hand — white stroke with a glow filter, interpolated via rAF lerp. -->
+      <g>
+        <line x1={handTip.x1} y1={handTip.y1} x2={handTip.x2} y2={handTip.y2}
+              stroke="var(--svg-hand-stroke)" stroke-width="2.2" stroke-linecap="round"
+              filter="url(#dial-hand-glow)" />
+      </g>
+
+      <!-- 11. Central hub. -->
+      <circle cx={CX} cy={CY} r="8" fill="var(--bg-base)" stroke="var(--border-bright)" stroke-width="1" />
+      <circle cx={CX} cy={CY} r="2.5" fill="var(--t1)" />
+    </svg>
+
+  <div class="dial-announcer" role="status" aria-live="polite" aria-atomic="true">
+    {crossingAnnouncement}
+  </div>
+
+  {#if paused}
+    <span class="paused-badge" aria-hidden="true">PAUSED</span>
+  {/if}
+</div>
+
+<style>
+  .dial-wrap {
+    position: relative;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 12px 0;
+  }
+
+  .dial {
+    width: 100%;
+    max-width: min(520px, 80vw);
+    height: auto;
+    display: block;
+  }
+
+  /* The svg-level pulsing class runs a one-shot drop-shadow pulse whenever the
+     aggregate median crosses the health threshold. Driven by the component's
+     `pulsing` signal, reset after `timing.pulseRim` ms. */
+  .dial.pulsing {
+    animation: dialPulse var(--timing-pulse-rim, 400ms) ease-out;
+    animation-duration: 900ms; /* full pulse window exceeds the rim swap */
+  }
+  @keyframes dialPulse {
+    0%   { filter: drop-shadow(0 0 0    var(--accent-pink-glow)); }
+    30%  { filter: drop-shadow(0 0 24px var(--accent-pink-glow)); }
+    100% { filter: drop-shadow(0 0 0    var(--accent-pink-glow)); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .dial.pulsing { animation: none; }
+  }
+
+  .paused-badge {
+    position: absolute;
+    bottom: 28px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-kicker);
+    color: var(--t3);
+    padding: 3px 10px;
+    border: 1px solid var(--border-mid);
+    border-radius: 3px;
+    text-transform: uppercase;
+  }
+
+  .dial-announcer {
+    position: absolute;
+    width: 1px; height: 1px;
+    padding: 0; margin: -1px; overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap; border: 0;
+  }
+</style>

--- a/src/lib/components/ChronographDial.svelte
+++ b/src/lib/components/ChronographDial.svelte
@@ -3,6 +3,7 @@
 <!-- with rAF lerp interpolation, endpoint orbit ring outside the scale, and a -->
 <!-- rim pulse when the aggregate median crosses the health threshold.         -->
 <script lang="ts">
+  import { onDestroy } from 'svelte';
   import { tokens } from '$lib/tokens';
   import { VERDICT_STYLES, overviewVerdict, type OverviewVerdict } from '$lib/utils/classify';
   import { fmt } from '$lib/utils/format';
@@ -115,45 +116,55 @@
     return () => { if (rafId !== null) cancelAnimationFrame(rafId); rafId = null; };
   });
 
-  // ── Threshold-cross rim pulse ─────────────────────────────────────────────
-  // Edge-triggered: pulse when the median transitions from under → over. Fires
-  // for `tokens.timing.pulseRim` ms, then resets. An $effect reads the current
-  // overThreshold and compares to the tracked "previously-over" state.
+  // ── Threshold-cross effects (rim pulse + SR announcement) ────────────────
+  // Single $effect — sibling effects on the same `wasOver` flag race in Svelte
+  // 5: one writes wasOver=true before the other reads !wasOver, dropping the
+  // announcement. Cleanup also moves to onDestroy so per-rerun cleanup doesn't
+  // cancel the pending timer when overThreshold flips back-and-forth (which
+  // would otherwise leave `pulsing` or `crossingAnnouncement` permanently set).
   let pulsing = $state(false);
+  let crossingAnnouncement = $state('');
   let wasOver = false;
   let pulseTimer: ReturnType<typeof setTimeout> | null = null;
-
-  $effect(() => {
-    const over = overThreshold;
-    if (over && !wasOver) {
-      pulsing = true;
-      if (pulseTimer !== null) clearTimeout(pulseTimer);
-      pulseTimer = setTimeout(() => { pulsing = false; pulseTimer = null; }, tokens.timing.pulseRim + 500);
-    }
-    wasOver = over;
-    return () => {
-      if (pulseTimer !== null) { clearTimeout(pulseTimer); pulseTimer = null; }
-    };
-  });
-
-  // ── SR live-region text (throttled via a signal tick) ──────────────────────
-  // Announces threshold crossings only. Cleared after a short dwell so the
-  // message doesn't linger in the reader buffer.
-  let crossingAnnouncement = $state('');
   let announceTimer: ReturnType<typeof setTimeout> | null = null;
 
   $effect(() => {
-    if (overThreshold && !wasOver) {
-      const msg = liveMedian == null
+    const over = overThreshold;
+    const median = liveMedian;
+    const t = threshold;
+    if (over && !wasOver) {
+      // Rim pulse — give the CSS animation a buffer beyond the rim swap window.
+      pulsing = true;
+      if (pulseTimer !== null) clearTimeout(pulseTimer);
+      pulseTimer = setTimeout(() => { pulsing = false; pulseTimer = null; }, tokens.timing.pulseRim + 500);
+
+      // SR announcement — cleared after a short dwell so it doesn't linger.
+      const msg = median == null
         ? 'Median latency crossed threshold.'
-        : `Median latency crossed threshold — now ${Math.round(liveMedian)}ms, threshold ${threshold}ms.`;
+        : `Median latency crossed threshold — now ${Math.round(median)}ms, threshold ${t}ms.`;
       crossingAnnouncement = msg;
       if (announceTimer !== null) clearTimeout(announceTimer);
       announceTimer = setTimeout(() => { crossingAnnouncement = ''; announceTimer = null; }, 2000);
     }
-    return () => {
-      if (announceTimer !== null) { clearTimeout(announceTimer); announceTimer = null; }
-    };
+    wasOver = over;
+  });
+
+  onDestroy(() => {
+    if (pulseTimer !== null) clearTimeout(pulseTimer);
+    if (announceTimer !== null) clearTimeout(announceTimer);
+  });
+
+  // ── prefers-reduced-motion (live-listened) ────────────────────────────────
+  // OS toggle can flip while the app is open, so a one-shot read is wrong;
+  // listen and re-render. SSR-safe via the typeof window guard.
+  let prefersReducedMotion = $state(false);
+  $effect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    prefersReducedMotion = mq.matches;
+    const handler = (e: MediaQueryListEvent): void => { prefersReducedMotion = e.matches; };
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
   });
 
   // ── Hand geometry ──────────────────────────────────────────────────────────
@@ -297,7 +308,7 @@
               stroke={m.over ? 'var(--accent-pink-glow)' : 'var(--bg-base)'}
               stroke-width={m.over ? 2 : 0.5}
             >
-              {#if m.over}
+              {#if m.over && !prefersReducedMotion}
                 <animate attributeName="r" values="{PIP_R_REST};4;{PIP_R_REST}" dur="1.4s" repeatCount="indefinite" />
               {/if}
             </circle>

--- a/src/lib/components/ChronographDial.svelte
+++ b/src/lib/components/ChronographDial.svelte
@@ -93,6 +93,20 @@
   const endpointCount = $derived(endpoints.length);
   const scoreDisplay = $derived(score == null ? '—' : String(score));
 
+  // ── prefers-reduced-motion (live-listened) ────────────────────────────────
+  // OS toggle can flip while the app is open, so a one-shot read is wrong;
+  // listen and re-render. SSR-safe via the typeof window guard. Declared
+  // before the rAF effect + SVG <animate> gate because both read it.
+  let prefersReducedMotion = $state(false);
+  $effect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    prefersReducedMotion = mq.matches;
+    const handler = (e: MediaQueryListEvent): void => { prefersReducedMotion = e.matches; };
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  });
+
   // ── Live hand: rAF lerp toward the target angle ────────────────────────────
   const targetAng = $derived(latToAng(liveMedian ?? 0));
   let displayAng = $state(targetAng);
@@ -142,10 +156,11 @@
     const median = liveMedian;
     const t = threshold;
     if (over && !wasOver) {
-      // Rim pulse — give the CSS animation a buffer beyond the rim swap window.
+      // Rim pulse — window matches the CSS keyframe duration (--timing-pulse-dial-glow)
+      // so the `pulsing` class drops off exactly when the animation completes.
       pulsing = true;
       if (pulseTimer !== null) clearTimeout(pulseTimer);
-      pulseTimer = setTimeout(() => { pulsing = false; pulseTimer = null; }, tokens.timing.pulseRim + 500);
+      pulseTimer = setTimeout(() => { pulsing = false; pulseTimer = null; }, tokens.timing.pulseDialGlow);
 
       // SR announcement — cleared after a short dwell so it doesn't linger.
       const msg = median == null
@@ -161,19 +176,6 @@
   onDestroy(() => {
     if (pulseTimer !== null) clearTimeout(pulseTimer);
     if (announceTimer !== null) clearTimeout(announceTimer);
-  });
-
-  // ── prefers-reduced-motion (live-listened) ────────────────────────────────
-  // OS toggle can flip while the app is open, so a one-shot read is wrong;
-  // listen and re-render. SSR-safe via the typeof window guard.
-  let prefersReducedMotion = $state(false);
-  $effect(() => {
-    if (typeof window === 'undefined' || !window.matchMedia) return;
-    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
-    prefersReducedMotion = mq.matches;
-    const handler = (e: MediaQueryListEvent): void => { prefersReducedMotion = e.matches; };
-    mq.addEventListener('change', handler);
-    return () => mq.removeEventListener('change', handler);
   });
 
   // ── Hand geometry ──────────────────────────────────────────────────────────
@@ -318,7 +320,7 @@
               stroke-width={m.over ? 2 : 0.5}
             >
               {#if m.over && !prefersReducedMotion}
-                <animate attributeName="r" values="{PIP_R_REST};4;{PIP_R_REST}" dur="1.4s" repeatCount="indefinite" />
+                <animate attributeName="r" values="{PIP_R_OVER};{PIP_R_OVER + 1.5};{PIP_R_OVER}" dur="1.4s" repeatCount="indefinite" />
               {/if}
             </circle>
           </g>
@@ -363,12 +365,12 @@
     display: block;
   }
 
-  /* The svg-level pulsing class runs a one-shot drop-shadow pulse whenever the
-     aggregate median crosses the health threshold. Driven by the component's
-     `pulsing` signal, reset after `timing.pulseRim` ms. */
+  /* One-shot drop-shadow flash when the aggregate median crosses the health
+     threshold. Driven by the component's `pulsing` signal, cleared after
+     --timing-pulse-dial-glow ms — same token as the JS setTimeout so the
+     class and the keyframe can't drift apart. */
   .dial.pulsing {
-    animation: dialPulse var(--timing-pulse-rim, 400ms) ease-out;
-    animation-duration: 900ms; /* full pulse window exceeds the rim swap */
+    animation: dialPulse var(--timing-pulse-dial-glow, 900ms) ease-out;
   }
   @keyframes dialPulse {
     0%   { filter: drop-shadow(0 0 0    var(--accent-pink-glow)); }

--- a/src/lib/components/EndpointRail.svelte
+++ b/src/lib/components/EndpointRail.svelte
@@ -50,7 +50,7 @@
 >
   <div class="rail-header">
     <span class="rail-title">Endpoints</span>
-    <span class="rail-count" aria-label="{endpoints.length} endpoints monitored">{endpoints.length}</span>
+    <span class="rail-count" aria-label="{endpoints.length} {endpoints.length === 1 ? 'endpoint' : 'endpoints'} listed">{endpoints.length}</span>
   </div>
 
   <div class="rail-list">

--- a/src/lib/components/OverviewView.svelte
+++ b/src/lib/components/OverviewView.svelte
@@ -5,17 +5,21 @@
 <!-- "Diagnose →" CTA.                                                          -->
 <script lang="ts">
   import { measurementStore } from '$lib/stores/measurements';
-  import { endpointStore } from '$lib/stores/endpoints';
   import { statisticsStore } from '$lib/stores/statistics';
   import { settingsStore } from '$lib/stores/settings';
   import { uiStore } from '$lib/stores/ui';
-  import { networkQualityStore } from '$lib/stores/derived';
+  import { networkQualityStore, monitoredEndpointsStore } from '$lib/stores/derived';
   import { overviewVerdict, VERDICT_STYLES } from '$lib/utils/classify';
   import { fmt, fmtParts, fmtCount } from '$lib/utils/format';
   import { tokens } from '$lib/tokens';
   import ChronographDial from './ChronographDial.svelte';
 
-  const endpoints = $derived($endpointStore);
+  // Cross-phase invariant — every user-facing aggregate (live median, worst
+  // endpoint, over-threshold count, sample total, dial orbit) routes through
+  // monitoredEndpointsStore so the score, verdict, and per-endpoint chrome on
+  // this view can never disagree about who's being measured. See
+  // PHASE_NOTES.md "Patterns" §1.
+  const monitored = $derived($monitoredEndpointsStore);
   const stats = $derived($statisticsStore);
   const measurements = $derived($measurementStore);
   const threshold = $derived($settingsStore.healthThreshold);
@@ -30,16 +34,16 @@
   // ── Per-endpoint last latency map (for the dial's orbit ring) ──────────────
   const lastLatencies = $derived.by(() => {
     const out: Record<string, number | null> = {};
-    for (const ep of endpoints) {
+    for (const ep of monitored) {
       out[ep.id] = measurements.endpoints[ep.id]?.lastLatency ?? null;
     }
     return out;
   });
 
-  // ── Live median across all endpoints' lastLatency (skip nulls) ─────────────
+  // ── Live median across monitored endpoints' lastLatency (skip nulls) ───────
   const liveMedian = $derived.by(() => {
     const vals: number[] = [];
-    for (const ep of endpoints) {
+    for (const ep of monitored) {
       const lat = measurements.endpoints[ep.id]?.lastLatency;
       if (lat != null && Number.isFinite(lat)) vals.push(lat);
     }
@@ -49,10 +53,10 @@
     return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
   });
 
-  // ── Worst endpoint by p95 among ready stats ────────────────────────────────
+  // ── Worst endpoint by p95 among ready monitored stats ──────────────────────
   const worst = $derived.by(() => {
     let worstEp: { id: string; label: string; color: string; p95: number } | null = null;
-    for (const ep of endpoints) {
+    for (const ep of monitored) {
       const s = stats[ep.id];
       if (!s || !s.ready) continue;
       if (!worstEp || s.p95 > worstEp.p95) {
@@ -67,10 +71,10 @@
     return worstEp;
   });
 
-  // ── Triptych metrics ───────────────────────────────────────────────────────
+  // ── Triptych metrics — monitored only ──────────────────────────────────────
   const overCount = $derived.by(() => {
     let n = 0, total = 0;
-    for (const ep of endpoints) {
+    for (const ep of monitored) {
       const lat = measurements.endpoints[ep.id]?.lastLatency;
       if (lat == null) continue;
       total++;
@@ -80,7 +84,7 @@
   });
   const totalSamples = $derived.by(() => {
     let n = 0;
-    for (const ep of endpoints) {
+    for (const ep of monitored) {
       n += measurements.endpoints[ep.id]?.samples.length ?? 0;
     }
     return n;
@@ -105,7 +109,7 @@
       {score}
       {liveMedian}
       {threshold}
-      {endpoints}
+      endpoints={monitored}
       {lastLatencies}
       {paused}
     />

--- a/src/lib/components/OverviewView.svelte
+++ b/src/lib/components/OverviewView.svelte
@@ -18,7 +18,7 @@
   // endpoint, over-threshold count, sample total, dial orbit) routes through
   // monitoredEndpointsStore so the score, verdict, and per-endpoint chrome on
   // this view can never disagree about who's being measured. See
-  // PHASE_NOTES.md "Patterns" §1.
+  // PATTERNS.md §3.
   const monitored = $derived($monitoredEndpointsStore);
   const stats = $derived($statisticsStore);
   const measurements = $derived($measurementStore);

--- a/src/lib/components/OverviewView.svelte
+++ b/src/lib/components/OverviewView.svelte
@@ -1,55 +1,358 @@
 <!-- src/lib/components/OverviewView.svelte -->
-<!-- Phase 1 stub. Phase 2 replaces the inner block with the chronograph dial.  -->
+<!-- Phase 2 Overview — chronograph dial, diagnosis strip, metrics triptych.    -->
+<!-- This view is "ambient" — one dial says everything's fine or it isn't, the  -->
+<!-- strip below points where to look. No interactive controls beyond the       -->
+<!-- "Diagnose →" CTA.                                                          -->
+<script lang="ts">
+  import { measurementStore } from '$lib/stores/measurements';
+  import { endpointStore } from '$lib/stores/endpoints';
+  import { statisticsStore } from '$lib/stores/statistics';
+  import { settingsStore } from '$lib/stores/settings';
+  import { uiStore } from '$lib/stores/ui';
+  import { networkQualityStore } from '$lib/stores/derived';
+  import { overviewVerdict, VERDICT_STYLES } from '$lib/utils/classify';
+  import { fmt, fmtParts, fmtCount } from '$lib/utils/format';
+  import { tokens } from '$lib/tokens';
+  import ChronographDial from './ChronographDial.svelte';
+
+  const endpoints = $derived($endpointStore);
+  const stats = $derived($statisticsStore);
+  const measurements = $derived($measurementStore);
+  const threshold = $derived($settingsStore.healthThreshold);
+  const score = $derived($networkQualityStore);
+  // PAUSED only when the user explicitly stopped a running test — never on
+  // first load (idle) or while transitioning. Score being non-null isn't a
+  // sufficient signal because we can have stats from a previous session.
+  const paused = $derived(
+    measurements.lifecycle === 'stopped' || measurements.lifecycle === 'completed',
+  );
+
+  // ── Per-endpoint last latency map (for the dial's orbit ring) ──────────────
+  const lastLatencies = $derived.by(() => {
+    const out: Record<string, number | null> = {};
+    for (const ep of endpoints) {
+      out[ep.id] = measurements.endpoints[ep.id]?.lastLatency ?? null;
+    }
+    return out;
+  });
+
+  // ── Live median across all endpoints' lastLatency (skip nulls) ─────────────
+  const liveMedian = $derived.by(() => {
+    const vals: number[] = [];
+    for (const ep of endpoints) {
+      const lat = measurements.endpoints[ep.id]?.lastLatency;
+      if (lat != null && Number.isFinite(lat)) vals.push(lat);
+    }
+    if (vals.length === 0) return null;
+    const sorted = [...vals].sort((a, b) => a - b);
+    const mid = sorted.length >> 1;
+    return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+  });
+
+  // ── Worst endpoint by p95 among ready stats ────────────────────────────────
+  const worst = $derived.by(() => {
+    let worstEp: { id: string; label: string; color: string; p95: number } | null = null;
+    for (const ep of endpoints) {
+      const s = stats[ep.id];
+      if (!s || !s.ready) continue;
+      if (!worstEp || s.p95 > worstEp.p95) {
+        worstEp = {
+          id: ep.id,
+          label: ep.label,
+          color: ep.color || tokens.color.endpoint[0],
+          p95: s.p95,
+        };
+      }
+    }
+    return worstEp;
+  });
+
+  // ── Triptych metrics ───────────────────────────────────────────────────────
+  const overCount = $derived.by(() => {
+    let n = 0, total = 0;
+    for (const ep of endpoints) {
+      const lat = measurements.endpoints[ep.id]?.lastLatency;
+      if (lat == null) continue;
+      total++;
+      if (lat > threshold) n++;
+    }
+    return { n, total };
+  });
+  const totalSamples = $derived.by(() => {
+    let n = 0;
+    for (const ep of endpoints) {
+      n += measurements.endpoints[ep.id]?.samples.length ?? 0;
+    }
+    return n;
+  });
+
+  const verdict = $derived(overviewVerdict(score));
+  const verdictStyle = $derived(VERDICT_STYLES[verdict]);
+
+  const liveMedianParts = $derived(fmtParts(liveMedian));
+
+  function handleDrill(): void {
+    if (worst) uiStore.setFocusedEndpoint(worst.id);
+    // Phase 2 fallback: drill to Lanes since Atlas (Phase 4) isn't built yet.
+    // Swap to 'atlas' once Phase 4 lands.
+    uiStore.setActiveView('lanes');
+  }
+</script>
+
 <section class="overview" aria-label="Overview">
-  <div class="overview-stub">
-    <div class="overview-stub-kicker">Overview</div>
-    <h1 class="overview-stub-title">Coming soon</h1>
-    <p class="overview-stub-desc">
-      The chronograph dial lands in Phase&nbsp;2. Pick the
-      <strong>Lanes</strong> tab to use the existing visualization
-      while the v2 surfaces are built out.
-    </p>
+  <div class="dial-slot">
+    <ChronographDial
+      {score}
+      {liveMedian}
+      {threshold}
+      {endpoints}
+      {lastLatencies}
+      {paused}
+    />
   </div>
+
+  <div
+    class="diagnosis-strip"
+    style:--verdict-color={verdictStyle.color}
+    style:--verdict-glow={verdictStyle.glow}
+  >
+    <div class="diag-verdict">
+      <span class="diag-dot" aria-hidden="true"></span>
+      <span class="diag-verdict-label">{verdictStyle.label}</span>
+    </div>
+
+    <div class="diag-worst">
+      <div class="diag-worst-kicker">Worst endpoint</div>
+      {#if worst}
+        <div class="diag-worst-row">
+          <span class="diag-worst-pip" style:background={worst.color} aria-hidden="true"></span>
+          <span class="diag-worst-label">{worst.label}</span>
+          <span class="diag-worst-metric">
+            <span class="diag-metric-num">{fmt(worst.p95)}</span>
+            <span class="diag-metric-unit">p95 ms</span>
+          </span>
+        </div>
+      {:else}
+        <div class="diag-worst-row diag-worst-empty">
+          <span class="diag-worst-label">—</span>
+          <span class="diag-worst-metric"><span class="diag-metric-unit">awaiting samples</span></span>
+        </div>
+      {/if}
+    </div>
+
+    <button
+      type="button"
+      class="diag-drill"
+      disabled={worst == null}
+      aria-label={worst ? `Diagnose ${worst.label}` : 'Diagnose worst endpoint (none yet)'}
+      onclick={handleDrill}
+    >
+      <span class="diag-drill-text">Diagnose</span>
+      <span class="diag-drill-arrow" aria-hidden="true">→</span>
+    </button>
+  </div>
+
+  <dl class="metrics-triptych" aria-label="Live metrics">
+    <div class="metric-cell">
+      <dt class="metric-kicker">Live median</dt>
+      <dd class="metric-value">
+        <span class="metric-num">{liveMedianParts.num}</span>
+        <span class="metric-unit">{liveMedianParts.unit}</span>
+      </dd>
+    </div>
+
+    <div class="metric-cell">
+      <dt class="metric-kicker">Over threshold</dt>
+      <dd class="metric-value">
+        <span class="metric-num">{overCount.n}<span class="metric-num-sep">/</span>{overCount.total}</span>
+        <span class="metric-unit">endpoints</span>
+      </dd>
+    </div>
+
+    <div class="metric-cell">
+      <dt class="metric-kicker">Samples</dt>
+      <dd class="metric-value">
+        <span class="metric-num">{fmtCount(totalSamples)}</span>
+        <span class="metric-unit">total</span>
+      </dd>
+    </div>
+  </dl>
 </section>
 
 <style>
   .overview {
     flex: 1;
-    display: grid;
-    place-items: center;
-    padding: 32px;
-    min-height: 0;
-  }
-  .overview-stub {
-    max-width: 480px;
-    text-align: center;
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    align-items: center;
+    gap: 24px;
+    padding: 32px 28px 40px;
+    min-height: 0;
+    overflow-y: auto;
   }
-  .overview-stub-kicker {
+
+  .dial-slot {
+    width: 100%;
+    max-width: 920px;
+    display: flex;
+    justify-content: center;
+  }
+
+  /* ── Diagnosis strip ─────────────────────────────────────────────────────── */
+  .diagnosis-strip {
+    width: 100%;
+    max-width: 920px;
+    background: var(--glass-bg-rail-hover);
+    border: 1px solid var(--border-mid);
+    border-radius: 14px;
+    padding: 14px 18px;
+    display: grid;
+    grid-template-columns: 1.2fr 2fr auto;
+    gap: 20px;
+    align-items: center;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+  }
+
+  .diag-verdict { display: flex; align-items: center; gap: 10px; color: var(--verdict-color); }
+  .diag-dot {
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    background: var(--verdict-color);
+    box-shadow: 0 0 10px var(--verdict-glow);
+  }
+  .diag-verdict-label {
+    color: var(--t1);
+    font-family: var(--sans);
+    font-size: var(--ts-base);
+    font-weight: 500;
+  }
+
+  .diag-worst { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+  .diag-worst-kicker {
     font-family: var(--mono);
     font-size: var(--ts-xs);
     letter-spacing: var(--tr-kicker);
-    color: var(--accent-cyan);
+    color: var(--t4);
     text-transform: uppercase;
   }
-  .overview-stub-title {
-    font-family: var(--sans);
-    font-size: var(--ts-3xl);
-    font-weight: 300;
-    letter-spacing: var(--tr-display);
+  .diag-worst-row { display: flex; align-items: center; gap: 10px; min-width: 0; }
+  .diag-worst-pip {
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    box-shadow: 0 0 6px currentColor;
+  }
+  .diag-worst-label {
+    flex: 1;
     color: var(--t1);
+    font-family: var(--mono);
+    font-size: var(--ts-sm);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .diag-worst-metric {
+    display: flex;
+    align-items: baseline;
+    gap: 4px;
+    font-family: var(--mono);
+    font-variant-numeric: tabular-nums;
+  }
+  .diag-worst-empty .diag-worst-label { color: var(--t4); }
+  .diag-metric-num {
+    font-size: var(--ts-xl);
+    font-weight: 300;
+    color: var(--t1);
+    letter-spacing: var(--tr-tight);
+  }
+  .diag-metric-unit {
+    font-size: var(--ts-sm);
+    color: var(--t3);
+    letter-spacing: var(--tr-label);
+  }
+
+  .diag-drill {
+    display: flex; align-items: center; gap: 8px;
+    padding: 8px 14px; border-radius: 8px;
+    background: var(--cyan-bg-subtle, rgba(103, 232, 249, 0.08));
+    border: 1px solid var(--cyan-border-subtle, rgba(103, 232, 249, 0.25));
+    color: var(--t1);
+    font-family: var(--sans);
+    font-size: var(--ts-md);
+    cursor: pointer;
+    transition: background 160ms ease, border-color 160ms ease;
+  }
+  .diag-drill:hover:not(:disabled) {
+    background: var(--cyan25);
+    border-color: var(--cyan-border-subtle);
+  }
+  .diag-drill:disabled { opacity: 0.5; cursor: not-allowed; }
+  .diag-drill:focus-visible {
+    outline: 1.5px solid var(--accent-cyan);
+    outline-offset: 2px;
+  }
+  .diag-drill-arrow { color: var(--accent-cyan); }
+
+  /* ── Metrics triptych ────────────────────────────────────────────────────── */
+  .metrics-triptych {
+    width: 100%;
+    max-width: 920px;
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 14px;
     margin: 0;
   }
-  .overview-stub-desc {
-    font-family: var(--sans);
-    font-size: var(--ts-base);
-    color: var(--t3);
-    line-height: 1.55;
+  .metric-cell {
+    background: var(--glass-bg-rail-hover);
+    border: 1px solid var(--border-mid);
+    border-radius: 14px;
+    padding: 16px 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
   }
-  .overview-stub-desc strong {
+  .metric-kicker {
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-kicker);
+    color: var(--t3);
+    text-transform: uppercase;
+    margin: 0;
+  }
+  .metric-value {
+    margin: 0;
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+  }
+  .metric-num {
+    font-family: var(--mono);
+    font-size: var(--ts-xxl);
+    font-weight: 200;
     color: var(--t1);
-    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: var(--tr-tight);
+  }
+  .metric-num-sep { color: var(--t4); margin: 0 1px; }
+  .metric-unit {
+    font-family: var(--mono);
+    font-size: var(--ts-sm);
+    color: var(--t3);
+    letter-spacing: var(--tr-label);
+  }
+
+  @media (max-width: 767px) {
+    .overview { padding: 16px 12px 28px; gap: 16px; }
+    .diagnosis-strip {
+      grid-template-columns: 1fr;
+      gap: 14px;
+      padding: 14px;
+    }
+    .diag-drill { justify-content: center; }
+    .metrics-triptych { grid-template-columns: 1fr; gap: 10px; }
+    .metric-cell { padding: 12px 14px; }
   }
 </style>

--- a/src/lib/stores/derived.ts
+++ b/src/lib/stores/derived.ts
@@ -8,17 +8,30 @@ import { endpointStore } from './endpoints';
 import { statisticsStore } from './statistics';
 import { settingsStore } from './settings';
 import { networkQuality } from '../utils/classify';
+import type { Endpoint } from '../types';
 
 /**
- * Aggregate 0–100 score across all enabled endpoints — null until at least one
+ * Endpoints currently being measured — i.e. `enabled === true`. Cross-phase
+ * invariant: any user-facing aggregate (score, dial median, dial orbit ring,
+ * triptych counts, racing-strip rows, event derivation, baseline window…) MUST
+ * derive from this set, not from the raw `endpointStore`. The raw store is
+ * still appropriate for chrome that explicitly lists every endpoint regardless
+ * of status (e.g. the EndpointRail). See PHASE_NOTES.md "Patterns" §1.
+ */
+export const monitoredEndpointsStore: Readable<readonly Endpoint[]> = derived(
+  endpointStore,
+  ($endpoints) => $endpoints.filter((ep) => ep.enabled),
+);
+
+/**
+ * Aggregate 0–100 score across monitored endpoints — null until at least one
  * endpoint's statistics are `ready`. Subscribed by Topbar status and the
  * chronograph dial's main hand.
  */
 export const networkQualityStore: Readable<number | null> = derived(
-  [endpointStore, statisticsStore, settingsStore],
-  ([$endpoints, $stats, $settings]) => {
-    const readyStats = $endpoints
-      .filter((e) => e.enabled)
+  [monitoredEndpointsStore, statisticsStore, settingsStore],
+  ([$monitored, $stats, $settings]) => {
+    const readyStats = $monitored
       .map((e) => $stats[e.id])
       .filter((s) => s !== undefined);
     return networkQuality(readyStats, $settings.healthThreshold);

--- a/src/lib/stores/derived.ts
+++ b/src/lib/stores/derived.ts
@@ -16,7 +16,7 @@ import type { Endpoint } from '../types';
  * triptych counts, racing-strip rows, event derivation, baseline window…) MUST
  * derive from this set, not from the raw `endpointStore`. The raw store is
  * still appropriate for chrome that explicitly lists every endpoint regardless
- * of status (e.g. the EndpointRail). See PHASE_NOTES.md "Patterns" §1.
+ * of status (e.g. the EndpointRail). See PATTERNS.md §3.
  */
 export const monitoredEndpointsStore: Readable<readonly Endpoint[]> = derived(
   endpointStore,

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -393,10 +393,11 @@ export const tokens = {
     loadingRingDuration:  1800,
 
     // v2 motion primitives.
-    handLerp:     0.15,   // dial hand smoothing factor (per-frame)
-    pulseRim:      400,   // ms — dial rim pulse on threshold cross
-    orbitPulse:   1400,   // ms — orbit pip pulse when over threshold
-    traceRepaint:   16,   // ms — scope canvas repaint throttle
+    handLerp:        0.15,   // dial hand smoothing factor (per-frame)
+    pulseRim:         400,   // ms — inner-rim stroke color swap on threshold cross
+    pulseDialGlow:    900,   // ms — outer drop-shadow flash window; shared by CSS keyframe duration and JS pulse-window timer so the two can't drift
+    orbitPulse:      1400,   // ms — orbit pip radius pulse when over threshold
+    traceRepaint:      16,   // ms — scope canvas repaint throttle
   },
 
   easing: {

--- a/src/lib/utils/classify.ts
+++ b/src/lib/utils/classify.ts
@@ -89,6 +89,23 @@ export function networkQuality(
   return Math.round(total / ready.length);
 }
 
+// ─── Verdict vs networkLevel — DELIBERATE ASYMMETRY ────────────────────────
+// The two classifiers below intentionally bucket the same score differently:
+//
+//   overviewVerdict (3 buckets)  answers  "how is the user's experience?"
+//   networkLevel    (4 buckets)  answers  "what alerting action is warranted?"
+//
+// They CAN disagree at boundaries — e.g. score 80 yields verdict='healthy'
+// (the dial reads "Healthy") while networkLevel='warning' (the topbar pill
+// reads "WARNING"). That is by design: the dial is an at-a-glance human
+// summary that compresses warning + early degraded into one bucket; the pill
+// is a live alerting indicator that needs the extra granularity to
+// distinguish "watch this" from "acknowledge this".
+//
+// Do not unify the two without an explicit product call. If you add a third
+// classifier (e.g. routing, paging), document its bucketing rationale here
+// alongside these two.
+//
 export type OverviewVerdict = 'unknown' | 'healthy' | 'degraded' | 'unhealthy';
 
 export interface VerdictStyle {

--- a/src/lib/utils/classify.ts
+++ b/src/lib/utils/classify.ts
@@ -89,6 +89,41 @@ export function networkQuality(
   return Math.round(total / ready.length);
 }
 
+export type OverviewVerdict = 'unknown' | 'healthy' | 'degraded' | 'unhealthy';
+
+export interface VerdictStyle {
+  readonly color:  string;
+  readonly glow:   string;
+  readonly label:  string;
+  readonly kicker: string;
+}
+
+/**
+ * Coarse 3-bucket label for the Overview dial and diagnosis strip. The topbar
+ * status pill uses `networkLevel()` for 4-bucket severity; this is intentionally
+ * coarser because the user-facing verdict should compress to "everything's fine
+ * / something's off / things are bad" without the warning/degraded split the
+ * pill uses for alerting.
+ *
+ *   null    → unknown   (Awaiting samples)
+ *   ≥ 80    → healthy
+ *   ≥ 50    → degraded
+ *   <  50   → unhealthy
+ */
+export function overviewVerdict(score: number | null): OverviewVerdict {
+  if (score === null) return 'unknown';
+  if (score >= 80) return 'healthy';
+  if (score >= 50) return 'degraded';
+  return 'unhealthy';
+}
+
+export const VERDICT_STYLES: Record<OverviewVerdict, VerdictStyle> = {
+  unknown:   { color: 'var(--t4)',           glow: 'transparent',              label: 'Awaiting samples', kicker: '···' },
+  healthy:   { color: 'var(--accent-cyan)',  glow: 'var(--accent-cyan-glow)',  label: 'Healthy',          kicker: 'HEALTHY' },
+  degraded:  { color: 'var(--accent-amber)', glow: 'var(--accent-amber-glow)', label: 'Degraded',         kicker: 'DEGRADED' },
+  unhealthy: { color: 'var(--accent-pink)',  glow: 'var(--accent-pink-glow)',  label: 'Unhealthy',        kicker: 'CRITICAL' },
+};
+
 export type NetworkLevel = 'unknown' | 'healthy' | 'warning' | 'degraded' | 'critical';
 
 /**

--- a/tests/unit/classify.test.ts
+++ b/tests/unit/classify.test.ts
@@ -3,8 +3,10 @@ import {
   classify,
   networkQuality,
   networkLevel,
+  overviewVerdict,
   HEALTH_STYLES,
   LEVEL_STYLES,
+  VERDICT_STYLES,
 } from '../../src/lib/utils/classify';
 import type { EndpointStatistics } from '../../src/lib/types';
 
@@ -145,5 +147,38 @@ describe('LEVEL_STYLES', () => {
   });
   it('keeps the "unknown" label distinguishable for screen readers', () => {
     expect(LEVEL_STYLES.unknown.label).toBe('No data');
+  });
+});
+
+describe('overviewVerdict()', () => {
+  it('returns "unknown" for null score', () => {
+    expect(overviewVerdict(null)).toBe('unknown');
+  });
+  it('returns "healthy" at 80 and above', () => {
+    expect(overviewVerdict(100)).toBe('healthy');
+    expect(overviewVerdict(80)).toBe('healthy');
+  });
+  it('returns "degraded" between 50 and 79', () => {
+    expect(overviewVerdict(79)).toBe('degraded');
+    expect(overviewVerdict(50)).toBe('degraded');
+  });
+  it('returns "unhealthy" below 50', () => {
+    expect(overviewVerdict(49)).toBe('unhealthy');
+    expect(overviewVerdict(0)).toBe('unhealthy');
+  });
+});
+
+describe('VERDICT_STYLES', () => {
+  it('defines an entry for every verdict including kicker text', () => {
+    for (const v of ['unknown', 'healthy', 'degraded', 'unhealthy'] as const) {
+      expect(VERDICT_STYLES[v].color).toBeTruthy();
+      expect(VERDICT_STYLES[v].label).toBeTruthy();
+      expect(VERDICT_STYLES[v].kicker).toBeTruthy();
+    }
+  });
+  it('uses CSS custom properties rather than raw hex', () => {
+    for (const v of ['healthy', 'degraded', 'unhealthy'] as const) {
+      expect(VERDICT_STYLES[v].color).toMatch(/^var\(--/);
+    }
   });
 });

--- a/tests/unit/derived.test.ts
+++ b/tests/unit/derived.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { get } from 'svelte/store';
-import { networkQualityStore } from '../../src/lib/stores/derived';
+import { networkQualityStore, monitoredEndpointsStore } from '../../src/lib/stores/derived';
 import { endpointStore } from '../../src/lib/stores/endpoints';
 import { measurementStore } from '../../src/lib/stores/measurements';
 import { settingsStore } from '../../src/lib/stores/settings';
@@ -52,5 +52,43 @@ describe('networkQualityStore', () => {
     // Raise threshold so p50 falls into the healthy half.
     settingsStore.update((s) => ({ ...s, healthThreshold: 250 }));
     expect(get(networkQualityStore)).toBe(100);
+  });
+});
+
+describe('monitoredEndpointsStore', () => {
+  beforeEach(() => {
+    endpointStore.setEndpoints([]);
+    measurementStore.reset();
+    settingsStore.set({ ...DEFAULT_SETTINGS });
+  });
+
+  it('is empty when the endpoint store is empty', () => {
+    expect(get(monitoredEndpointsStore)).toEqual([]);
+  });
+
+  it('passes through enabled endpoints in declaration order', () => {
+    const a = endpointStore.addEndpoint('https://a.example', 'a');
+    const b = endpointStore.addEndpoint('https://b.example', 'b');
+    endpointStore.updateEndpoint(a, { enabled: true });
+    endpointStore.updateEndpoint(b, { enabled: true });
+    const result = get(monitoredEndpointsStore);
+    expect(result.map((e) => e.id)).toEqual([a, b]);
+  });
+
+  it('excludes disabled endpoints — the cross-phase invariant', () => {
+    const on  = endpointStore.addEndpoint('https://on.example',  'on');
+    const off = endpointStore.addEndpoint('https://off.example', 'off');
+    endpointStore.updateEndpoint(on,  { enabled: true });
+    endpointStore.updateEndpoint(off, { enabled: false });
+    const result = get(monitoredEndpointsStore);
+    expect(result.map((e) => e.id)).toEqual([on]);
+  });
+
+  it('reacts when an endpoint flips enabled→disabled', () => {
+    const id = endpointStore.addEndpoint('https://x.example', 'x');
+    endpointStore.updateEndpoint(id, { enabled: true });
+    expect(get(monitoredEndpointsStore)).toHaveLength(1);
+    endpointStore.updateEndpoint(id, { enabled: false });
+    expect(get(monitoredEndpointsStore)).toHaveLength(0);
   });
 });

--- a/tests/unit/tokens.test.ts
+++ b/tests/unit/tokens.test.ts
@@ -315,7 +315,15 @@ describe('v2 foundation tokens (Phase 0)', () => {
   it('exposes v2 motion primitives', () => {
     expect(tokens.timing.handLerp).toBe(0.15);
     expect(tokens.timing.pulseRim).toBe(400);
+    expect(tokens.timing.pulseDialGlow).toBe(900);
     expect(tokens.timing.orbitPulse).toBe(1400);
     expect(tokens.timing.traceRepaint).toBe(16);
+  });
+
+  it('pulseDialGlow > pulseRim so the glow completes after the rim-color swap', () => {
+    // Invariant: the outer drop-shadow glow must visibly outlast the inner
+    // rim stroke transition. If they ever invert, the rim would snap back
+    // while the glow is still expanding — visually jarring.
+    expect(tokens.timing.pulseDialGlow).toBeGreaterThan(tokens.timing.pulseRim);
   });
 });


### PR DESCRIPTION
## Summary

Overview becomes the real ambient health view for the v2 redesign. The Phase 1 stub is replaced by the chronograph dial, a diagnosis strip pointing at the worst endpoint, and a metrics triptych. Phase 2.5 (Enriched: baseline arc, quality trace, racing strip, breathing chrome) lands later — this PR is the **Classic** dial only.

Risk tier: **HIGH** (classifier extension, cross-phase invariant, new derived store).

## What shipped

- **`ChronographDial.svelte`** — 520 × 520 minimal dial, fixed geometry per `handoff/03-components/chronograph-dial.md`. Outer rim, threshold arc, 21 ticks, numeric labels, central score readout + verdict kicker + live-median caption, white hand interpolated via rAF lerp at `tokens.timing.handLerp = 0.15`, endpoint orbit ring with per-endpoint pip + radial bar, over-threshold pip pulse, edge-triggered rim pulse on threshold cross. `role="img"` + `aria-label` on the SVG; off-screen polite live region announces threshold crossings. All three motion surfaces (CSS rim pulse, SVG `<animate>` pip, JS rAF hand) gated on `prefers-reduced-motion` via a live `matchMedia` listener.
- **`OverviewView.svelte`** — composes dial + diagnosis strip + triptych. Every user-facing aggregate (live median, worst endpoint, over-count, total samples, dial orbit) derives from `monitoredEndpointsStore`, not raw `endpointStore`.
- **`classify.ts`** — adds `overviewVerdict(score)` + `VERDICT_STYLES`. Documents the deliberate asymmetry between the 3-bucket verdict (dial) and 4-bucket `networkLevel` (topbar pill) at the declaration site so a future reader won't file this as a bug.
- **`derived.ts`** — new `monitoredEndpointsStore` (enabled-only filter of `endpointStore`). `networkQualityStore` refactored to consume it so the "enabled-only" invariant lives in one place.
- **`App.svelte#bridgeTokensToCss`** — exposes SVG primitives globally (`--svg-{grid-cyan, grid-major, tick-minor, tick-major, hand-stroke, dial-rim, orbit-track, orbit-edge, threshold}`).
- **`EndpointRail.svelte`** — aria-label rewording ("endpoints monitored" → "endpoints listed") since the rail intentionally lists disabled endpoints too.
- **`PATTERNS.md`** (NEW) — bootstraps three cross-phase rules from this PR's CR findings.
- **`scripts/phase-2-screenshots.mjs`** — Playwright capture for the four dial states.

## Bundle delta vs main

| | JS gzip | CSS gzip |
|---|---:|---:|
| Pre-Phase-2 | 59.92 KB | 9.58 KB |
| Phase 2 | **63.83 KB** | **10.19 KB** |
| Delta | **+3.91 KB** | **+0.61 KB** |

Total **+4.52 KB gzip**, well under the +15 KB Phase 2 budget.

## Adversarial self-review (per policy, HIGH-risk tier)

| Check | Result |
|---|---|
| Race conditions in `$effect`s with shared state | **Fixed (CR #1)** — merged the two threshold-cross effects into one; `wasOver` is read before being written in a single effect, no cross-effect race. |
| Cleanup-on-rerun cancelling timers before they fire | **Fixed (CR #1)** — pulse + announce timers moved to `onDestroy`. |
| Derivations iterating raw `endpointStore` instead of `monitoredEndpointsStore` | **Fixed (CR #3)** — all five OverviewView aggregates switched; dial receives `endpoints={monitored}` so its orbit mirrors the score. Rail intentionally keeps raw iteration (it lists disabled rows by design — aria-label reworded to reflect "listed" not "monitored"). |
| Reduced-motion coverage — CSS + SVG + JS | **Fixed (CR #2 + self-review add)** — CSS `.dial.pulsing` `@media` ✓; SVG `<animate>` gated on `prefersReducedMotion` ✓; **rAF hand lerp** also gated (found during self-review, not in CR output — snaps to target instead of lerping when reduced-motion is active). Live `matchMedia` listener with cleanup via `$effect` return. |
| Store subscriptions firing before init | **Safe** — `monitoredEndpointsStore` is pure `derived()`, always valid. `matchMedia` runs inside `$effect` (post-mount). |
| Migration fallback for unknown version numbers | **N/A** — no persistence changes. |
| Reactive ordering across components | **Safe** — dial consumes props that OverviewView derives atomically from the same stores on the same tick. |
| Token usage — no raw hex / raw px for token-covered values | **Clean** — classify additions have no visuals; derived logic only; matchMedia logic is pure JS; OverviewView layout uses existing tokens. |

## Screenshots

Four dial states — see the follow-up comment (at-rest / healthy / mixed / critical).

## Notes for reviewer

- Verdict vs pill asymmetry is intentional and documented at the declaration site in `classify.ts`.
- PAUSED badge only shows on lifecycle `stopped`/`completed`, never `idle`.
- Drill destination is `'lanes'` until Phase 4's Atlas ships — comment flags the TODO at the call site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Phase 2 overview dashboard featuring an analog dial display showing network quality with live hand animation and endpoint status markers.
  * Introduced network quality verdict system with visual color coding and diagnostics for worst-endpoint analysis.
  * Added metrics triptych and drill-down functionality for detailed endpoint inspection.

* **Improvements**
  * Enhanced accessibility with reduced-motion support and live status announcements.
  * Improved endpoint labeling clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->