### PR TITLE
Phase 2.5 — enriched overview: dial v2, verdict, racing, feed + v5→v6 migration

### DIFF
--- a/scripts/phase-2-5-screenshots.mjs
+++ b/scripts/phase-2-5-screenshots.mjs
@@ -77,14 +77,19 @@ try {
       unsub = epMod.endpointStore.subscribe((v) => { resolve(v); queueMicrotask(() => unsub?.()); });
     });
     // Push a sequence of alternating over/under samples to fabricate several
-    // crossings across multiple endpoints.
+    // crossings across multiple endpoints. Timestamps must be in the past so
+    // relTime() doesn't clamp everything to "0s ago". Per-endpoint offset
+    // avoids key collisions on `${t}-${epId}-${kind}` when all five cycles
+    // emit the same transition millisecond.
     let round = 40;
     const now = Date.now();
     for (let cycle = 0; cycle < 5; cycle++) {
       const over = cycle % 2 === 0;
-      for (const ep of eps) {
+      const cycleTime = now - (5 - cycle) * 1000;
+      for (let epIdx = 0; epIdx < eps.length; epIdx++) {
+        const ep = eps[epIdx];
         const lat = over ? 300 : 25;
-        measMod.measurementStore.addSample(ep.id, round, lat, 'ok', now + cycle * 1000);
+        measMod.measurementStore.addSample(ep.id, round, lat, 'ok', cycleTime - epIdx * 10);
       }
       round++;
     }

--- a/scripts/phase-2-5-screenshots.mjs
+++ b/scripts/phase-2-5-screenshots.mjs
@@ -1,0 +1,98 @@
+// Playwright runner for the Phase 2.5 PR screenshots. Outputs four PNGs:
+//   1. Classic dial (overviewMode='classic')          — Phase 2 visual sanity
+//   2. Enriched dial (overviewMode='enriched')        — baseline arc, score
+//   3. Causal verdict populated                       — after seeding mixed stats
+//   4. Event feed with ≥3 entries                     — after toggling thresholds
+import { chromium } from 'playwright';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+const OUT = path.resolve('screenshots/phase-2-5');
+await mkdir(OUT, { recursive: true });
+
+const browser = await chromium.launch();
+try {
+  const context = await browser.newContext({ viewport: { width: 1440, height: 1000 }, deviceScaleFactor: 2 });
+  const page = await context.newPage();
+
+  await page.goto('http://127.0.0.1:5173/');
+  await page.evaluate(() => { localStorage.clear(); });
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+  await page.evaluate(async () => { await document.fonts.ready; });
+
+  async function seedSamples(profiles) {
+    await page.evaluate(async (profiles) => {
+      const measMod = await import('/src/lib/stores/measurements.ts');
+      const epMod = await import('/src/lib/stores/endpoints.ts');
+      const eps = await new Promise((resolve) => {
+        let unsub;
+        unsub = epMod.endpointStore.subscribe((v) => { resolve(v); queueMicrotask(() => unsub?.()); });
+      });
+      measMod.measurementStore.reset();
+      for (let i = 0; i < eps.length; i++) {
+        const ep = eps[i];
+        const lat = profiles[i] || profiles[profiles.length - 1];
+        measMod.measurementStore.initEndpoint(ep.id);
+        for (let r = 0; r < lat.length; r++) {
+          measMod.measurementStore.addSample(ep.id, r + 1, lat[r], 'ok', Date.now() - (lat.length - r) * 1000);
+        }
+      }
+    }, profiles);
+    await page.waitForTimeout(300);
+  }
+
+  async function setOverviewMode(mode) {
+    await page.evaluate(async (mode) => {
+      const settingsMod = await import('/src/lib/stores/settings.ts');
+      settingsMod.settingsStore.update((s) => ({ ...s, overviewMode: mode }));
+    }, mode);
+    await page.waitForTimeout(200);
+  }
+
+  // Shot 1 — Classic dial (mid-load state with healthy samples for visual clarity).
+  const fast = Array.from({ length: 35 }, (_, i) => 25 + (i % 5) * 2);
+  await setOverviewMode('classic');
+  await seedSamples([fast, fast, fast, fast]);
+  await page.screenshot({ path: path.join(OUT, '1-classic.png'), type: 'png' });
+
+  // Shot 2 — Enriched dial, healthy: baseline arc + quality trace.
+  await setOverviewMode('enriched');
+  await page.waitForTimeout(300);
+  await page.screenshot({ path: path.join(OUT, '2-enriched-healthy.png'), type: 'png' });
+
+  // Shot 3 — Enriched, mixed state with a verdict populated.
+  const slow = Array.from({ length: 35 }, (_, i) => 180 + (i % 5) * 10);
+  await seedSamples([fast, slow, slow, fast]);
+  // Nudge baseline recompute.
+  await page.waitForTimeout(500);
+  await page.screenshot({ path: path.join(OUT, '3-enriched-verdict.png'), type: 'png' });
+
+  // Shot 4 — Event feed with ≥3 entries by toggling latencies across rounds.
+  await page.evaluate(async () => {
+    const measMod = await import('/src/lib/stores/measurements.ts');
+    const epMod = await import('/src/lib/stores/endpoints.ts');
+    const eps = await new Promise((resolve) => {
+      let unsub;
+      unsub = epMod.endpointStore.subscribe((v) => { resolve(v); queueMicrotask(() => unsub?.()); });
+    });
+    // Push a sequence of alternating over/under samples to fabricate several
+    // crossings across multiple endpoints.
+    let round = 40;
+    const now = Date.now();
+    for (let cycle = 0; cycle < 5; cycle++) {
+      const over = cycle % 2 === 0;
+      for (const ep of eps) {
+        const lat = over ? 300 : 25;
+        measMod.measurementStore.addSample(ep.id, round, lat, 'ok', now + cycle * 1000);
+      }
+      round++;
+    }
+  });
+  await page.waitForTimeout(500);
+  await page.screenshot({ path: path.join(OUT, '4-enriched-events.png'), type: 'png' });
+
+  console.log('Screenshots written to', OUT);
+} finally {
+  await browser.close();
+}

--- a/src/lib/components/App.svelte
+++ b/src/lib/components/App.svelte
@@ -173,7 +173,7 @@
       const endpoints = get(endpointStore);
 
       const payload: PersistedSettings = {
-        version: 5,
+        version: 6,
         endpoints: endpoints.map(ep => ({ url: ep.url, enabled: ep.enabled })),
         settings,
         ui: {

--- a/src/lib/components/CausalVerdictStrip.svelte
+++ b/src/lib/components/CausalVerdictStrip.svelte
@@ -1,0 +1,198 @@
+<!-- src/lib/components/CausalVerdictStrip.svelte -->
+<!-- Single-sentence diagnosis with backing triptych + drill CTA. Pure render  -->
+<!-- — verdict is computed in the parent via verdict.ts and passed in whole.   -->
+<script lang="ts">
+  import type { Verdict } from '$lib/utils/verdict';
+  import type { Endpoint } from '$lib/types';
+
+  interface Props {
+    verdict: Verdict;
+    avgP50: number | null;
+    avgJitter: number | null;
+    avgLoss: number | null;
+    drillEndpoint: Endpoint | null;
+    onDrill: (epId: string) => void;
+  }
+
+  let { verdict, avgP50, avgJitter, avgLoss, drillEndpoint, onDrill }: Props = $props();
+
+  const fmtInt = (n: number | null): string => (n == null ? '—' : String(Math.round(n)));
+  const fmt1 = (n: number | null): string => (n == null ? '—' : n.toFixed(1));
+</script>
+
+<section
+  class="verdict"
+  class:warn={verdict.tone === 'warn'}
+  class:good={verdict.tone === 'good'}
+  aria-live="polite"
+  aria-atomic="true"
+>
+  <div class="verdict-main">
+    <span class="verdict-dot" aria-hidden="true"></span>
+    <h2 class="verdict-headline">{verdict.headline}</h2>
+  </div>
+
+  <dl class="verdict-metrics">
+    <div class="verdict-metric">
+      <dt class="verdict-metric-label">Median</dt>
+      <dd class="verdict-metric-value">
+        <span class="verdict-metric-num">{fmtInt(avgP50)}</span>
+        <span class="verdict-metric-unit">ms</span>
+      </dd>
+    </div>
+    <div class="verdict-metric">
+      <dt class="verdict-metric-label">Jitter</dt>
+      <dd class="verdict-metric-value">
+        <span class="verdict-metric-num">{fmt1(avgJitter)}</span>
+        <span class="verdict-metric-unit">σ</span>
+      </dd>
+    </div>
+    <div class="verdict-metric">
+      <dt class="verdict-metric-label">Loss</dt>
+      <dd class="verdict-metric-value">
+        <span class="verdict-metric-num">{fmt1(avgLoss)}</span>
+        <span class="verdict-metric-unit">%</span>
+      </dd>
+    </div>
+  </dl>
+
+  {#if drillEndpoint && verdict.tone === 'warn'}
+    <button
+      type="button"
+      class="verdict-drill"
+      onclick={() => onDrill(drillEndpoint.id)}
+      aria-label="Diagnose {drillEndpoint.label}, route to diagnose view"
+    >
+      <span class="verdict-drill-text">Diagnose</span>
+      <span class="verdict-drill-ep" style:color={drillEndpoint.color}>{drillEndpoint.label}</span>
+      <span class="verdict-drill-arrow" aria-hidden="true">→</span>
+    </button>
+  {/if}
+</section>
+
+<style>
+  .verdict {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 14px 22px;
+    align-items: center;
+    background: var(--glass-bg-rail-hover);
+    border: 1px solid var(--border-mid);
+    border-radius: 14px;
+    padding: 14px 18px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+  }
+  .verdict.warn { border-color: var(--accent-amber-glow); background: linear-gradient(0deg, rgba(251,191,36,.03), rgba(251,191,36,.03)), var(--glass-bg-rail-hover); }
+  .verdict.good { border-color: rgba(134,239,172,.25); }
+
+  .verdict-main {
+    grid-column: 1 / -1;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .verdict-dot {
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .verdict.good .verdict-dot {
+    background: var(--accent-green);
+    box-shadow: 0 0 8px var(--green-glow);
+  }
+  .verdict.warn .verdict-dot {
+    background: var(--accent-amber);
+    box-shadow: 0 0 8px var(--accent-amber-glow);
+    animation: verdictPulse 1.8s ease-in-out infinite;
+  }
+  @keyframes verdictPulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.55; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .verdict.warn .verdict-dot { animation: none; }
+  }
+  .verdict-headline {
+    margin: 0;
+    color: var(--t1);
+    font-family: var(--sans);
+    font-size: var(--ts-base);
+    font-weight: 500;
+    letter-spacing: var(--tr-tight);
+  }
+
+  .verdict-metrics {
+    grid-column: 1;
+    margin: 0;
+    padding-top: 10px;
+    border-top: 1px solid var(--border-mid);
+    display: flex;
+    gap: 24px;
+    align-items: baseline;
+  }
+  .verdict-metric {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .verdict-metric-label {
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-kicker);
+    color: var(--t4);
+    text-transform: uppercase;
+    margin: 0;
+  }
+  .verdict-metric-value {
+    margin: 0;
+    display: flex;
+    align-items: baseline;
+    gap: 4px;
+    font-family: var(--mono);
+    font-variant-numeric: tabular-nums;
+  }
+  .verdict-metric-num {
+    font-size: var(--ts-xl);
+    font-weight: 300;
+    color: var(--t1);
+    letter-spacing: var(--tr-tight);
+  }
+  .verdict-metric-unit {
+    font-size: var(--ts-sm);
+    color: var(--t3);
+    letter-spacing: var(--tr-label);
+  }
+
+  .verdict-drill {
+    grid-column: 2;
+    align-self: center;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    border-radius: 8px;
+    background: var(--cyan-bg-subtle, rgba(103, 232, 249, 0.08));
+    border: 1px solid var(--cyan-border-subtle, rgba(103, 232, 249, 0.25));
+    color: var(--t1);
+    font-family: var(--mono);
+    font-size: var(--ts-sm);
+    letter-spacing: var(--tr-label);
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: background 160ms ease, border-color 160ms ease;
+  }
+  .verdict-drill:hover { background: var(--cyan25); }
+  .verdict-drill:focus-visible {
+    outline: 1.5px solid var(--accent-cyan);
+    outline-offset: 2px;
+  }
+  .verdict-drill-ep { font-variant-numeric: tabular-nums; }
+  .verdict-drill-arrow { color: var(--accent-cyan); }
+
+  @media (max-width: 767px) {
+    .verdict { grid-template-columns: 1fr; }
+    .verdict-metrics { flex-wrap: wrap; gap: 14px; }
+    .verdict-drill { grid-column: 1; justify-content: center; }
+  }
+</style>

--- a/src/lib/components/ChronographDialV2.svelte
+++ b/src/lib/components/ChronographDialV2.svelte
@@ -1,0 +1,619 @@
+<!-- src/lib/components/ChronographDialV2.svelte -->
+<!-- Enriched Phase 2.5 dial — sibling of ChronographDial, same base geometry  -->
+<!-- (rim / threshold arc / ticks / hand / orbit / pulse) plus four layers:    -->
+<!--   • Baseline arc inside the tick track (where the network usually lives)  -->
+<!--   • 60s quality trace inside the face                                     -->
+<!--   • Within-band / above / below label below the score                    -->
+<!--   • Breathing chrome — dial weights lerp between healthy and degraded     -->
+<!-- Duplicates the Classic dial's scaffolding by design: per PHASE_NOTES.md   -->
+<!-- Phase 2.5 policy, the two dials are sibling components gated by           -->
+<!-- settings.overviewMode — not a variant branch inside one component.        -->
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import { tokens } from '$lib/tokens';
+  import { VERDICT_STYLES, overviewVerdict, type OverviewVerdict } from '$lib/utils/classify';
+  import { fmt } from '$lib/utils/format';
+  import type { Endpoint } from '$lib/types';
+
+  interface Baseline {
+    p25: number;
+    median: number;
+    p75: number;
+  }
+
+  interface Props {
+    score: number | null;
+    liveMedian: number | null;
+    threshold: number;
+    endpoints: readonly Endpoint[];
+    lastLatencies: Record<string, number | null>;
+    /** True only after the user has explicitly stopped a previously-running test
+     *  (lifecycle 'stopped' or 'completed'). 'idle' / 'starting' do not paint
+     *  the PAUSED badge — there's nothing to be paused from. */
+    paused: boolean;
+    /** Last 60 samples of `networkQuality()`; used to draw the quality trace. */
+    scoreHistory: readonly number[];
+    /** Baseline latency cluster computed from ≥30 samples over last 120s;
+     *  null when confidence is too low — dial hides the baseline arc. */
+    baseline: Baseline | null;
+  }
+
+  let { score, liveMedian, threshold, endpoints, lastLatencies, paused, scoreHistory, baseline }: Props = $props();
+
+  // ── Geometry constants ─────────────────────────────────────────────────────
+  const SIZE = 520;
+  const CX = SIZE / 2;
+  const CY = SIZE / 2;
+  const OUTER_R = 240;
+  const ORBIT_R = OUTER_R + 4;
+  const BAR_INNER = ORBIT_R - 3;
+  const BAR_OUTER = ORBIT_R + 3;
+  const PIP_R_REST = 2.2;
+  const PIP_R_OVER = 3;
+
+  const START_ANG = -135;
+  const END_ANG = 135;
+  const MAX_MS = 300;
+
+  function clamp01(t: number): number { return t < 0 ? 0 : t > 1 ? 1 : t; }
+  function latToAng(ms: number): number {
+    return START_ANG + clamp01(ms / MAX_MS) * (END_ANG - START_ANG);
+  }
+
+  // SVG arc helper for the threshold zone (from threshold → MAX_MS).
+  function arcPath(cx: number, cy: number, r: number, startDeg: number, endDeg: number): string {
+    const a0 = (startDeg * Math.PI) / 180;
+    const a1 = (endDeg   * Math.PI) / 180;
+    const x0 = cx + Math.cos(a0) * r;
+    const y0 = cy + Math.sin(a0) * r;
+    const x1 = cx + Math.cos(a1) * r;
+    const y1 = cy + Math.sin(a1) * r;
+    const largeArc = Math.abs(endDeg - startDeg) > 180 ? 1 : 0;
+    const sweep = endDeg > startDeg ? 1 : 0;
+    return `M ${x0} ${y0} A ${r} ${r} 0 ${largeArc} ${sweep} ${x1} ${y1}`;
+  }
+
+  // ── Precomputed static layers ──────────────────────────────────────────────
+  // Tick marks every 15ms; every 60ms is a major tick. Major/minor geometry
+  // differs slightly (deeper inset + thicker stroke for major).
+  interface Tick { ms: number; major: boolean; x1: number; y1: number; x2: number; y2: number; }
+  const ticks: readonly Tick[] = (() => {
+    const out: Tick[] = [];
+    for (let ms = 0; ms <= MAX_MS; ms += 15) {
+      const major = ms % 60 === 0;
+      const a = (latToAng(ms) * Math.PI) / 180;
+      const r1 = OUTER_R - (major ? 16 : 8);
+      const r2 = OUTER_R - 2;
+      out.push({
+        ms,
+        major,
+        x1: CX + Math.cos(a) * r1, y1: CY + Math.sin(a) * r1,
+        x2: CX + Math.cos(a) * r2, y2: CY + Math.sin(a) * r2,
+      });
+    }
+    return out;
+  })();
+
+  interface Label { ms: number; x: number; y: number; }
+  const NUMERIC_LABELS: readonly Label[] = [0, 60, 120, 180, 240, 300].map((ms) => {
+    const a = (latToAng(ms) * Math.PI) / 180;
+    const r = OUTER_R - 30;
+    return { ms, x: CX + Math.cos(a) * r, y: CY + Math.sin(a) * r + 3 };
+  });
+
+  // ── Reactive derivations ───────────────────────────────────────────────────
+  const threshAngDeg = $derived(latToAng(threshold));
+  const threshArcD = $derived(arcPath(CX, CY, OUTER_R - 4, threshAngDeg, END_ANG));
+  const verdict: OverviewVerdict = $derived(overviewVerdict(score));
+  const verdictStyle = $derived(VERDICT_STYLES[verdict]);
+  const overThreshold = $derived(liveMedian != null && liveMedian > threshold);
+  const endpointCount = $derived(endpoints.length);
+  const scoreDisplay = $derived(score == null ? '—' : String(score));
+
+  // ── Baseline arc (Dial v2) ─────────────────────────────────────────────────
+  // "Where the network usually lives." Drawn inside the tick track — its width
+  // is the p25→p75 spread of the last 120s sample pool. A central tick marks
+  // the median. Hidden when `baseline == null` (view gates on sample count).
+  const BASELINE_R = OUTER_R - 48;
+  const baselineArc = $derived.by(() => {
+    if (baseline === null) return null;
+    const startAng = latToAng(baseline.p25);
+    const endAng = latToAng(baseline.p75);
+    return {
+      d: arcPath(CX, CY, BASELINE_R, startAng, endAng),
+      medianAng: latToAng(baseline.median),
+    };
+  });
+  // Small tick at the baseline's median angle, 6px long radially inward.
+  const baselineMedianTick = $derived.by(() => {
+    if (baselineArc === null) return null;
+    const a = (baselineArc.medianAng * Math.PI) / 180;
+    return {
+      x1: CX + Math.cos(a) * (BASELINE_R - 3),
+      y1: CY + Math.sin(a) * (BASELINE_R - 3),
+      x2: CX + Math.cos(a) * (BASELINE_R + 3),
+      y2: CY + Math.sin(a) * (BASELINE_R + 3),
+    };
+  });
+
+  // ── 60s quality trace (Dial v2) ────────────────────────────────────────────
+  // Sparkline inside the face, below the score. Score 100 at top, 0 at bottom.
+  // Hidden when history is too short — calibrating label shows instead.
+  const TRACE_X = CX - 70;
+  const TRACE_Y = CY + 34;
+  const TRACE_W = 140;
+  const TRACE_H = 26;
+  const TRACE_MIN_POINTS = 4;
+  const qualityTraceD = $derived.by(() => {
+    if (!scoreHistory || scoreHistory.length < TRACE_MIN_POINTS) return null;
+    const n = scoreHistory.length;
+    let d = '';
+    for (let i = 0; i < n; i++) {
+      const x = TRACE_X + (n === 1 ? TRACE_W / 2 : (i / (n - 1)) * TRACE_W);
+      const s = Math.max(0, Math.min(100, scoreHistory[i]));
+      const y = TRACE_Y + (TRACE_H - (s / 100) * (TRACE_H - 2) - 1);
+      d += (i === 0 ? 'M ' : 'L ') + `${x.toFixed(1)} ${y.toFixed(1)} `;
+    }
+    return d.trim();
+  });
+  // Dynamic trace color, synced to the current score's verdict tone.
+  const traceColor = $derived.by(() => {
+    if (score == null) return 'var(--t4)';
+    if (score >= 70) return 'var(--accent-green)';
+    if (score >= 45) return 'var(--accent-amber)';
+    return 'var(--accent-pink)';
+  });
+
+  // ── Within-band label (Dial v2) ────────────────────────────────────────────
+  type BandLabel = 'WITHIN BAND' | 'ABOVE BAND' | 'BELOW BAND' | null;
+  const bandLabel: BandLabel = $derived.by(() => {
+    if (baseline === null || liveMedian == null) return null;
+    if (liveMedian >= baseline.p25 && liveMedian <= baseline.p75) return 'WITHIN BAND';
+    if (liveMedian > baseline.p75) return 'ABOVE BAND';
+    return 'BELOW BAND';
+  });
+  const bandLabelColor = $derived.by(() => {
+    if (bandLabel === 'WITHIN BAND') return 'var(--accent-green)';
+    if (bandLabel === 'ABOVE BAND')  return 'var(--accent-amber)';
+    return 'var(--t4)';
+  });
+
+  // ── Breathing chrome (Dial v2) ─────────────────────────────────────────────
+  // Weight scalar: 0 when healthy (score ≥ 70), 1 when degraded (score < 45),
+  // linearly interpolated across the [45, 70] band. Drives stroke opacity,
+  // tick weight, label opacity, and score weight via CSS custom properties so
+  // the whole dial "breathes" on score changes without per-element animation.
+  const breatheWeight = $derived.by(() => {
+    if (score == null) return 0;
+    const s = Math.max(45, Math.min(70, score));
+    return (70 - s) / 25;
+  });
+  const breatheVars = $derived.by(() => {
+    const w = breatheWeight;
+    return {
+      '--ring-opacity':   String(0.14 + w * 0.18),
+      '--face-stroke':    `${1.2 + w * 1.0}px`,
+      '--tick-minor-op':  String(0.55 + w * 0.23),
+      '--tick-major-op':  String(0.72 + w * 0.13),
+      '--label-op':       String(0.42 + w * 0.26),
+      '--score-weight':   String(Math.round(500 + w * 200)),
+    } as Record<string, string>;
+  });
+
+  // ── prefers-reduced-motion (live-listened) ────────────────────────────────
+  // OS toggle can flip while the app is open, so a one-shot read is wrong;
+  // listen and re-render. SSR-safe via the typeof window guard. Declared
+  // before the rAF effect + SVG <animate> gate because both read it.
+  let prefersReducedMotion = $state(false);
+  $effect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    prefersReducedMotion = mq.matches;
+    const handler = (e: MediaQueryListEvent): void => { prefersReducedMotion = e.matches; };
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  });
+
+  // ── Live hand: rAF lerp toward the target angle ────────────────────────────
+  const targetAng = $derived(latToAng(liveMedian ?? 0));
+  let displayAng = $state(targetAng);
+  let rafId: number | null = null;
+
+  $effect(() => {
+    const target = targetAng;
+    const lerp = tokens.timing.handLerp;
+    // Reduced-motion users get the target snap — no smooth lerp. Covers the
+    // third motion surface alongside the CSS rim pulse and the SVG <animate>
+    // pip ring.
+    if (prefersReducedMotion) {
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      rafId = null;
+      displayAng = target;
+      return;
+    }
+    const stepFn = (): void => {
+      const diff = target - displayAng;
+      if (Math.abs(diff) < 0.1) {
+        displayAng = target;
+        rafId = null;
+        return;
+      }
+      displayAng = displayAng + diff * lerp;
+      rafId = requestAnimationFrame(stepFn);
+    };
+    if (rafId !== null) cancelAnimationFrame(rafId);
+    rafId = requestAnimationFrame(stepFn);
+    return () => { if (rafId !== null) cancelAnimationFrame(rafId); rafId = null; };
+  });
+
+  // ── Threshold-cross effects (rim pulse + SR announcement) ────────────────
+  // Single $effect — sibling effects on the same `wasOver` flag race in Svelte
+  // 5: one writes wasOver=true before the other reads !wasOver, dropping the
+  // announcement. Cleanup also moves to onDestroy so per-rerun cleanup doesn't
+  // cancel the pending timer when overThreshold flips back-and-forth (which
+  // would otherwise leave `pulsing` or `crossingAnnouncement` permanently set).
+  let pulsing = $state(false);
+  let crossingAnnouncement = $state('');
+  let wasOver = false;
+  let pulseTimer: ReturnType<typeof setTimeout> | null = null;
+  let announceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  $effect(() => {
+    const over = overThreshold;
+    const median = liveMedian;
+    const t = threshold;
+    if (over && !wasOver) {
+      // Rim pulse — window matches the CSS keyframe duration (--timing-pulse-dial-glow)
+      // so the `pulsing` class drops off exactly when the animation completes.
+      pulsing = true;
+      if (pulseTimer !== null) clearTimeout(pulseTimer);
+      pulseTimer = setTimeout(() => { pulsing = false; pulseTimer = null; }, tokens.timing.pulseDialGlow);
+
+      // SR announcement — cleared after a short dwell so it doesn't linger.
+      const msg = median == null
+        ? 'Median latency crossed threshold.'
+        : `Median latency crossed threshold — now ${Math.round(median)}ms, threshold ${t}ms.`;
+      crossingAnnouncement = msg;
+      if (announceTimer !== null) clearTimeout(announceTimer);
+      announceTimer = setTimeout(() => { crossingAnnouncement = ''; announceTimer = null; }, 2000);
+    }
+    wasOver = over;
+  });
+
+  onDestroy(() => {
+    if (pulseTimer !== null) clearTimeout(pulseTimer);
+    if (announceTimer !== null) clearTimeout(announceTimer);
+  });
+
+  // ── Hand geometry ──────────────────────────────────────────────────────────
+  const handTip = $derived.by(() => {
+    const a = (displayAng * Math.PI) / 180;
+    const tipR = OUTER_R - 10;
+    const tailR = 24;
+    return {
+      x1: CX - Math.cos(a) * tailR,
+      y1: CY - Math.sin(a) * tailR,
+      x2: CX + Math.cos(a) * tipR,
+      y2: CY + Math.sin(a) * tipR,
+    };
+  });
+
+  // ── Orbit markers ──────────────────────────────────────────────────────────
+  interface OrbitMarker { id: string; color: string; x1: number; y1: number; x2: number; y2: number; pipX: number; pipY: number; over: boolean; }
+  const orbitMarkers: readonly OrbitMarker[] = $derived.by(() => {
+    const result: OrbitMarker[] = [];
+    for (const ep of endpoints) {
+      const lat = lastLatencies[ep.id];
+      if (lat == null || !Number.isFinite(lat)) continue;
+      const a = (latToAng(lat) * Math.PI) / 180;
+      const over = lat > threshold;
+      result.push({
+        id: ep.id,
+        color: ep.color || tokens.color.endpoint[0],
+        x1: CX + Math.cos(a) * BAR_INNER,
+        y1: CY + Math.sin(a) * BAR_INNER,
+        x2: CX + Math.cos(a) * BAR_OUTER,
+        y2: CY + Math.sin(a) * BAR_OUTER,
+        pipX: CX + Math.cos(a) * (BAR_OUTER + 4),
+        pipY: CY + Math.sin(a) * (BAR_OUTER + 4),
+        over,
+      });
+    }
+    return result;
+  });
+
+  // ── Accessibility label ────────────────────────────────────────────────────
+  const ariaLabel = $derived.by(() => {
+    const scorePart = score == null ? 'no data' : `${score} percent healthy`;
+    const medianPart = liveMedian == null ? 'unknown median' : `median ${Math.round(liveMedian)} milliseconds`;
+    const countPart = `${endpointCount} endpoint${endpointCount === 1 ? '' : 's'} monitored`;
+    const bandPart = bandLabel === null
+      ? ''
+      : `, ${bandLabel === 'WITHIN BAND' ? 'within normal range' : bandLabel === 'ABOVE BAND' ? 'above normal range' : 'below normal range'}`;
+    return `Network health dial — ${scorePart}, ${medianPart}${bandPart}, ${countPart}.`;
+  });
+</script>
+
+<div class="dial-wrap" class:paused>
+  <svg
+    class="dial"
+    class:pulsing
+    viewBox="0 0 {SIZE} {SIZE}"
+    preserveAspectRatio="xMidYMid meet"
+    role="img"
+    aria-label={ariaLabel}
+    style={Object.entries(breatheVars).map(([k, v]) => `${k}:${v}`).join(';')}
+  >
+      <defs>
+        <radialGradient id="dial-face-bg" cx="50%" cy="40%">
+          <stop offset="0%"   stop-color="var(--surface-raised)" />
+          <stop offset="60%"  stop-color="var(--bg-base)" />
+          <stop offset="100%" stop-color="#030207" />
+        </radialGradient>
+        <filter id="dial-hand-glow">
+          <feGaussianBlur stdDeviation="3" result="b" />
+          <feMerge><feMergeNode in="b" /><feMergeNode in="SourceGraphic" /></feMerge>
+        </filter>
+      </defs>
+
+      <!-- 1. Outer structural hairline. -->
+      <circle cx={CX} cy={CY} r={OUTER_R + 8} fill="none" stroke="var(--border-mid)" stroke-width="1" />
+
+      <!-- 2. Dial face with a radial fill for depth. -->
+      <circle cx={CX} cy={CY} r={OUTER_R} fill="url(#dial-face-bg)"
+              stroke="var(--svg-dial-rim)" stroke-width="1" />
+
+      <!-- 3. Inner rim — stroke swaps to verdict color while pulsing. -->
+      <circle cx={CX} cy={CY} r={OUTER_R - 4} fill="none"
+              stroke={pulsing ? verdictStyle.color : 'var(--svg-grid-major)'}
+              stroke-width={pulsing ? 2 : 1}
+              style:transition="stroke var(--timing-pulse-rim, 400ms) ease" />
+
+      <!-- 4. Decorative concentric guides. -->
+      <circle cx={CX} cy={CY} r={OUTER_R - 36} fill="none" stroke="var(--svg-grid-cyan)" stroke-width="0.5" />
+      <circle cx={CX} cy={CY} r={60}           fill="none" stroke="var(--svg-grid-cyan)" stroke-width="0.5" />
+
+      <!-- 4a (v2). Baseline arc — "where the network usually lives". Hidden
+           when baseline is null (sample count < 30). Decorative, no role. -->
+      {#if baselineArc !== null}
+        <g aria-hidden="true">
+          <path
+            d={baselineArc.d}
+            fill="none"
+            stroke="rgba(255,255,255,.07)"
+            stroke-width="14"
+            stroke-linecap="round"
+          />
+          {#if baselineMedianTick !== null}
+            <line
+              x1={baselineMedianTick.x1} y1={baselineMedianTick.y1}
+              x2={baselineMedianTick.x2} y2={baselineMedianTick.y2}
+              stroke="rgba(255,255,255,.14)" stroke-width="1.5" stroke-linecap="round"
+            />
+          {/if}
+        </g>
+      {/if}
+
+      <!-- 5. Threshold arc (over-threshold zone). -->
+      <path d={threshArcD} fill="none" stroke="var(--svg-threshold)" stroke-width="2" stroke-linecap="round" />
+
+      <!-- 6. Tick marks. -->
+      {#each ticks as t (t.ms)}
+        <line
+          x1={t.x1} y1={t.y1} x2={t.x2} y2={t.y2}
+          stroke={t.major ? 'var(--svg-tick-major)' : 'var(--svg-tick-minor)'}
+          stroke-width={t.major ? 1.3 : 0.8}
+        />
+      {/each}
+
+      <!-- 7. Numeric labels. -->
+      {#each NUMERIC_LABELS as l (l.ms)}
+        <text
+          x={l.x} y={l.y}
+          text-anchor="middle"
+          font-size="10"
+          font-family={tokens.typography.mono.fontFamily}
+          fill="var(--t3)"
+          letter-spacing="0.1em"
+        >{l.ms}</text>
+      {/each}
+
+      <!-- 8. Center readouts. Kicker / score / verdict / live-median. -->
+      <text x={CX} y={CY - 94} text-anchor="middle" font-size="10"
+            font-family={tokens.typography.mono.fontFamily} fill="var(--t3)" letter-spacing="0.3em">QUALITY</text>
+      <text x={CX} y={CY - 8} text-anchor="middle" font-size="120" font-weight="200"
+            fill="var(--t1)" font-family={tokens.typography.sans.fontFamily}
+            style="letter-spacing: -0.05em; font-variant-numeric: tabular-nums;">{scoreDisplay}</text>
+      <text x={CX} y={CY + 38} text-anchor="middle" font-size="11"
+            font-family={tokens.typography.mono.fontFamily} fill={verdictStyle.color} letter-spacing="0.28em">
+        {verdictStyle.kicker}
+      </text>
+      <text x={CX} y={CY + 64} text-anchor="middle" font-size="10"
+            font-family={tokens.typography.mono.fontFamily} fill="var(--t4)" letter-spacing="0.18em">
+        LIVE {fmt(liveMedian).toUpperCase()} · {endpointCount} {endpointCount === 1 ? 'LINK' : 'LINKS'}
+      </text>
+
+      <!-- 8a (v2). 60s quality trace inside the face. Decorative — the numeric
+           score + verdict kicker carry the primary meaning for SR users. -->
+      {#if qualityTraceD !== null}
+        <g aria-hidden="true">
+          <path
+            d={qualityTraceD}
+            fill="none"
+            stroke={traceColor}
+            stroke-width="1.4"
+            stroke-linejoin="round"
+            stroke-linecap="round"
+            opacity="0.9"
+          />
+        </g>
+      {:else if scoreHistory && scoreHistory.length > 0}
+        <text
+          x={CX} y={TRACE_Y + TRACE_H / 2 + 4}
+          text-anchor="middle" font-size="9"
+          font-family={tokens.typography.mono.fontFamily}
+          fill="var(--t4)" letter-spacing="0.18em"
+          aria-hidden="true"
+        >CALIBRATING</text>
+      {/if}
+
+      <!-- 8b (v2). Within-band / above / below label. Informative — included
+           in the dial's aria-label via `bandLabel`. -->
+      {#if bandLabel !== null}
+        <text
+          x={CX} y={CY + 86}
+          text-anchor="middle" font-size="10"
+          font-family={tokens.typography.mono.fontFamily}
+          fill={bandLabelColor} letter-spacing="0.14em"
+        >{bandLabel}</text>
+      {/if}
+
+      <!-- 9. Endpoint orbit ring. -->
+      <g aria-hidden="true">
+        <circle cx={CX} cy={CY} r={ORBIT_R} fill="none" stroke="var(--svg-orbit-track)" stroke-width="6" />
+        <circle cx={CX} cy={CY} r={ORBIT_R} fill="none" stroke="var(--svg-orbit-edge)"  stroke-width="0.8" />
+        {#each orbitMarkers as m (m.id)}
+          <g>
+            <line
+              x1={m.x1} y1={m.y1} x2={m.x2} y2={m.y2}
+              stroke={m.color} stroke-width="2.5" stroke-linecap="round"
+              opacity={m.over ? 1 : 0.9}
+            />
+            <circle
+              cx={m.pipX} cy={m.pipY}
+              r={m.over ? PIP_R_OVER : PIP_R_REST}
+              fill={m.color}
+              stroke={m.over ? 'var(--accent-pink-glow)' : 'var(--bg-base)'}
+              stroke-width={m.over ? 2 : 0.5}
+            >
+              {#if m.over && !prefersReducedMotion}
+                <animate attributeName="r" values="{PIP_R_OVER};{PIP_R_OVER + 1.5};{PIP_R_OVER}" dur="1.4s" repeatCount="indefinite" />
+              {/if}
+            </circle>
+          </g>
+        {/each}
+      </g>
+
+      <!-- 10. Hand — white stroke with a glow filter, interpolated via rAF lerp. -->
+      <g>
+        <line x1={handTip.x1} y1={handTip.y1} x2={handTip.x2} y2={handTip.y2}
+              stroke="var(--svg-hand-stroke)" stroke-width="2.2" stroke-linecap="round"
+              filter="url(#dial-hand-glow)" />
+      </g>
+
+      <!-- 11. Central hub. -->
+      <circle cx={CX} cy={CY} r="8" fill="var(--bg-base)" stroke="var(--border-bright)" stroke-width="1" />
+      <circle cx={CX} cy={CY} r="2.5" fill="var(--t1)" />
+    </svg>
+
+  <div class="dial-announcer" role="status" aria-live="polite" aria-atomic="true">
+    {crossingAnnouncement}
+  </div>
+
+  {#if paused}
+    <span class="paused-badge" aria-hidden="true">PAUSED</span>
+  {/if}
+</div>
+
+<style>
+  .dial-wrap {
+    position: relative;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 12px 0;
+  }
+
+  /* Register the breathing-chrome custom properties so transitions can animate
+     them. Without @property the browser treats custom props as untyped strings
+     and snaps between values. Falls back to unanimated snaps on older browsers. */
+  @property --ring-opacity {
+    syntax: '<number>';
+    initial-value: 0.14;
+    inherits: true;
+  }
+  @property --face-stroke {
+    syntax: '<length>';
+    initial-value: 1.2px;
+    inherits: true;
+  }
+  @property --tick-minor-op {
+    syntax: '<number>';
+    initial-value: 0.55;
+    inherits: true;
+  }
+  @property --tick-major-op {
+    syntax: '<number>';
+    initial-value: 0.72;
+    inherits: true;
+  }
+  @property --label-op {
+    syntax: '<number>';
+    initial-value: 0.42;
+    inherits: true;
+  }
+  @property --score-weight {
+    syntax: '<number>';
+    initial-value: 500;
+    inherits: true;
+  }
+
+  .dial {
+    width: 100%;
+    max-width: min(520px, 80vw);
+    height: auto;
+    display: block;
+    /* Breathing chrome — all five transitions run in parallel. Subtle by
+       design; if visibly "pulsing", amplitude is wrong, not timing. */
+    transition:
+      --ring-opacity 900ms ease,
+      --face-stroke  900ms ease,
+      --tick-minor-op 900ms ease,
+      --tick-major-op 900ms ease,
+      --label-op     900ms ease,
+      --score-weight 900ms ease;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .dial { transition: none; }
+  }
+
+  /* One-shot drop-shadow flash when the aggregate median crosses the health
+     threshold. Driven by the component's `pulsing` signal, cleared after
+     --timing-pulse-dial-glow ms — same token as the JS setTimeout so the
+     class and the keyframe can't drift apart. */
+  .dial.pulsing {
+    animation: dialPulse var(--timing-pulse-dial-glow, 900ms) ease-out;
+  }
+  @keyframes dialPulse {
+    0%   { filter: drop-shadow(0 0 0    var(--accent-pink-glow)); }
+    30%  { filter: drop-shadow(0 0 24px var(--accent-pink-glow)); }
+    100% { filter: drop-shadow(0 0 0    var(--accent-pink-glow)); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .dial.pulsing { animation: none; }
+  }
+
+  .paused-badge {
+    position: absolute;
+    bottom: 28px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-kicker);
+    color: var(--t3);
+    padding: 3px 10px;
+    border: 1px solid var(--border-mid);
+    border-radius: 3px;
+    text-transform: uppercase;
+  }
+
+  .dial-announcer {
+    position: absolute;
+    width: 1px; height: 1px;
+    padding: 0; margin: -1px; overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap; border: 0;
+  }
+</style>

--- a/src/lib/components/EventFeed.svelte
+++ b/src/lib/components/EventFeed.svelte
@@ -3,6 +3,7 @@
 <!-- plays a feedArrive flash when it arrives. Pure render — event derivation  -->
 <!-- lives in the parent (OverviewView event ring buffer).                     -->
 <script lang="ts">
+  import { onDestroy } from 'svelte';
   import { tokens } from '$lib/tokens';
   import { fmt } from '$lib/utils/format';
   import type { Endpoint } from '$lib/types';
@@ -31,22 +32,28 @@
   const MAX_ROWS = 5;
   const rows = $derived(events.slice(0, MAX_ROWS));
 
-  // Track the latest event "key" so we can flash the arrived row once per new
-  // event. Stored as a $state var rather than inside $effect cleanup so it
-  // survives re-runs cleanly.
-  let latestKey = $state<string | null>(null);
+  // Detect when the top event key changes and flash the arrival. Previous-key
+  // state is kept untracked — if it were $state read inside the $effect, the
+  // effect would self-invalidate as soon as we wrote the new key, cancelling
+  // arriveTimer before it fired. Timer cleanup lives in onDestroy so a fresh
+  // arrival during an already-pending flash doesn't cancel the flash mid-way.
+  let prevKey: string | null = null;
   let arrivedKey = $state<string | null>(null);
   let arriveTimer: ReturnType<typeof setTimeout> | null = null;
+
   $effect(() => {
     const top = rows[0];
     const nextKey = top ? `${top.t}-${top.epId}-${top.kind}` : null;
-    if (nextKey !== null && nextKey !== latestKey) {
-      latestKey = nextKey;
+    if (nextKey !== null && nextKey !== prevKey) {
+      prevKey = nextKey;
       arrivedKey = nextKey;
       if (arriveTimer !== null) clearTimeout(arriveTimer);
       arriveTimer = setTimeout(() => { arrivedKey = null; arriveTimer = null; }, 1200);
     }
-    return () => { if (arriveTimer !== null) { clearTimeout(arriveTimer); arriveTimer = null; } };
+  });
+
+  onDestroy(() => {
+    if (arriveTimer !== null) clearTimeout(arriveTimer);
   });
 
   function relTime(ms: number): string {

--- a/src/lib/components/EventFeed.svelte
+++ b/src/lib/components/EventFeed.svelte
@@ -1,0 +1,199 @@
+<!-- src/lib/components/EventFeed.svelte -->
+<!-- Newest-loud activity log. 5 rows max. Each row fades by rank; newest row   -->
+<!-- plays a feedArrive flash when it arrives. Pure render — event derivation  -->
+<!-- lives in the parent (OverviewView event ring buffer).                     -->
+<script lang="ts">
+  import { tokens } from '$lib/tokens';
+  import { fmt } from '$lib/utils/format';
+  import type { Endpoint } from '$lib/types';
+
+  export type FeedEventKind = 'cross-up' | 'cross-down' | 'shift';
+
+  export interface FeedEvent {
+    t: number;         // ms timestamp
+    epId: string;
+    kind: FeedEventKind;
+    value?: number;
+    from?: number;
+    to?: number;
+    threshold?: number;
+  }
+
+  interface Props {
+    events: readonly FeedEvent[];         // most-recent-first; max 5 rendered
+    endpoints: readonly Endpoint[];
+    now: number;
+    onDrill: (epId: string) => void;
+  }
+
+  let { events, endpoints, now, onDrill }: Props = $props();
+
+  const MAX_ROWS = 5;
+  const rows = $derived(events.slice(0, MAX_ROWS));
+
+  // Track the latest event "key" so we can flash the arrived row once per new
+  // event. Stored as a $state var rather than inside $effect cleanup so it
+  // survives re-runs cleanly.
+  let latestKey = $state<string | null>(null);
+  let arrivedKey = $state<string | null>(null);
+  let arriveTimer: ReturnType<typeof setTimeout> | null = null;
+  $effect(() => {
+    const top = rows[0];
+    const nextKey = top ? `${top.t}-${top.epId}-${top.kind}` : null;
+    if (nextKey !== null && nextKey !== latestKey) {
+      latestKey = nextKey;
+      arrivedKey = nextKey;
+      if (arriveTimer !== null) clearTimeout(arriveTimer);
+      arriveTimer = setTimeout(() => { arrivedKey = null; arriveTimer = null; }, 1200);
+    }
+    return () => { if (arriveTimer !== null) { clearTimeout(arriveTimer); arriveTimer = null; } };
+  });
+
+  function relTime(ms: number): string {
+    const s = Math.max(0, Math.round(ms / 1000));
+    if (s < 60) return `${s}s ago`;
+    const m = Math.round(s / 60);
+    if (m < 60) return `${m}m ago`;
+    const h = Math.round(m / 60);
+    return `${h}h ago`;
+  }
+
+  function endpointFor(epId: string): Endpoint | undefined {
+    return endpoints.find((ep) => ep.id === epId);
+  }
+
+  function actionPhrase(ev: FeedEvent): { phrase: string; value: string } {
+    switch (ev.kind) {
+      case 'cross-up':   return { phrase: 'crossed up',   value: ev.value != null ? `${fmt(ev.value)}ms` : '' };
+      case 'cross-down': return { phrase: 'recovered',    value: ev.value != null ? `${fmt(ev.value)}ms` : '' };
+      case 'shift':      return {
+        phrase: 'p95 shift',
+        value: ev.from != null && ev.to != null ? `${fmt(ev.from)}→${fmt(ev.to)}ms` : '',
+      };
+    }
+  }
+</script>
+
+<section class="feed" aria-label="Recent events">
+  <header class="feed-header">
+    <h3 class="feed-title">Recent events</h3>
+    <p class="feed-sub">Threshold activity</p>
+  </header>
+
+  {#if rows.length === 0}
+    <p class="feed-empty">No crossings in window. Network steady.</p>
+  {:else}
+    <ol class="feed-rows" aria-live="polite">
+      {#each rows as ev, rank (`${ev.t}-${ev.epId}-${ev.kind}`)}
+        {@const ep = endpointFor(ev.epId)}
+        {@const color = ep?.color || tokens.color.endpoint[0]}
+        {@const name = ep?.label || ev.epId}
+        {@const { phrase, value } = actionPhrase(ev)}
+        {@const key = `${ev.t}-${ev.epId}-${ev.kind}`}
+        <li class="feed-row" class:latest={rank === 0} class:arrived={arrivedKey === key} class:k-up={ev.kind === 'cross-up'} class:k-down={ev.kind === 'cross-down'} class:k-shift={ev.kind === 'shift'} style="--rank: {rank};">
+          <button
+            type="button"
+            class="feed-btn"
+            onclick={() => onDrill(ev.epId)}
+            aria-label="{relTime(now - ev.t)} {name} {phrase} {value}"
+          >
+            <span class="feed-time">{relTime(now - ev.t)}</span>
+            <span class="feed-dot" style:background={color} aria-hidden="true"></span>
+            <span class="feed-name">{name}</span>
+            <span class="feed-action">{phrase} · <em class="feed-value">{value}</em></span>
+          </button>
+        </li>
+      {/each}
+    </ol>
+  {/if}
+</section>
+
+<style>
+  .feed {
+    background: var(--glass-bg-rail-hover);
+    border: 1px solid var(--border-mid);
+    border-radius: 14px;
+    padding: 14px 16px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .feed-header { display: flex; flex-direction: column; gap: 2px; }
+  .feed-title { margin: 0; font-size: var(--ts-lg); font-weight: 500; color: var(--t1); letter-spacing: var(--tr-tight); }
+  .feed-sub { margin: 0; font-family: var(--mono); font-size: var(--ts-xs); letter-spacing: var(--tr-kicker); color: var(--t3); text-transform: uppercase; }
+
+  .feed-empty { margin: 0; padding: 8px 0; font-family: var(--mono); font-size: var(--ts-sm); color: var(--t4); }
+
+  .feed-rows { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 2px; }
+  .feed-row {
+    opacity: calc(1 - var(--rank, 0) * 0.14);
+    transition: background 140ms ease, opacity 400ms ease;
+    border-radius: 6px;
+  }
+  .feed-row:hover { opacity: 1; background: rgba(255,255,255,.04); }
+  .feed-row.latest { font-size: var(--ts-base); }
+  .feed-row.latest .feed-name { color: var(--t1); font-weight: 500; }
+  .feed-row.latest .feed-dot  { width: 8px; height: 8px; box-shadow: 0 0 6px currentColor; }
+
+  .feed-btn {
+    width: 100%;
+    display: grid;
+    grid-template-columns: 60px 10px 120px 1fr;
+    gap: 8px;
+    align-items: center;
+    padding: 6px 8px;
+    background: transparent;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    text-align: left;
+    font-family: inherit;
+  }
+  .feed-btn:focus-visible { outline: 1.5px solid var(--accent-cyan); outline-offset: 2px; border-radius: 6px; }
+
+  .feed-time {
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    color: var(--t4);
+    font-variant-numeric: tabular-nums;
+  }
+  .feed-dot {
+    width: 7px; height: 7px;
+    border-radius: 50%;
+  }
+  .feed-name {
+    font-family: var(--mono);
+    font-size: var(--ts-sm);
+    color: var(--t2);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .feed-action {
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    color: var(--t3);
+    letter-spacing: var(--tr-label);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .feed-row.k-up    .feed-value { color: var(--accent-pink); }
+  .feed-row.k-down  .feed-value { color: var(--accent-green); }
+  .feed-row.k-shift .feed-value { color: var(--accent-amber); }
+
+  .feed-row.arrived { animation: feedArrive 1.2s cubic-bezier(0.2, 0.7, 0.2, 1) both; }
+  @keyframes feedArrive {
+    0%   { background: rgba(255,255,255,.1);  transform: translateX(-4px); }
+    30%  { background: rgba(255,255,255,.06); transform: none; }
+    100% { background: transparent; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .feed-row, .feed-row.arrived { transition: none; animation: none; }
+  }
+</style>

--- a/src/lib/components/OverviewView.svelte
+++ b/src/lib/components/OverviewView.svelte
@@ -124,7 +124,9 @@
   });
 
   // Score history ring buffer — one entry per round, max 60 entries. Driven
-  // by roundCounter changes; append on every round.
+  // by roundCounter changes; append on every round. Svelte 5 $state arrays
+  // are proxied, so push/shift notify subscribers directly — no re-assignment
+  // needed.
   const HISTORY_MAX = 60;
   let scoreHistory = $state<number[]>([]);
   let lastSeenRound = -1;
@@ -137,9 +139,6 @@
     if (score === null) return;
     scoreHistory.push(score);
     while (scoreHistory.length > HISTORY_MAX) scoreHistory.shift();
-    // Trigger Svelte reactivity — mutations to a $state array don't always
-    // notify subscribers; reassign the reference.
-    scoreHistory = scoreHistory;
   });
 
   // Event ring buffer — threshold crossings + p95 shifts. Per-endpoint
@@ -293,12 +292,30 @@
     uiStore.setActiveView('lanes');
   }
 
-  // Rerender clock for the event feed's relative-time labels.
+  // Rerender clock for the event feed's relative-time labels. Ticks every
+  // second while enriched is active so labels age monotonically regardless of
+  // measurement cadence — a round-counter-driven clock would freeze "N s ago"
+  // between rounds or after lifecycle stops. The ticker is torn down when
+  // mode flips back to classic and on component destroy.
+  let nowTick = $state(Date.now());
+  let nowTimer: ReturnType<typeof setInterval> | null = null;
+  $effect(() => {
+    if (!isEnriched) {
+      if (nowTimer !== null) { clearInterval(nowTimer); nowTimer = null; }
+      return;
+    }
+    nowTick = Date.now();
+    if (nowTimer !== null) clearInterval(nowTimer);
+    nowTimer = setInterval(() => { nowTick = Date.now(); }, 1000);
+  });
+  onDestroy(() => {
+    if (nowTimer !== null) clearInterval(nowTimer);
+  });
+  // Include the round counter as a secondary trigger so the feed also updates
+  // on the measurement edge (not just on the 1s tick).
   const now = $derived.by(() => {
-    // Tie rerender cadence to the round counter so labels refresh without a
-    // separate setInterval clock.
     void measurements.roundCounter;
-    return Date.now();
+    return nowTick;
   });
 </script>
 

--- a/src/lib/components/OverviewView.svelte
+++ b/src/lib/components/OverviewView.svelte
@@ -1,37 +1,43 @@
 <!-- src/lib/components/OverviewView.svelte -->
-<!-- Phase 2 Overview — chronograph dial, diagnosis strip, metrics triptych.    -->
-<!-- This view is "ambient" — one dial says everything's fine or it isn't, the  -->
-<!-- strip below points where to look. No interactive controls beyond the       -->
-<!-- "Diagnose →" CTA.                                                          -->
+<!-- Overview — Classic (Phase 2) or Enriched (Phase 2.5) gated by              -->
+<!-- settings.overviewMode. The Enriched path composes the chronograph dial v2, -->
+<!-- the CausalVerdictStrip, the RacingStrip, and the EventFeed — with          -->
+<!-- score-history / baseline / events derived locally here. Classic and         -->
+<!-- Enriched share the cross-store data spine; only the dial component and the -->
+<!-- layout of the supporting cards differ.                                     -->
 <script lang="ts">
+  import { onDestroy } from 'svelte';
   import { measurementStore } from '$lib/stores/measurements';
   import { statisticsStore } from '$lib/stores/statistics';
   import { settingsStore } from '$lib/stores/settings';
   import { uiStore } from '$lib/stores/ui';
   import { networkQualityStore, monitoredEndpointsStore } from '$lib/stores/derived';
   import { overviewVerdict, VERDICT_STYLES } from '$lib/utils/classify';
+  import { computeCausalVerdict, type Verdict, type VerdictRow } from '$lib/utils/verdict';
   import { fmt, fmtParts, fmtCount } from '$lib/utils/format';
   import { tokens } from '$lib/tokens';
   import ChronographDial from './ChronographDial.svelte';
+  import ChronographDialV2 from './ChronographDialV2.svelte';
+  import CausalVerdictStrip from './CausalVerdictStrip.svelte';
+  import RacingStrip from './RacingStrip.svelte';
+  import EventFeed from './EventFeed.svelte';
+  import type { Endpoint, MeasurementSample } from '$lib/types';
+  import type { FeedEvent } from './EventFeed.svelte';
 
-  // Cross-phase invariant — every user-facing aggregate (live median, worst
-  // endpoint, over-threshold count, sample total, dial orbit) routes through
-  // monitoredEndpointsStore so the score, verdict, and per-endpoint chrome on
-  // this view can never disagree about who's being measured. See
-  // PATTERNS.md §3.
+  // ── Shared spine (both Classic and Enriched) ──────────────────────────────
+  // Cross-phase invariant — user-facing aggregates derive from
+  // monitoredEndpointsStore so dial orbit / verdict / triptych / racing strip
+  // can't disagree about who's being measured. See PATTERNS.md §3.
   const monitored = $derived($monitoredEndpointsStore);
   const stats = $derived($statisticsStore);
   const measurements = $derived($measurementStore);
   const threshold = $derived($settingsStore.healthThreshold);
   const score = $derived($networkQualityStore);
-  // PAUSED only when the user explicitly stopped a running test — never on
-  // first load (idle) or while transitioning. Score being non-null isn't a
-  // sufficient signal because we can have stats from a previous session.
+  const overviewMode = $derived($settingsStore.overviewMode);
   const paused = $derived(
     measurements.lifecycle === 'stopped' || measurements.lifecycle === 'completed',
   );
 
-  // ── Per-endpoint last latency map (for the dial's orbit ring) ──────────────
   const lastLatencies = $derived.by(() => {
     const out: Record<string, number | null> = {};
     for (const ep of monitored) {
@@ -40,7 +46,6 @@
     return out;
   });
 
-  // ── Live median across monitored endpoints' lastLatency (skip nulls) ───────
   const liveMedian = $derived.by(() => {
     const vals: number[] = [];
     for (const ep of monitored) {
@@ -53,7 +58,6 @@
     return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
   });
 
-  // ── Worst endpoint by p95 among ready monitored stats ──────────────────────
   const worst = $derived.by(() => {
     let worstEp: { id: string; label: string; color: string; p95: number } | null = null;
     for (const ep of monitored) {
@@ -71,7 +75,6 @@
     return worstEp;
   });
 
-  // ── Triptych metrics — monitored only ──────────────────────────────────────
   const overCount = $derived.by(() => {
     let n = 0, total = 0;
     for (const ep of monitored) {
@@ -90,110 +93,349 @@
     return n;
   });
 
-  const verdict = $derived(overviewVerdict(score));
-  const verdictStyle = $derived(VERDICT_STYLES[verdict]);
-
+  const classicVerdict = $derived(overviewVerdict(score));
+  const classicVerdictStyle = $derived(VERDICT_STYLES[classicVerdict]);
   const liveMedianParts = $derived(fmtParts(liveMedian));
 
-  function handleDrill(): void {
+  function handleClassicDrill(): void {
     if (worst) uiStore.setFocusedEndpoint(worst.id);
     // Phase 2 fallback: drill to Lanes since Atlas (Phase 4) isn't built yet.
-    // Swap to 'atlas' once Phase 4 lands.
     uiStore.setActiveView('lanes');
   }
+
+  // ── Enriched-only spine ────────────────────────────────────────────────────
+  // These derivations are opt-in — they require iteration over sample histories
+  // and would waste CPU if Classic never reads them. Gated by overviewMode.
+  const isEnriched = $derived(overviewMode === 'enriched');
+
+  // Samples slice per endpoint, materialized once per render for the racing
+  // strip sparkline. 40-sample tail is enough for the spec. Using toArray()
+  // copies out of the ring buffer — acceptable at N<=20 endpoints.
+  const samplesByEndpoint = $derived.by<Record<string, readonly MeasurementSample[]>>(() => {
+    const out: Record<string, readonly MeasurementSample[]> = {};
+    if (!isEnriched) return out;
+    for (const ep of monitored) {
+      const m = measurements.endpoints[ep.id];
+      if (!m) { out[ep.id] = []; continue; }
+      const all = m.samples.toArray();
+      out[ep.id] = all.slice(-40);
+    }
+    return out;
+  });
+
+  // Score history ring buffer — one entry per round, max 60 entries. Driven
+  // by roundCounter changes; append on every round.
+  const HISTORY_MAX = 60;
+  let scoreHistory = $state<number[]>([]);
+  let lastSeenRound = -1;
+  $effect(() => {
+    if (!isEnriched) return;
+    const round = measurements.roundCounter;
+    if (round === lastSeenRound) return;
+    lastSeenRound = round;
+    // Only append when we have a valid score for this round.
+    if (score === null) return;
+    scoreHistory.push(score);
+    while (scoreHistory.length > HISTORY_MAX) scoreHistory.shift();
+    // Trigger Svelte reactivity — mutations to a $state array don't always
+    // notify subscribers; reassign the reference.
+    scoreHistory = scoreHistory;
+  });
+
+  // Event ring buffer — threshold crossings + p95 shifts. Per-endpoint
+  // prev-state map tracks the comparison baseline across ticks.
+  const EVENT_MAX = 12;
+  const SHIFT_FRACTION = 0.35;
+  interface PrevState { readonly over: boolean; readonly p95: number; }
+  let prevByEp: Record<string, PrevState> = {};
+  let events = $state<FeedEvent[]>([]);
+  let lastSeenEventRound = -1;
+  $effect(() => {
+    if (!isEnriched) return;
+    const round = measurements.roundCounter;
+    if (round === lastSeenEventRound) return;
+    const prevRound = lastSeenEventRound;
+    lastSeenEventRound = round;
+
+    const now = Date.now();
+    const nextPrev: Record<string, PrevState> = {};
+    const newEvents: FeedEvent[] = [];
+
+    for (const ep of monitored) {
+      const lat = measurements.endpoints[ep.id]?.lastLatency ?? null;
+      const s = stats[ep.id];
+      const p95 = s?.p95 ?? 0;
+      const over = lat != null && lat > threshold;
+      const prev = prevByEp[ep.id];
+
+      if (prev !== undefined) {
+        if (over && !prev.over) {
+          newEvents.push({ t: now, epId: ep.id, kind: 'cross-up', value: lat ?? undefined, threshold });
+        } else if (!over && prev.over) {
+          newEvents.push({ t: now, epId: ep.id, kind: 'cross-down', value: lat ?? undefined, threshold });
+        }
+        // Shift event: only check every 8th round to avoid chatter.
+        if (prevRound >= 0 && round % 8 === 0 && prev.p95 > 0) {
+          const delta = Math.abs(p95 - prev.p95) / prev.p95;
+          if (delta > SHIFT_FRACTION) {
+            newEvents.push({ t: now, epId: ep.id, kind: 'shift', from: prev.p95, to: p95 });
+          }
+        }
+      }
+      nextPrev[ep.id] = { over, p95 };
+    }
+
+    prevByEp = nextPrev;
+    if (newEvents.length > 0) {
+      events = [...newEvents.reverse(), ...events].slice(0, EVENT_MAX);
+    }
+  });
+
+  // Baseline — p25/median/p75 over last 120s of samples × monitored endpoints.
+  // Recomputes every 5s on a setInterval, not every tick — stable band avoids
+  // jitter on the dial.
+  interface Baseline { p25: number; median: number; p75: number; }
+  const BASELINE_WINDOW_MS = 120_000;
+  const BASELINE_MIN_SAMPLES = 30;
+  const BASELINE_REFRESH_MS = 5_000;
+  let baseline = $state<Baseline | null>(null);
+  function recomputeBaseline(): void {
+    if (!isEnriched) return;
+    const cutoff = Date.now() - BASELINE_WINDOW_MS;
+    const pool: number[] = [];
+    for (const ep of monitored) {
+      const m = measurements.endpoints[ep.id];
+      if (!m) continue;
+      for (const s of m.samples) {
+        if (s.status !== 'ok' || !Number.isFinite(s.latency)) continue;
+        if (s.timestamp < cutoff) continue;
+        pool.push(s.latency);
+      }
+    }
+    if (pool.length < BASELINE_MIN_SAMPLES) {
+      baseline = null;
+      return;
+    }
+    pool.sort((a, b) => a - b);
+    const at = (p: number): number => pool[Math.max(0, Math.min(pool.length - 1, Math.floor(p * pool.length)))];
+    baseline = { p25: at(0.25), median: at(0.5), p75: at(0.75) };
+  }
+  let baselineTimer: ReturnType<typeof setInterval> | null = null;
+  $effect(() => {
+    if (!isEnriched) {
+      if (baselineTimer !== null) { clearInterval(baselineTimer); baselineTimer = null; }
+      baseline = null;
+      return;
+    }
+    // Kick immediately so the first render has something to work with, then
+    // recompute every 5s.
+    recomputeBaseline();
+    if (baselineTimer !== null) clearInterval(baselineTimer);
+    baselineTimer = setInterval(recomputeBaseline, BASELINE_REFRESH_MS);
+  });
+  onDestroy(() => {
+    if (baselineTimer !== null) clearInterval(baselineTimer);
+  });
+
+  // Causal verdict (Enriched). Only rows with `ready` stats feed the tree —
+  // unready endpoints haven't contributed enough samples for phase dominance
+  // to be meaningful.
+  const verdictRows: readonly VerdictRow[] = $derived.by(() => {
+    const rows: VerdictRow[] = [];
+    for (const ep of monitored) {
+      const s = stats[ep.id];
+      if (s && s.ready) rows.push({ ep, stats: s });
+    }
+    return rows;
+  });
+  const enrichedVerdict: Verdict = $derived(
+    isEnriched ? computeCausalVerdict(verdictRows, threshold) : { tone: 'good', headline: '' }
+  );
+
+  // Average metrics for the verdict strip triptych (backing evidence).
+  const avgP50 = $derived.by(() => {
+    if (verdictRows.length === 0) return null;
+    let sum = 0;
+    for (const r of verdictRows) sum += r.stats.p50;
+    return sum / verdictRows.length;
+  });
+  const avgJitter = $derived.by(() => {
+    if (verdictRows.length === 0) return null;
+    let sum = 0;
+    for (const r of verdictRows) sum += r.stats.stddev;
+    return sum / verdictRows.length;
+  });
+  const avgLoss = $derived.by(() => {
+    if (verdictRows.length === 0) return null;
+    let sum = 0;
+    for (const r of verdictRows) sum += r.stats.lossPercent;
+    return sum / verdictRows.length;
+  });
+
+  // Drill target for the verdict strip — worstEpId wins; fall back to the
+  // overall worst-p95 endpoint. null when all-healthy (no drill shown).
+  const drillEndpoint: Endpoint | null = $derived.by(() => {
+    if (enrichedVerdict.tone !== 'warn') return null;
+    const targetId = enrichedVerdict.worstEpId ?? worst?.id ?? null;
+    if (targetId === null) return null;
+    return monitored.find((ep) => ep.id === targetId) ?? null;
+  });
+
+  function handleEnrichedDrill(epId: string): void {
+    uiStore.setFocusedEndpoint(epId);
+    // Phase 2.5 fallback: drill to Lanes until Atlas (Phase 4) ships.
+    uiStore.setActiveView('lanes');
+  }
+
+  function handleEventDrill(epId: string): void {
+    uiStore.setFocusedEndpoint(epId);
+    // Phase 2.5 fallback: drill to Lanes until Live (Phase 3) ships.
+    uiStore.setActiveView('lanes');
+  }
+
+  // Rerender clock for the event feed's relative-time labels.
+  const now = $derived.by(() => {
+    // Tie rerender cadence to the round counter so labels refresh without a
+    // separate setInterval clock.
+    void measurements.roundCounter;
+    return Date.now();
+  });
 </script>
 
-<section class="overview" aria-label="Overview">
-  <div class="dial-slot">
-    <ChronographDial
-      {score}
-      {liveMedian}
-      {threshold}
-      endpoints={monitored}
-      {lastLatencies}
-      {paused}
-    />
-  </div>
-
-  <div
-    class="diagnosis-strip"
-    style:--verdict-color={verdictStyle.color}
-    style:--verdict-glow={verdictStyle.glow}
-  >
-    <div class="diag-verdict">
-      <span class="diag-dot" aria-hidden="true"></span>
-      <span class="diag-verdict-label">{verdictStyle.label}</span>
+{#if isEnriched}
+  <section class="overview enriched" aria-label="Overview · enriched">
+    <div class="enriched-grid">
+      <div class="enriched-left">
+        <ChronographDialV2
+          {score}
+          {liveMedian}
+          {threshold}
+          endpoints={monitored}
+          {lastLatencies}
+          {paused}
+          {scoreHistory}
+          {baseline}
+        />
+        <CausalVerdictStrip
+          verdict={enrichedVerdict}
+          {avgP50}
+          {avgJitter}
+          {avgLoss}
+          {drillEndpoint}
+          onDrill={handleEnrichedDrill}
+        />
+      </div>
+      <div class="enriched-right">
+        <RacingStrip
+          endpoints={monitored}
+          {stats}
+          {lastLatencies}
+          {samplesByEndpoint}
+          {threshold}
+          focusedEndpointId={$uiStore.focusedEndpointId}
+        />
+        <EventFeed
+          {events}
+          endpoints={monitored}
+          {now}
+          onDrill={handleEventDrill}
+        />
+      </div>
+    </div>
+  </section>
+{:else}
+  <section class="overview classic" aria-label="Overview">
+    <div class="dial-slot">
+      <ChronographDial
+        {score}
+        {liveMedian}
+        {threshold}
+        endpoints={monitored}
+        {lastLatencies}
+        {paused}
+      />
     </div>
 
-    <div class="diag-worst">
-      <div class="diag-worst-kicker">Worst endpoint</div>
-      {#if worst}
-        <div class="diag-worst-row">
-          <span class="diag-worst-pip" style:background={worst.color} aria-hidden="true"></span>
-          <span class="diag-worst-label">{worst.label}</span>
-          <span class="diag-worst-metric">
-            <span class="diag-metric-num">{fmt(worst.p95)}</span>
-            <span class="diag-metric-unit">p95 ms</span>
-          </span>
-        </div>
-      {:else}
-        <div class="diag-worst-row diag-worst-empty">
-          <span class="diag-worst-label">—</span>
-          <span class="diag-worst-metric"><span class="diag-metric-unit">awaiting samples</span></span>
-        </div>
-      {/if}
-    </div>
-
-    <button
-      type="button"
-      class="diag-drill"
-      disabled={worst == null}
-      aria-label={worst ? `Diagnose ${worst.label}` : 'Diagnose worst endpoint (none yet)'}
-      onclick={handleDrill}
+    <div
+      class="diagnosis-strip"
+      style:--verdict-color={classicVerdictStyle.color}
+      style:--verdict-glow={classicVerdictStyle.glow}
     >
-      <span class="diag-drill-text">Diagnose</span>
-      <span class="diag-drill-arrow" aria-hidden="true">→</span>
-    </button>
-  </div>
+      <div class="diag-verdict">
+        <span class="diag-dot" aria-hidden="true"></span>
+        <span class="diag-verdict-label">{classicVerdictStyle.label}</span>
+      </div>
 
-  <dl class="metrics-triptych" aria-label="Live metrics">
-    <div class="metric-cell">
-      <dt class="metric-kicker">Live median</dt>
-      <dd class="metric-value">
-        <span class="metric-num">{liveMedianParts.num}</span>
-        <span class="metric-unit">{liveMedianParts.unit}</span>
-      </dd>
+      <div class="diag-worst">
+        <div class="diag-worst-kicker">Worst endpoint</div>
+        {#if worst}
+          <div class="diag-worst-row">
+            <span class="diag-worst-pip" style:background={worst.color} aria-hidden="true"></span>
+            <span class="diag-worst-label">{worst.label}</span>
+            <span class="diag-worst-metric">
+              <span class="diag-metric-num">{fmt(worst.p95)}</span>
+              <span class="diag-metric-unit">p95 ms</span>
+            </span>
+          </div>
+        {:else}
+          <div class="diag-worst-row diag-worst-empty">
+            <span class="diag-worst-label">—</span>
+            <span class="diag-worst-metric"><span class="diag-metric-unit">awaiting samples</span></span>
+          </div>
+        {/if}
+      </div>
+
+      <button
+        type="button"
+        class="diag-drill"
+        disabled={worst == null}
+        aria-label={worst ? `Diagnose ${worst.label}` : 'Diagnose worst endpoint (none yet)'}
+        onclick={handleClassicDrill}
+      >
+        <span class="diag-drill-text">Diagnose</span>
+        <span class="diag-drill-arrow" aria-hidden="true">→</span>
+      </button>
     </div>
 
-    <div class="metric-cell">
-      <dt class="metric-kicker">Over threshold</dt>
-      <dd class="metric-value">
-        <span class="metric-num">{overCount.n}<span class="metric-num-sep">/</span>{overCount.total}</span>
-        <span class="metric-unit">endpoints</span>
-      </dd>
-    </div>
+    <dl class="metrics-triptych" aria-label="Live metrics">
+      <div class="metric-cell">
+        <dt class="metric-kicker">Live median</dt>
+        <dd class="metric-value">
+          <span class="metric-num">{liveMedianParts.num}</span>
+          <span class="metric-unit">{liveMedianParts.unit}</span>
+        </dd>
+      </div>
 
-    <div class="metric-cell">
-      <dt class="metric-kicker">Samples</dt>
-      <dd class="metric-value">
-        <span class="metric-num">{fmtCount(totalSamples)}</span>
-        <span class="metric-unit">total</span>
-      </dd>
-    </div>
-  </dl>
-</section>
+      <div class="metric-cell">
+        <dt class="metric-kicker">Over threshold</dt>
+        <dd class="metric-value">
+          <span class="metric-num">{overCount.n}<span class="metric-num-sep">/</span>{overCount.total}</span>
+          <span class="metric-unit">endpoints</span>
+        </dd>
+      </div>
+
+      <div class="metric-cell">
+        <dt class="metric-kicker">Samples</dt>
+        <dd class="metric-value">
+          <span class="metric-num">{fmtCount(totalSamples)}</span>
+          <span class="metric-unit">total</span>
+        </dd>
+      </div>
+    </dl>
+  </section>
+{/if}
 
 <style>
   .overview {
     flex: 1;
     display: flex;
     flex-direction: column;
-    align-items: center;
     gap: 24px;
     padding: 32px 28px 40px;
     min-height: 0;
     overflow-y: auto;
   }
+  .overview.classic { align-items: center; }
 
   .dial-slot {
     width: 100%;
@@ -202,7 +444,27 @@
     justify-content: center;
   }
 
-  /* ── Diagnosis strip ─────────────────────────────────────────────────────── */
+  /* ── Enriched 2-column grid ──────────────────────────────────────────────── */
+  .enriched-grid {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
+    gap: 24px;
+    align-items: start;
+  }
+  .enriched-left, .enriched-right {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    min-width: 0;
+  }
+  @media (max-width: 1023px) {
+    .enriched-grid { grid-template-columns: 1fr; }
+  }
+
+  /* ── Classic diagnosis strip ──────────────────────────────────────────────── */
   .diagnosis-strip {
     width: 100%;
     max-width: 920px;
@@ -298,7 +560,7 @@
   }
   .diag-drill-arrow { color: var(--accent-cyan); }
 
-  /* ── Metrics triptych ────────────────────────────────────────────────────── */
+  /* ── Classic metrics triptych ───────────────────────────────────────────── */
   .metrics-triptych {
     width: 100%;
     max-width: 920px;

--- a/src/lib/components/RacingStrip.svelte
+++ b/src/lib/components/RacingStrip.svelte
@@ -49,31 +49,38 @@
   }
 
   // Trailing sparkline path for an endpoint — last 40 samples, normalized to the
-  // shared axis. Missing/error samples break the path (M vs L).
+  // shared axis. Missing/error samples break the path (M starts a new subpath,
+  // L continues the current one). An explicit `prevWasGap` flag avoids the
+  // string-inspection bug where `d.endsWith(' ')` was true on every iteration
+  // (every space-terminated previous emission), so every point became an M.
   function sparklinePath(epId: string): string {
     const samples = samplesByEndpoint[epId] ?? [];
     if (samples.length === 0) return '';
     const slice = samples.slice(-40);
     const n = slice.length;
     let d = '';
+    let prevWasGap = true;
     for (let i = 0; i < n; i++) {
       const s = slice[i];
       const x = n === 1 ? 50 : (i / (n - 1)) * 100;
       if (s.status !== 'ok' || !Number.isFinite(s.latency)) {
-        // Gap — next non-ok sample starts a fresh move.
+        prevWasGap = true;
         continue;
       }
       const y = 28 - Math.min(28, (s.latency / maxSeen) * 28);
-      d += (d.length === 0 || d.endsWith(' ')) ? `M ${x.toFixed(1)} ${y.toFixed(1)} ` : `L ${x.toFixed(1)} ${y.toFixed(1)} `;
+      d += `${prevWasGap ? 'M' : 'L'} ${x.toFixed(1)} ${y.toFixed(1)} `;
+      prevWasGap = false;
     }
     return d.trim();
   }
 
   function handleClick(event: MouseEvent, ep: Endpoint): void {
     uiStore.setFocusedEndpoint(ep.id);
-    // Phase 2.5 fallback: drill to Lanes since Live (Phase 3) and Atlas (Phase 4)
-    // aren't shipped yet. Swap to 'live' / 'atlas' when those land.
-    uiStore.setActiveView(event.shiftKey ? 'lanes' : 'lanes');
+    // Phase 2.5 fallback: both taps route to Lanes because Live (Phase 3) and
+    // Atlas (Phase 4) aren't shipped yet. Keep the single-target wiring until
+    // the hint can honestly advertise `Click → Live · ⇧ → Diagnose`.
+    void event;
+    uiStore.setActiveView('lanes');
   }
 </script>
 
@@ -83,7 +90,7 @@
       <h3 class="racing-title">Per-endpoint comparison</h3>
       <p class="racing-sub">Live latencies on shared axis</p>
     </div>
-    <p class="racing-hint">Click → Live · ⇧ → Diagnose</p>
+    <p class="racing-hint">Click → Lanes</p>
   </header>
 
   <div class="racing-axis" aria-hidden="true">

--- a/src/lib/components/RacingStrip.svelte
+++ b/src/lib/components/RacingStrip.svelte
@@ -1,0 +1,291 @@
+<!-- src/lib/components/RacingStrip.svelte -->
+<!-- Shared-latency-axis workbench — one row per endpoint plotting p50→p95     -->
+<!-- band, trailing sparkline, live dot on a common x-scale. Compare endpoints  -->
+<!-- directly. Click drills to Live; Shift-click drills to Diagnose.            -->
+<script lang="ts">
+  import { tokens } from '$lib/tokens';
+  import { fmt } from '$lib/utils/format';
+  import type { Endpoint, EndpointStatistics, MeasurementSample } from '$lib/types';
+  import { uiStore } from '$lib/stores/ui';
+
+  interface Props {
+    endpoints: readonly Endpoint[];
+    stats: Record<string, EndpointStatistics>;
+    lastLatencies: Record<string, number | null>;
+    samplesByEndpoint: Record<string, readonly MeasurementSample[]>;
+    threshold: number;
+    focusedEndpointId: string | null;
+  }
+
+  let { endpoints, stats, lastLatencies, samplesByEndpoint, threshold, focusedEndpointId }: Props = $props();
+
+  // Dynamic axis scale, clamped to [150, 300] ms, rounded to next 30ms boundary.
+  const maxSeen = $derived.by(() => {
+    let maxP95 = 0;
+    for (const ep of endpoints) {
+      const s = stats[ep.id];
+      if (s && s.p95 > maxP95) maxP95 = s.p95;
+    }
+    const scaled = Math.ceil((maxP95 * 1.2) / 30) * 30;
+    return Math.min(300, Math.max(150, scaled));
+  });
+
+  const thresholdPct = $derived(Math.min(100, (threshold / maxSeen) * 100));
+
+  const axisLabels = $derived([
+    0,
+    Math.round(maxSeen / 3),
+    Math.round((2 * maxSeen) / 3),
+    maxSeen,
+  ]);
+
+  function rowStyle(epId: string): { p50Pct: number; p95Pct: number; livePct: number; over: boolean } {
+    const s = stats[epId];
+    const last = lastLatencies[epId];
+    const p50Pct = s ? Math.min(100, (s.p50 / maxSeen) * 100) : 0;
+    const p95Pct = s ? Math.min(100, (s.p95 / maxSeen) * 100) : 0;
+    const livePct = last == null ? 0 : Math.min(100, (last / maxSeen) * 100);
+    return { p50Pct, p95Pct, livePct, over: last != null && last > threshold };
+  }
+
+  // Trailing sparkline path for an endpoint — last 40 samples, normalized to the
+  // shared axis. Missing/error samples break the path (M vs L).
+  function sparklinePath(epId: string): string {
+    const samples = samplesByEndpoint[epId] ?? [];
+    if (samples.length === 0) return '';
+    const slice = samples.slice(-40);
+    const n = slice.length;
+    let d = '';
+    for (let i = 0; i < n; i++) {
+      const s = slice[i];
+      const x = n === 1 ? 50 : (i / (n - 1)) * 100;
+      if (s.status !== 'ok' || !Number.isFinite(s.latency)) {
+        // Gap — next non-ok sample starts a fresh move.
+        continue;
+      }
+      const y = 28 - Math.min(28, (s.latency / maxSeen) * 28);
+      d += (d.length === 0 || d.endsWith(' ')) ? `M ${x.toFixed(1)} ${y.toFixed(1)} ` : `L ${x.toFixed(1)} ${y.toFixed(1)} `;
+    }
+    return d.trim();
+  }
+
+  function handleClick(event: MouseEvent, ep: Endpoint): void {
+    uiStore.setFocusedEndpoint(ep.id);
+    // Phase 2.5 fallback: drill to Lanes since Live (Phase 3) and Atlas (Phase 4)
+    // aren't shipped yet. Swap to 'live' / 'atlas' when those land.
+    uiStore.setActiveView(event.shiftKey ? 'lanes' : 'lanes');
+  }
+</script>
+
+<section class="racing" aria-label="Per-endpoint comparison">
+  <header class="racing-header">
+    <div>
+      <h3 class="racing-title">Per-endpoint comparison</h3>
+      <p class="racing-sub">Live latencies on shared axis</p>
+    </div>
+    <p class="racing-hint">Click → Live · ⇧ → Diagnose</p>
+  </header>
+
+  <div class="racing-axis" aria-hidden="true">
+    {#each axisLabels as label (label)}
+      <span class="racing-axis-label">{label}</span>
+    {/each}
+    <span class="racing-axis-label racing-axis-threshold" style:left="{thresholdPct}%">
+      {threshold} trigger
+    </span>
+  </div>
+
+  <div class="racing-rows">
+    {#each endpoints as ep (ep.id)}
+      {@const row = rowStyle(ep.id)}
+      {@const s = stats[ep.id]}
+      {@const live = lastLatencies[ep.id]}
+      {@const focused = focusedEndpointId === ep.id}
+      <button
+        type="button"
+        class="racing-row"
+        class:over={row.over}
+        class:focused
+        aria-label="{ep.label}, live {live == null ? 'no data' : Math.round(live) + ' milliseconds'}, p95 {s ? Math.round(s.p95) + ' milliseconds' : 'no data'}, {row.over ? 'above threshold' : 'within threshold'}"
+        onclick={(e) => handleClick(e, ep)}
+      >
+        <span class="racing-label">
+          <span class="racing-dot" style:background={ep.color || tokens.color.endpoint[0]} style:--ep-color={ep.color} aria-hidden="true"></span>
+          <span class="racing-name">{ep.label}</span>
+        </span>
+
+        <span class="racing-track">
+          <span
+            class="racing-threshtick"
+            style:left="{thresholdPct}%"
+            aria-hidden="true"
+          ></span>
+          {#if s}
+            <span
+              class="racing-band"
+              style:left="{row.p50Pct}%"
+              style:width="{Math.max(0.5, row.p95Pct - row.p50Pct)}%"
+              style:background={ep.color || tokens.color.endpoint[0]}
+              aria-hidden="true"
+            ></span>
+          {/if}
+          <svg class="racing-spark" viewBox="0 0 100 28" preserveAspectRatio="none" aria-hidden="true">
+            <path d={sparklinePath(ep.id)} fill="none" stroke={ep.color || tokens.color.endpoint[0]} stroke-width="1.2" stroke-linejoin="round" stroke-linecap="round" opacity="0.55" />
+          </svg>
+          {#if live != null}
+            <span
+              class="racing-dotlive"
+              class:over={row.over}
+              style:left="{row.livePct}%"
+              style:background={ep.color || tokens.color.endpoint[0]}
+              style:--ep-color={ep.color || tokens.color.endpoint[0]}
+              aria-hidden="true"
+            ></span>
+          {/if}
+        </span>
+
+        <span class="racing-stats">
+          <span class="racing-stats-live">{fmt(live)}</span>
+          <span class="racing-stats-p95">{s ? `p95 ${fmt(s.p95)}` : '—'}</span>
+        </span>
+      </button>
+    {/each}
+  </div>
+</section>
+
+<style>
+  .racing {
+    background: var(--glass-bg-rail-hover);
+    border: 1px solid var(--border-mid);
+    border-radius: 14px;
+    padding: 14px 16px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    min-width: 0;
+  }
+
+  .racing-header { display: flex; justify-content: space-between; align-items: flex-end; gap: 12px; margin-bottom: 8px; }
+  .racing-title { margin: 0; font-size: var(--ts-lg); font-weight: 500; color: var(--t1); letter-spacing: var(--tr-tight); }
+  .racing-sub { margin: 2px 0 0; font-family: var(--mono); font-size: var(--ts-xs); letter-spacing: var(--tr-kicker); color: var(--t3); text-transform: uppercase; }
+  .racing-hint { margin: 0; font-family: var(--mono); font-size: var(--ts-sm); color: var(--t4); }
+
+  .racing-axis {
+    position: relative;
+    display: flex;
+    justify-content: space-between;
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    color: var(--t4);
+    letter-spacing: var(--tr-label);
+    padding: 4px 0 10px;
+    border-bottom: 1px solid var(--border-mid);
+    margin-bottom: 8px;
+    font-variant-numeric: tabular-nums;
+  }
+  .racing-axis-threshold {
+    position: absolute;
+    top: 0;
+    transform: translateX(-50%);
+    color: var(--accent-pink);
+    padding: 0 4px;
+    background: var(--surface-topbar-bg);
+  }
+
+  .racing-rows { display: flex; flex-direction: column; gap: 4px; }
+  .racing-row {
+    display: grid;
+    grid-template-columns: 180px 1fr 78px;
+    align-items: center;
+    gap: 12px;
+    padding: 6px 8px;
+    border-radius: 8px;
+    border: 1px solid transparent;
+    background: transparent;
+    color: inherit;
+    font-family: inherit;
+    text-align: left;
+    cursor: pointer;
+    transition: background 140ms ease, border-color 140ms ease;
+  }
+  .racing-row:hover { background: rgba(255,255,255,.03); border-color: var(--border-mid); }
+  .racing-row.focused { background: rgba(255,255,255,.05); border-color: var(--border-bright); }
+  .racing-row.over { background: rgba(249,168,212,.04); }
+  .racing-row:focus-visible { outline: 1.5px solid var(--accent-cyan); outline-offset: 2px; }
+
+  .racing-label { display: flex; align-items: center; gap: 8px; min-width: 0; }
+  .racing-dot {
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    box-shadow: 0 0 6px currentColor;
+  }
+  .racing-name {
+    font-size: var(--ts-sm);
+    color: var(--t1);
+    font-family: var(--mono);
+    letter-spacing: var(--tr-body);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .racing-track {
+    position: relative;
+    height: 28px;
+    border-radius: 4px;
+    overflow: hidden;
+    border: 1px solid var(--border-mid);
+    background: linear-gradient(to right,
+      rgba(255,255,255,.04) 0%, rgba(255,255,255,.04) var(--thresh, 50%),
+      rgba(249,168,212,.06) var(--thresh, 50%), rgba(249,168,212,.06) 100%);
+  }
+  .racing-threshtick {
+    position: absolute; top: 0; bottom: 0;
+    width: 1px;
+    background: var(--accent-pink);
+    box-shadow: 0 0 4px var(--accent-pink-glow);
+    opacity: 0.5;
+  }
+  .racing-band {
+    position: absolute;
+    top: 11px;
+    height: 6px;
+    border-radius: 3px;
+    opacity: 0.2;
+  }
+  .racing-spark { position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; }
+  .racing-dotlive {
+    position: absolute;
+    top: 50%;
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    transform: translate(-50%, -50%);
+    box-shadow: 0 0 6px var(--ep-color, #fff);
+    transition: left 250ms ease-out;
+  }
+  .racing-dotlive.over {
+    box-shadow: 0 0 10px var(--ep-color, #fff);
+    width: 10px; height: 10px;
+  }
+
+  .racing-stats {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    font-family: var(--mono);
+    font-variant-numeric: tabular-nums;
+  }
+  .racing-stats-live {
+    font-size: var(--ts-sm);
+    color: var(--t1);
+  }
+  .racing-stats-p95 {
+    font-size: var(--ts-xs);
+    color: var(--t4);
+    letter-spacing: var(--tr-label);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .racing-row, .racing-dotlive { transition: none; }
+  }
+</style>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -322,8 +322,9 @@ export interface SharePayload {
 
 // ── Persistence schema ─────────────────────────────────────────────────────
 // v5 adds `healthThreshold` (settings) and `focusedEndpointId`, `liveOptions`,
-// `terminalFilters` (ui). Older versions migrate forward via persistence.ts.
-// Sets serialize as arrays on disk; `ui.terminalFilters` round-trips accordingly.
+// `terminalFilters` (ui). v6 adds `settings.overviewMode` (classic | enriched).
+// Older versions migrate forward via persistence.ts. Sets serialize as arrays
+// on disk; `ui.terminalFilters` round-trips accordingly.
 export interface PersistedSettings {
   version: 2 | 3 | 4 | 5 | 6;
   endpoints: { url: string; enabled: boolean }[];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -170,12 +170,18 @@ export interface EndpointStatistics {
     ttfb: number;
     contentTransfer: number;
   };
+  // Percent of samples that did NOT return `ok` (0–100). Consumed by
+  // verdict.ts's `Packet loss elevated to N.N%` branch. Zero when
+  // sampleCount is zero — consumers should gate on `ready` instead.
+  readonly lossPercent: number;
   readonly ready: boolean;
 }
 
 export type StatisticsState = Record<string, EndpointStatistics>;
 
 // ── Settings store ─────────────────────────────────────────────────────────
+export type OverviewMode = 'classic' | 'enriched';
+
 export interface Settings {
   timeout: number;
   delay: number;
@@ -184,6 +190,11 @@ export interface Settings {
   cap: number;
   corsMode: 'no-cors' | 'cors';
   region?: Region;
+  // Chooses between the Phase 2 Classic dial (score + ticks + hand) and the
+  // Phase 2.5 Enriched dial (+ baseline arc + quality trace + racing strip +
+  // event feed + causal verdict). Landed in v6; default 'classic' until the
+  // enriched surface is flipped to default in a later release.
+  overviewMode: OverviewMode;
   // Latency alarm threshold in ms — distinct from `timeout` (which is the hard
   // request abort). Drives classify()/networkQuality() and the chronograph dial.
   // Must be strictly less than `timeout`; callers enforce.
@@ -198,6 +209,7 @@ export const DEFAULT_SETTINGS: Settings = {
   cap: 0,
   corsMode: 'no-cors',
   healthThreshold: 120,
+  overviewMode: 'classic',
 };
 
 // ── UI store ───────────────────────────────────────────────────────────────
@@ -313,7 +325,7 @@ export interface SharePayload {
 // `terminalFilters` (ui). Older versions migrate forward via persistence.ts.
 // Sets serialize as arrays on disk; `ui.terminalFilters` round-trips accordingly.
 export interface PersistedSettings {
-  version: 2 | 3 | 4 | 5;
+  version: 2 | 3 | 4 | 5 | 6;
   endpoints: { url: string; enabled: boolean }[];
   settings: Settings;
   ui: {

--- a/src/lib/utils/classify.ts
+++ b/src/lib/utils/classify.ts
@@ -1,7 +1,12 @@
 // src/lib/utils/classify.ts
-// Health classification for endpoint latency. Pure functions — single source of
-// truth so the chronograph dial, rail pip color, and causal verdict cannot drift
-// apart. No store imports; callers pass stats + threshold explicitly.
+// Thin classifier — maps raw stats/scores into named buckets and style palettes.
+// Pure, synchronous, no reasoning about causation. If a function answers "which
+// bucket does X land in?" it lives here; if it answers "why is X in that
+// bucket?" it lives in verdict.ts.
+//
+// classify.ts owns: classify(), networkQuality(), networkLevel(),
+// overviewVerdict(), and the three style maps (HEALTH_STYLES, LEVEL_STYLES,
+// VERDICT_STYLES). No store imports; callers pass stats + threshold explicitly.
 
 import type { EndpointStatistics } from '../types';
 

--- a/src/lib/utils/persistence.ts
+++ b/src/lib/utils/persistence.ts
@@ -1,15 +1,17 @@
 // src/lib/utils/persistence.ts
 // Versioned localStorage persistence with forward-only migration support.
 //
-// Migration chain: v1 → v2 → v3 → v4 → v5 (current). Each normalizeVN shapes a
-// payload at version N; migrateSettings threads older payloads through the
-// chain up to CURRENT_VERSION. Never re-read a newer version in an older build.
+// Migration chain: v1 → v2 → v3 → v4 → v5 → v6 (current). Each normalizeVN
+// shapes a payload at version N; migrateSettings threads older payloads
+// through the chain up to CURRENT_VERSION. Never re-read a newer version in
+// an older build.
 
 import { DEFAULT_SETTINGS } from '../types';
 import { detectRegion, isValidRegion } from '../regional-defaults';
 import type {
   ActiveView,
   LiveTimeRange,
+  OverviewMode,
   PersistedSettings,
   Settings,
   TerminalEventType,
@@ -18,7 +20,9 @@ import type { Region } from '../regional-defaults';
 
 const STORAGE_KEY = 'chronoscope_settings'; // skipcq: JS-0860 — localStorage key, not a credential
 const LEGACY_STORAGE_KEY = 'chronoscope_v2_settings'; // skipcq: JS-0860 — localStorage key, not a credential
-const CURRENT_VERSION = 5;
+const CURRENT_VERSION = 6;
+
+const V6_OVERVIEW_MODES: ReadonlySet<OverviewMode> = new Set<OverviewMode>(['classic', 'enriched']);
 
 // v2-era labels that v5 rewrites to 'lanes' (the legacy escape hatch).
 const LEGACY_VIEWS: ReadonlySet<string> = new Set(['timeline', 'heatmap', 'split']);
@@ -76,11 +80,18 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
   const record = data as Record<string, unknown>;
   const version = typeof record['version'] === 'number' ? record['version'] : 0;
 
-  if (version === CURRENT_VERSION) return normalizeV5(record);
+  if (version === CURRENT_VERSION) return normalizeV6(record);
+
+  if (version === 5) {
+    const v5 = normalizeV5(record);
+    return v5 ? stepV5toV6(v5, record) : null;
+  }
 
   if (version === 4) {
     const v4 = normalizeV4(record);
-    return v4 ? stepV4toV5(v4, record) : null;
+    if (!v4) return null;
+    const v5 = stepV4toV5(v4, record);
+    return stepV5toV6(v5, record);
   }
 
   if (version === 3) {
@@ -91,7 +102,8 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
       version: 4,
       settings: { ...v3.settings, region: detectRegion() },
     };
-    return stepV4toV5(v4, record);
+    const v5 = stepV4toV5(v4, record);
+    return stepV5toV6(v5, record);
   }
 
   if (version === 2) {
@@ -113,7 +125,8 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
       version: 4,
       settings: { ...v3.settings, region: detectRegion() },
     };
-    return stepV4toV5(v4, record);
+    const v5 = stepV4toV5(v4, record);
+    return stepV5toV6(v5, record);
   }
 
   if (version === 1) {
@@ -131,13 +144,36 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
       settings: { ...DEFAULT_SETTINGS, region: detectRegion() },
       ui: { expandedCards: [], activeView: 'split' as ActiveView },
     };
-    return stepV4toV5(v4, record);
+    const v5 = stepV4toV5(v4, record);
+    return stepV5toV6(v5, record);
   }
 
   // Unknown version — return null (triggers first-install path). We deliberately
   // do NOT coerce through the current normalizer; that would silently drop
   // future shape changes we don't understand yet.
   return null;
+}
+
+// ── v5 → v6 step ─────────────────────────────────────────────────────────────
+// Seeds Settings.overviewMode. Accepts a forward-written overviewMode if
+// present (e.g. a future patch or a debug tool wrote one into a v5 payload);
+// otherwise defaults to 'classic'. Any garbage type coerces to 'classic' so
+// the app never reads an invalid mode.
+function stepV5toV6(v5: PersistedSettings, rawRecord: Record<string, unknown>): PersistedSettings {
+  const rawSettings =
+    rawRecord['settings'] !== null && typeof rawRecord['settings'] === 'object'
+      ? (rawRecord['settings'] as Record<string, unknown>)
+      : {};
+  const raw = rawSettings['overviewMode'];
+  const overviewMode: OverviewMode =
+    typeof raw === 'string' && V6_OVERVIEW_MODES.has(raw as OverviewMode)
+      ? (raw as OverviewMode)
+      : 'classic';
+  return {
+    ...v5,
+    version: 6,
+    settings: { ...v5.settings, overviewMode },
+  };
 }
 
 // ── v4 → v5 step ─────────────────────────────────────────────────────────────
@@ -229,6 +265,11 @@ function readSettingsField(record: Record<string, unknown>): Settings {
     raw['corsMode'] === 'cors' || raw['corsMode'] === 'no-cors'
       ? raw['corsMode']
       : DEFAULT_SETTINGS.corsMode;
+  const overviewModeRaw = raw['overviewMode'];
+  const overviewMode: OverviewMode =
+    typeof overviewModeRaw === 'string' && V6_OVERVIEW_MODES.has(overviewModeRaw as OverviewMode)
+      ? (overviewModeRaw as OverviewMode)
+      : DEFAULT_SETTINGS.overviewMode;
   return {
     timeout:         typeof raw['timeout']         === 'number' ? raw['timeout']         : DEFAULT_SETTINGS.timeout,
     delay:           typeof raw['delay']           === 'number' ? raw['delay']           : DEFAULT_SETTINGS.delay,
@@ -237,6 +278,7 @@ function readSettingsField(record: Record<string, unknown>): Settings {
     cap:             typeof raw['cap']             === 'number' ? raw['cap']             : DEFAULT_SETTINGS.cap,
     healthThreshold: typeof raw['healthThreshold'] === 'number' ? raw['healthThreshold'] : DEFAULT_SETTINGS.healthThreshold,
     corsMode,
+    overviewMode,
     ...(region !== undefined ? { region } : {}),
   };
 }
@@ -295,6 +337,29 @@ function normalizeV5(record: Record<string, unknown>): PersistedSettings | null 
   }
 }
 
+// v6 shape mirrors v5 exactly on the ui side; the only delta is Settings gains
+// `overviewMode` — already handled by readSettingsField so this is a thin
+// wrapper that tags the version.
+function normalizeV6(record: Record<string, unknown>): PersistedSettings | null {
+  try {
+    const rawUi = asRecord(record['ui']) ?? {};
+    return {
+      version: 6,
+      endpoints: readEndpointsField(record),
+      settings: readSettingsField(record),
+      ui: {
+        expandedCards:     readExpandedCards(rawUi),
+        activeView:        readActiveView(rawUi),
+        focusedEndpointId: readFocusedEndpointId(rawUi),
+        liveOptions:       readLiveOptions(rawUi),
+        terminalFilters:   readTerminalFilters(rawUi),
+      },
+    };
+  } catch {
+    return null;
+  }
+}
+
 // ── Legacy normalizers (v2/v3/v4) ────────────────────────────────────────────
 // Each produces a payload tagged with its own version; migrateSettings threads
 // them forward. healthThreshold defaults are seeded here so downstream steps
@@ -326,6 +391,7 @@ function normalizeV2(record: Record<string, unknown>): PersistedSettings | null 
           ? rawSettings['corsMode']
           : DEFAULT_SETTINGS.corsMode,
       healthThreshold: DEFAULT_SETTINGS.healthThreshold,
+      overviewMode: DEFAULT_SETTINGS.overviewMode,
     };
 
     const rawUi =
@@ -374,6 +440,7 @@ function normalizeV3(record: Record<string, unknown>): PersistedSettings | null 
           ? rawSettings['corsMode']
           : DEFAULT_SETTINGS.corsMode,
       healthThreshold: DEFAULT_SETTINGS.healthThreshold,
+      overviewMode: DEFAULT_SETTINGS.overviewMode,
     };
 
     const rawUi =
@@ -429,6 +496,9 @@ function normalizeV4(record: Record<string, unknown>): PersistedSettings | null 
         typeof rawSettings['healthThreshold'] === 'number'
           ? rawSettings['healthThreshold']
           : DEFAULT_SETTINGS.healthThreshold,
+      // v4 storage never wrote overviewMode either; stepV5toV6 reads it from
+      // the raw payload if present, so this field is a safe default here.
+      overviewMode: DEFAULT_SETTINGS.overviewMode,
       ...(region !== undefined ? { region } : {}),
     };
 

--- a/src/lib/utils/statistics.ts
+++ b/src/lib/utils/statistics.ts
@@ -73,6 +73,9 @@ export function computeEndpointStatistics(
 
   const count = latencies.length;
   const ready = samples.length >= READY_SAMPLE_GATE;
+  const lossPercent = samples.length > 0
+    ? ((samples.length - okSamples.length) / samples.length) * 100
+    : 0;
 
   if (count === 0) {
     return {
@@ -83,6 +86,7 @@ export function computeEndpointStatistics(
       ci95: { lower: 0, upper: 0, margin: 0 },
       connectionReuseDelta: null,
       tier2Averages: undefined,
+      lossPercent,
       ready,
     };
   }
@@ -167,6 +171,7 @@ export function computeEndpointStatistics(
     connectionReuseDelta,
     tier2Averages,
     tier2P95,
+    lossPercent,
     ready,
   };
 }
@@ -195,6 +200,7 @@ export function computeEndpointStatisticsFromBuffer(
       ci95: { lower: 0, upper: 0, margin: 0 },
       connectionReuseDelta: null,
       tier2Averages: undefined,
+      lossPercent: lossCounts.lossPercent,
       ready,
     };
   }
@@ -284,6 +290,7 @@ export function computeEndpointStatisticsFromBuffer(
     connectionReuseDelta,
     tier2Averages,
     tier2P95,
+    lossPercent: lossCounts.lossPercent,
     ready,
   };
 }

--- a/src/lib/utils/verdict.ts
+++ b/src/lib/utils/verdict.ts
@@ -180,7 +180,9 @@ export function computeCausalVerdict(
 
   return {
     tone: 'warn',
-    headline: `${overCount} ${overCount === 1 ? 'endpoint' : 'endpoints'} above threshold.`,
+    // Singular form is unreachable — overCount === 1 is handled above by the
+    // endpoint-specific branch; this fallback only fires for 0 or ≥2.
+    headline: `${overCount} endpoints above threshold.`,
   };
 }
 

--- a/src/lib/utils/verdict.ts
+++ b/src/lib/utils/verdict.ts
@@ -1,0 +1,192 @@
+// src/lib/utils/verdict.ts
+// Causal diagnosis — reads rolling stats + tier2 phase dominance to produce the
+// Overview's single-sentence "why is this degraded" verdict. Owns the decision
+// tree; consumes classify.ts for bucket membership but does not duplicate its
+// logic. If a finding is "here's which phase is dominant", it belongs here;
+// if it's "here's which severity bucket this endpoint is in", that stays in
+// classify.ts.
+//
+// verdict.ts owns: computeCausalVerdict(), phase-dominance derivation, and the
+// Tier2Phase / Verdict type vocabulary. Pure, synchronous, no store imports.
+
+import type { Endpoint, EndpointStatistics } from '../types';
+
+// ── Phase vocabulary ─────────────────────────────────────────────────────────
+// tier2 field keys on EndpointStatistics.tier2Averages/tier2P95 are the long
+// internal names (`dnsLookup`, `tcpConnect`, ...). User-facing phase ids and
+// labels are shorter to match the prototype and natural speech.
+export type Tier2Phase = 'dns' | 'tcp' | 'tls' | 'ttfb' | 'transfer';
+
+export const PHASE_LABELS: Readonly<Record<Tier2Phase, string>> = {
+  dns:      'DNS',
+  tcp:      'TCP handshake',
+  tls:      'TLS handshake',
+  ttfb:     'TTFB',
+  transfer: 'Transfer',
+};
+
+type Tier2FieldKey = 'dnsLookup' | 'tcpConnect' | 'tlsHandshake' | 'ttfb' | 'contentTransfer';
+
+const PHASE_TO_FIELD: Readonly<Record<Tier2Phase, Tier2FieldKey>> = {
+  dns:      'dnsLookup',
+  tcp:      'tcpConnect',
+  tls:      'tlsHandshake',
+  ttfb:     'ttfb',
+  transfer: 'contentTransfer',
+};
+
+// Deterministic order used for the tied-dominant-phase tiebreak. Alphabetical
+// on Tier2Phase ids (not on the pretty labels), so the outcome is stable
+// regardless of rendering changes.
+const PHASE_ORDER: readonly Tier2Phase[] = (['dns', 'tcp', 'tls', 'ttfb', 'transfer'] as const)
+  .slice()
+  .sort();
+
+// ── Verdict type ─────────────────────────────────────────────────────────────
+export interface Verdict {
+  readonly tone: 'good' | 'warn';
+  readonly headline: string;
+  readonly phase?: Tier2Phase;      // set when headline cites a dominant phase
+  readonly worstEpId?: string;      // set when only one endpoint is degraded
+}
+
+export interface VerdictRow {
+  readonly ep: Endpoint;
+  readonly stats: EndpointStatistics;
+}
+
+// ── Thresholds baked into the decision tree ─────────────────────────────────
+// Surfaced as constants so the spec's design choices are grep-findable, not
+// hidden inside the function body.
+const LOSS_WARN_PERCENT = 1;       // > 1% avg loss → packet-loss branch
+const JITTER_WARN_MS = 25;         // > 25ms avg stddev → jitter branch
+const DOMINANCE_THRESHOLD_FACTOR = 0.7;  // phase dominance counted below full threshold
+
+// ── Dominance computation ────────────────────────────────────────────────────
+function dominantPhase(stats: EndpointStatistics): Tier2Phase | null {
+  const t2 = stats.tier2Averages;
+  if (!t2) return null;
+  const total = t2.dnsLookup + t2.tcpConnect + t2.tlsHandshake + t2.ttfb + t2.contentTransfer;
+  if (total <= 0) return null;
+
+  let bestPhase: Tier2Phase | null = null;
+  let bestValue = -1;
+  // Iterate in alphabetical phase order so ties break deterministically on the
+  // earlier phase name (e.g. dns beats tcp at equal values).
+  for (const phase of PHASE_ORDER) {
+    const value = t2[PHASE_TO_FIELD[phase]];
+    if (value > bestValue) {
+      bestValue = value;
+      bestPhase = phase;
+    }
+  }
+  return bestPhase;
+}
+
+function countByPhase(
+  rows: readonly VerdictRow[],
+  threshold: number,
+): Readonly<Partial<Record<Tier2Phase, number>>> {
+  const counts: Partial<Record<Tier2Phase, number>> = {};
+  const dominanceThreshold = threshold * DOMINANCE_THRESHOLD_FACTOR;
+  for (const row of rows) {
+    if (row.stats.p50 <= dominanceThreshold) continue;
+    const phase = dominantPhase(row.stats);
+    if (phase === null) continue;
+    counts[phase] = (counts[phase] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function topPhaseWithCount(
+  counts: Readonly<Partial<Record<Tier2Phase, number>>>,
+): { phase: Tier2Phase; count: number } | null {
+  let best: { phase: Tier2Phase; count: number } | null = null;
+  // Iterate in alphabetical phase order so equal counts break deterministically
+  // on the earlier phase name.
+  for (const phase of PHASE_ORDER) {
+    const count = counts[phase] ?? 0;
+    if (count === 0) continue;
+    if (best === null || count > best.count) {
+      best = { phase, count };
+    }
+  }
+  return best;
+}
+
+// ── Main entrypoint ──────────────────────────────────────────────────────────
+/**
+ * Compute the one-sentence Overview verdict from rolling stats + threshold.
+ *
+ * Decision order (first matching branch wins):
+ *   1. No rows at all → "Calibrating…" (good tone)
+ *   2. Everyone fine AND no loss AND no jitter → "All links within tolerance."
+ *   3. ≥2 endpoints share a dominant phase → "{phase} slow on N endpoints — likely upstream."
+ *   4. Exactly 1 endpoint over threshold → "{label} degraded alone — endpoint-specific."
+ *   5. Avg loss > 1% → "Packet loss elevated to N.N%."
+ *   6. Avg jitter > 25ms → "Jitter elevated — σ N.Nms."
+ *   7. Fallback → "N endpoints above threshold."
+ */
+export function computeCausalVerdict(
+  rows: readonly VerdictRow[],
+  threshold: number,
+): Verdict {
+  if (rows.length === 0) {
+    return { tone: 'good', headline: 'Calibrating…' };
+  }
+
+  const overRows = rows.filter((r) => r.stats.p50 > threshold);
+  const overCount = overRows.length;
+  const avgLoss = mean(rows.map((r) => r.stats.lossPercent));
+  const avgJit = mean(rows.map((r) => r.stats.stddev));
+
+  if (overCount === 0 && avgLoss < LOSS_WARN_PERCENT && avgJit < JITTER_WARN_MS) {
+    return { tone: 'good', headline: 'All links within tolerance.' };
+  }
+
+  const phaseCounts = countByPhase(rows, threshold);
+  const topPhase = topPhaseWithCount(phaseCounts);
+
+  if (overCount >= 2 && topPhase !== null && topPhase.count >= 2) {
+    return {
+      tone: 'warn',
+      headline: `${PHASE_LABELS[topPhase.phase]} slow on ${topPhase.count} endpoints — likely upstream.`,
+      phase: topPhase.phase,
+    };
+  }
+
+  if (overCount === 1) {
+    const bad = overRows[0];
+    return {
+      tone: 'warn',
+      headline: `${bad.ep.label} degraded alone — endpoint-specific.`,
+      worstEpId: bad.ep.id,
+    };
+  }
+
+  if (avgLoss > LOSS_WARN_PERCENT) {
+    return {
+      tone: 'warn',
+      headline: `Packet loss elevated to ${avgLoss.toFixed(1)}%.`,
+    };
+  }
+
+  if (avgJit > JITTER_WARN_MS) {
+    return {
+      tone: 'warn',
+      headline: `Jitter elevated — σ ${avgJit.toFixed(1)}ms.`,
+    };
+  }
+
+  return {
+    tone: 'warn',
+    headline: `${overCount} ${overCount === 1 ? 'endpoint' : 'endpoints'} above threshold.`,
+  };
+}
+
+function mean(values: readonly number[]): number {
+  if (values.length === 0) return 0;
+  let sum = 0;
+  for (const v of values) sum += v;
+  return sum / values.length;
+}

--- a/tests/unit/persistence.test.ts
+++ b/tests/unit/persistence.test.ts
@@ -20,22 +20,22 @@ describe('persistence', () => {
     expect(loadPersistedSettings()).toBeNull();
   });
 
-  it('round-trips v3 settings into current v5 shape', () => {
+  it('round-trips v3 settings into current v6 shape', () => {
     const settings = {
       version: 3,
       endpoints: [{ url: 'https://example.com', enabled: true }],
       settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors' },
       ui: { expandedCards: [], activeView: 'timeline' },
     };
-    // Cast because the on-disk v3 payload pre-dates healthThreshold — migration
-    // is expected to seed the field forward.
     saveSettings(settings as unknown as PersistedSettings);
     const loaded = loadPersistedSettings();
-    expect(loaded?.version).toBe(5);
+    expect(loaded?.version).toBe(6);
     expect(loaded?.endpoints[0]?.url).toBe('https://example.com');
     expect(loaded?.settings.burstRounds).toBe(50);
     expect(loaded?.settings.monitorDelay).toBe(1000);
     expect(loaded?.settings.healthThreshold).toBe(120);
+    // v5→v6 seeds overviewMode; default is 'classic' until Enriched is promoted.
+    expect(loaded?.settings.overviewMode).toBe('classic');
   });
 
   it('returns null for corrupt data', () => {
@@ -53,22 +53,23 @@ describe('persistence', () => {
     };
     localStorageMock.setItem('chronoscope_v2_settings', JSON.stringify(settings));
     const loaded = loadPersistedSettings();
-    expect(loaded?.version).toBe(5);
+    expect(loaded?.version).toBe(6);
     expect(localStorageMock.getItem('chronoscope_v2_settings')).toBeNull();
     expect(localStorageMock.getItem('chronoscope_settings')).not.toBeNull();
   });
 
-  it('migrates v1 data all the way to v5', () => {
+  it('migrates v1 data all the way to v6', () => {
     const v1Data = { version: 1, endpoints: [{ url: 'https://example.com' }] };
     const migrated = migrateSettings(v1Data);
-    expect(migrated?.version).toBe(5);
+    expect(migrated?.version).toBe(6);
     expect(migrated?.settings.burstRounds).toBe(50);
     expect(migrated?.settings.monitorDelay).toBe(1000);
     expect(migrated?.settings.healthThreshold).toBe(120);
+    expect(migrated?.settings.overviewMode).toBe('classic');
     expect(migrated?.ui.activeView).toBe('overview');
   });
 
-  it('migrates v2 data to v5 with old delay as monitorDelay', () => {
+  it('migrates v2 data to v6 with old delay as monitorDelay', () => {
     const v2Data = {
       version: 2,
       endpoints: [{ url: 'https://example.com', enabled: true }],
@@ -76,17 +77,17 @@ describe('persistence', () => {
       ui: { expandedCards: [], activeView: 'split' },
     };
     const migrated = migrateSettings(v2Data);
-    expect(migrated?.version).toBe(5);
+    expect(migrated?.version).toBe(6);
     expect(migrated?.settings.monitorDelay).toBe(500);
     expect(migrated?.settings.burstRounds).toBe(50);
     expect(migrated?.settings.delay).toBe(0);
     expect(migrated?.settings.healthThreshold).toBe(120);
-    // 'split' is a deprecated view that migrates to 'lanes'.
+    expect(migrated?.settings.overviewMode).toBe('classic');
     expect(migrated?.ui.activeView).toBe('lanes');
   });
 
-  describe('v4 → v5 migration', () => {
-    it('seeds healthThreshold default on a real v4 payload', () => {
+  describe('v4 → v5 → v6 migration (chain)', () => {
+    it('seeds healthThreshold default + overviewMode on a real v4 payload', () => {
       const v4: unknown = {
         version: 4,
         endpoints: [{ url: 'https://cloudflare-dns.com', enabled: true }],
@@ -102,8 +103,9 @@ describe('persistence', () => {
         ui: { expandedCards: ['ep-1'], activeView: 'split' },
       };
       const migrated = migrateSettings(v4);
-      expect(migrated?.version).toBe(5);
+      expect(migrated?.version).toBe(6);
       expect(migrated?.settings.healthThreshold).toBe(120);
+      expect(migrated?.settings.overviewMode).toBe('classic');
       expect(migrated?.settings.region).toBe('north-america');
     });
 
@@ -144,27 +146,6 @@ describe('persistence', () => {
       expect(migrated?.ui.expandedCards).toEqual(['a', 'b']);
     });
 
-    it('round-trips a v5 payload unchanged (already current)', () => {
-      const v5: PersistedSettings = {
-        version: 5,
-        endpoints: [{ url: 'https://a.example', enabled: true }],
-        settings: {
-          timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000,
-          cap: 0, corsMode: 'no-cors', healthThreshold: 200,
-        },
-        ui: {
-          expandedCards: [],
-          activeView: 'overview',
-          focusedEndpointId: 'ep-1',
-          liveOptions: { split: true, timeRange: '15m' },
-          terminalFilters: ['timeout', 'error'],
-        },
-      };
-      saveSettings(v5);
-      const loaded = loadPersistedSettings();
-      expect(loaded).toEqual(v5);
-    });
-
     it('coerces an unknown activeView value to the default "overview"', () => {
       const v4 = {
         version: 4,
@@ -174,6 +155,151 @@ describe('persistence', () => {
       };
       const migrated = migrateSettings(v4);
       expect(migrated?.ui.activeView).toBe('overview');
+    });
+  });
+
+  describe('v5 → v6 migration', () => {
+    it('seeds overviewMode=classic on a real v5 payload, preserves everything else', () => {
+      const v5: unknown = {
+        version: 5,
+        endpoints: [{ url: 'https://a.example', enabled: true }],
+        settings: {
+          timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000,
+          cap: 0, corsMode: 'no-cors', healthThreshold: 180,
+          region: 'europe',
+        },
+        ui: {
+          expandedCards: ['ep-1'],
+          activeView: 'overview',
+          focusedEndpointId: 'ep-9',
+          liveOptions: { split: true, timeRange: '15m' },
+          terminalFilters: ['timeout'],
+        },
+      };
+      const migrated = migrateSettings(v5);
+      expect(migrated?.version).toBe(6);
+      expect(migrated?.settings.overviewMode).toBe('classic');
+      // Existing v5 fields survive intact.
+      expect(migrated?.settings.healthThreshold).toBe(180);
+      expect(migrated?.settings.region).toBe('europe');
+      expect(migrated?.ui.activeView).toBe('overview');
+      expect(migrated?.ui.focusedEndpointId).toBe('ep-9');
+      expect(migrated?.ui.liveOptions).toEqual({ split: true, timeRange: '15m' });
+      expect(migrated?.ui.terminalFilters).toEqual(['timeout']);
+      expect(migrated?.ui.expandedCards).toEqual(['ep-1']);
+    });
+
+    it('preserves an existing overviewMode value when present on v5 (forward-compat guard)', () => {
+      // Defensive: if a future/debug tool injected overviewMode into a v5
+      // payload, the migration should carry the value forward rather than
+      // overwrite with the default.
+      const v5 = {
+        version: 5,
+        endpoints: [],
+        settings: {
+          timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000,
+          cap: 0, corsMode: 'no-cors', healthThreshold: 120,
+          overviewMode: 'enriched',
+        },
+        ui: { expandedCards: [], activeView: 'overview' },
+      };
+      const migrated = migrateSettings(v5);
+      expect(migrated?.settings.overviewMode).toBe('enriched');
+    });
+
+    it('coerces a garbage overviewMode value to the default "classic"', () => {
+      const v5 = {
+        version: 5,
+        endpoints: [],
+        settings: {
+          timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000,
+          cap: 0, corsMode: 'no-cors', healthThreshold: 120,
+          overviewMode: 'not-a-real-mode',
+        },
+        ui: { expandedCards: [], activeView: 'overview' },
+      };
+      const migrated = migrateSettings(v5);
+      expect(migrated?.settings.overviewMode).toBe('classic');
+    });
+  });
+
+  describe('v6 pass-through', () => {
+    it('round-trips a v6 payload unchanged (already current)', () => {
+      const v6: PersistedSettings = {
+        version: 6,
+        endpoints: [{ url: 'https://a.example', enabled: true }],
+        settings: {
+          timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000,
+          cap: 0, corsMode: 'no-cors', healthThreshold: 200,
+          overviewMode: 'enriched',
+        },
+        ui: {
+          expandedCards: [],
+          activeView: 'overview',
+          focusedEndpointId: 'ep-1',
+          liveOptions: { split: true, timeRange: '15m' },
+          terminalFilters: ['timeout', 'error'],
+        },
+      };
+      saveSettings(v6);
+      const loaded = loadPersistedSettings();
+      expect(loaded).toEqual(v6);
+    });
+
+    it('accepts both valid overviewMode values', () => {
+      for (const mode of ['classic', 'enriched'] as const) {
+        const v6: PersistedSettings = {
+          version: 6,
+          endpoints: [],
+          settings: {
+            timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000,
+            cap: 0, corsMode: 'no-cors', healthThreshold: 120,
+            overviewMode: mode,
+          },
+          ui: { expandedCards: [], activeView: 'overview' },
+        };
+        const migrated = migrateSettings(v6);
+        expect(migrated?.settings.overviewMode).toBe(mode);
+      }
+    });
+
+    it('rejects a corrupted v6 overviewMode by falling back to "classic"', () => {
+      const bad = {
+        version: 6,
+        endpoints: [],
+        settings: {
+          timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000,
+          cap: 0, corsMode: 'no-cors', healthThreshold: 120,
+          overviewMode: 42,   // wrong type — shouldn't happen, but we guard
+        },
+        ui: { expandedCards: [], activeView: 'overview' },
+      };
+      const migrated = migrateSettings(bad);
+      expect(migrated?.settings.overviewMode).toBe('classic');
+    });
+  });
+
+  describe('unknown-version fallback', () => {
+    it('version 99 returns null (no forward-compat coercion)', () => {
+      const future = {
+        version: 99,
+        endpoints: [{ url: 'https://example.com', enabled: true }],
+        settings: {
+          timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000,
+          cap: 0, corsMode: 'no-cors', healthThreshold: 120, overviewMode: 'classic',
+        },
+        ui: { expandedCards: [], activeView: 'overview' },
+        unknownFutureField: 'ignored',
+      };
+      expect(migrateSettings(future)).toBeNull();
+    });
+
+    it('missing version number returns null', () => {
+      expect(migrateSettings({ endpoints: [] })).toBeNull();
+    });
+
+    it('non-numeric version returns null', () => {
+      expect(migrateSettings({ version: 'six', endpoints: [] })).toBeNull();
     });
   });
 });

--- a/tests/unit/utils/persistence-migration.test.ts
+++ b/tests/unit/utils/persistence-migration.test.ts
@@ -13,8 +13,8 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('migrateSettings — full chain through v5', () => {
-  it('v3 payload with no region → v5 with region = detectRegion() and healthThreshold default', () => {
+describe('migrateSettings — full chain through v6', () => {
+  it('v3 → v6: region from detectRegion(), healthThreshold default, overviewMode=classic', () => {
     const v3 = {
       version: 3,
       endpoints: [{ url: 'https://example.com', enabled: true }],
@@ -22,15 +22,16 @@ describe('migrateSettings — full chain through v5', () => {
       ui: { expandedCards: [], activeView: 'timeline' },
     };
     const result = migrateSettings(v3);
-    expect(result?.version).toBe(5);
+    expect(result?.version).toBe(6);
     expect(result?.settings.region).toBe('europe');
     expect(result?.settings.healthThreshold).toBe(120);
+    expect(result?.settings.overviewMode).toBe('classic');
     expect(result?.endpoints[0]?.url).toBe('https://example.com');
     // 'timeline' is a v2-era view that rewrites to 'lanes'.
     expect(result?.ui.activeView).toBe('lanes');
   });
 
-  it('v4 payload with valid region migrates to v5 with region preserved', () => {
+  it('v4 → v6 (two hops): preserves region, seeds healthThreshold + overviewMode', () => {
     const v4 = {
       version: 4,
       endpoints: [{ url: 'https://example.com', enabled: true }],
@@ -38,12 +39,13 @@ describe('migrateSettings — full chain through v5', () => {
       ui: { expandedCards: [], activeView: 'split' },
     };
     const result = migrateSettings(v4);
-    expect(result?.version).toBe(5);
+    expect(result?.version).toBe(6);
     expect(result?.settings.region).toBe('east-asia');
     expect(result?.settings.healthThreshold).toBe(120);
+    expect(result?.settings.overviewMode).toBe('classic');
   });
 
-  it('v4 payload with invalid region string strips the field', () => {
+  it('v4 payload with invalid region string strips the field on the way to v6', () => {
     const v4 = {
       version: 4,
       endpoints: [],
@@ -51,7 +53,7 @@ describe('migrateSettings — full chain through v5', () => {
       ui: { expandedCards: [], activeView: 'split' },
     };
     const result = migrateSettings(v4);
-    expect(result?.version).toBe(5);
+    expect(result?.version).toBe(6);
     expect(result?.settings.region).toBeUndefined();
   });
 
@@ -66,7 +68,35 @@ describe('migrateSettings — full chain through v5', () => {
     expect(result?.settings.region).toBeUndefined();
   });
 
-  it('v2 payload migrates through to v5 (chain migration)', () => {
+  it('v5 → v6 (one hop): seeds overviewMode=classic, preserves all v5 fields', () => {
+    const v5 = {
+      version: 5,
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: {
+        timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000,
+        cap: 0, corsMode: 'no-cors', region: 'europe', healthThreshold: 200,
+      },
+      ui: {
+        expandedCards: ['a'],
+        activeView: 'live',
+        focusedEndpointId: 'ep-x',
+        liveOptions: { split: true, timeRange: '15m' },
+        terminalFilters: ['timeout', 'error'],
+      },
+    };
+    const result = migrateSettings(v5);
+    expect(result?.version).toBe(6);
+    expect(result?.settings.overviewMode).toBe('classic');
+    expect(result?.settings.healthThreshold).toBe(200);
+    expect(result?.settings.region).toBe('europe');
+    expect(result?.ui.activeView).toBe('live');
+    expect(result?.ui.focusedEndpointId).toBe('ep-x');
+    expect(result?.ui.liveOptions).toEqual({ split: true, timeRange: '15m' });
+    expect(result?.ui.terminalFilters).toEqual(['timeout', 'error']);
+    expect(result?.ui.expandedCards).toEqual(['a']);
+  });
+
+  it('v2 → v6 (chain): old delay becomes monitorDelay, region from detectRegion()', () => {
     const v2 = {
       version: 2,
       endpoints: [{ url: 'https://example.com', enabled: true }],
@@ -74,21 +104,22 @@ describe('migrateSettings — full chain through v5', () => {
       ui: { expandedCards: [], activeView: 'split' },
     };
     const result = migrateSettings(v2);
-    expect(result?.version).toBe(5);
+    expect(result?.version).toBe(6);
     expect(result?.settings.burstRounds).toBe(50);
     expect(result?.settings.region).toBe('europe');
     expect(result?.settings.healthThreshold).toBe(120);
+    expect(result?.settings.overviewMode).toBe('classic');
   });
 
-  it('v1 payload migrates through to v5', () => {
+  it('v1 → v6: minimal payload inflates with full defaults', () => {
     const v1 = {
       version: 1,
       endpoints: [{ url: 'https://example.com' }],
     };
     const result = migrateSettings(v1);
-    expect(result?.version).toBe(5);
-    // v1 has no ui block → v5 default view is 'overview'.
+    expect(result?.version).toBe(6);
     expect(result?.ui.activeView).toBe('overview');
+    expect(result?.settings.overviewMode).toBe('classic');
   });
 
   it('version 99 (future unknown): returns null — no forward-compat coercion', () => {

--- a/tests/unit/verdict.test.ts
+++ b/tests/unit/verdict.test.ts
@@ -217,14 +217,18 @@ describe('computeCausalVerdict — fallback', () => {
     expect(v.headline).toBe('2 endpoints above threshold.');
   });
 
-  it('uses singular form when the fallback pluralization collapses to 1', () => {
-    // Contrived: tier2 missing, loss/jit fine, overCount=1. This should hit
-    // the endpoint-specific branch instead, proving the fallback is rare.
+  it('endpoint-specific branch pre-empts the count fallback when overCount=1', () => {
+    // With a single row over threshold the endpoint-specific branch wins even
+    // though tier2 is missing and would otherwise hit the count fallback.
+    // (CR review on PR #47: previous title claimed this exercised the
+    // fallback's singular form — it never did; the endpoint-specific branch
+    // fires first. Renamed to describe actual behavior.)
     const rows = [
       makeRow({ id: 'a', label: 'a' }, { p50: 200, tier2Averages: undefined }),
     ];
     const v = computeCausalVerdict(rows, THRESHOLD);
     expect(v.headline).toBe('a degraded alone — endpoint-specific.');
+    expect(v.worstEpId).toBe(rows[0].ep.id);
   });
 });
 

--- a/tests/unit/verdict.test.ts
+++ b/tests/unit/verdict.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from 'vitest';
+import { computeCausalVerdict, PHASE_LABELS, type VerdictRow } from '../../src/lib/utils/verdict';
+import type { Endpoint, EndpointStatistics } from '../../src/lib/types';
+
+// ── Fixture helpers ─────────────────────────────────────────────────────────
+function makeEndpoint(over: Partial<Endpoint> = {}): Endpoint {
+  return {
+    id: 'ep-' + (over.id ?? Math.random().toString(36).slice(2, 8)),
+    url: over.url ?? 'https://example.test',
+    enabled: over.enabled ?? true,
+    label: over.label ?? 'example',
+    color: over.color ?? '#67e8f9',
+    ...over,
+  };
+}
+
+function makeStats(over: Partial<EndpointStatistics> = {}): EndpointStatistics {
+  return {
+    endpointId: over.endpointId ?? 'ep-x',
+    sampleCount: 50,
+    p50: 0, p95: 0, p99: 0, p25: 0, p75: 0, p90: 0,
+    min: 0, max: 0, stddev: 0,
+    ci95: { lower: 0, upper: 0, margin: 0 },
+    connectionReuseDelta: null,
+    lossPercent: 0,
+    ready: true,
+    ...over,
+  };
+}
+
+function makeRow(
+  epOver: Partial<Endpoint> = {},
+  statsOver: Partial<EndpointStatistics> = {},
+): VerdictRow {
+  const ep = makeEndpoint(epOver);
+  const stats = makeStats({ endpointId: ep.id, ...statsOver });
+  return { ep, stats };
+}
+
+// Tier2 averages with one clearly dominant phase.
+function tier2Dominating(phase: 'dns' | 'tcp' | 'tls' | 'ttfb' | 'transfer'): EndpointStatistics['tier2Averages'] {
+  const fieldFor = {
+    dns: 'dnsLookup', tcp: 'tcpConnect', tls: 'tlsHandshake', ttfb: 'ttfb', transfer: 'contentTransfer',
+  } as const;
+  const base = { dnsLookup: 5, tcpConnect: 5, tlsHandshake: 5, ttfb: 5, contentTransfer: 5 };
+  return { ...base, [fieldFor[phase]]: 200 };
+}
+
+const THRESHOLD = 120;
+
+// ── Branch 1: empty rows ────────────────────────────────────────────────────
+describe('computeCausalVerdict — empty', () => {
+  it('returns Calibrating… when no rows', () => {
+    const v = computeCausalVerdict([], THRESHOLD);
+    expect(v.tone).toBe('good');
+    expect(v.headline).toBe('Calibrating…');
+    expect(v.phase).toBeUndefined();
+    expect(v.worstEpId).toBeUndefined();
+  });
+});
+
+// ── Branch 2: all-healthy happy path ────────────────────────────────────────
+describe('computeCausalVerdict — all healthy', () => {
+  it('returns "All links within tolerance." when no one is over threshold and loss+jit are low', () => {
+    const rows = [
+      makeRow({ id: 'a', label: 'a' }, { p50: 40, stddev: 4, lossPercent: 0.2 }),
+      makeRow({ id: 'b', label: 'b' }, { p50: 60, stddev: 6, lossPercent: 0.5 }),
+    ];
+    const v = computeCausalVerdict(rows, THRESHOLD);
+    expect(v.tone).toBe('good');
+    expect(v.headline).toBe('All links within tolerance.');
+  });
+});
+
+// ── Branch 3: shared-phase upstream ─────────────────────────────────────────
+describe('computeCausalVerdict — shared upstream phase', () => {
+  it('calls out "DNS slow on N endpoints — likely upstream." when ≥2 share DNS dominance', () => {
+    const rows = [
+      makeRow({ id: 'a', label: 'a' }, { p50: 200, tier2Averages: tier2Dominating('dns') }),
+      makeRow({ id: 'b', label: 'b' }, { p50: 180, tier2Averages: tier2Dominating('dns') }),
+      makeRow({ id: 'c', label: 'c' }, { p50: 30,  tier2Averages: tier2Dominating('transfer') }),
+    ];
+    const v = computeCausalVerdict(rows, THRESHOLD);
+    expect(v.tone).toBe('warn');
+    expect(v.headline).toBe('DNS slow on 2 endpoints — likely upstream.');
+    expect(v.phase).toBe('dns');
+  });
+
+  it('counts endpoints above 0.7×threshold as dominance candidates even when under full threshold', () => {
+    // p50=90 is under threshold (120) but over 0.7*threshold (84). Should
+    // still be counted in the dominance bucket.
+    const rows = [
+      makeRow({ id: 'a', label: 'a' }, { p50: 200, tier2Averages: tier2Dominating('ttfb') }),
+      makeRow({ id: 'b', label: 'b' }, { p50: 200, tier2Averages: tier2Dominating('ttfb') }),
+      makeRow({ id: 'c', label: 'c' }, { p50: 90,  tier2Averages: tier2Dominating('ttfb') }),
+    ];
+    const v = computeCausalVerdict(rows, THRESHOLD);
+    expect(v.headline).toBe('TTFB slow on 3 endpoints — likely upstream.');
+    expect(v.phase).toBe('ttfb');
+  });
+
+  it('does NOT call upstream when only 1 endpoint is dominant on a phase', () => {
+    const rows = [
+      makeRow({ id: 'a', label: 'a' }, { p50: 200, tier2Averages: tier2Dominating('tls') }),
+      makeRow({ id: 'b', label: 'b' }, { p50: 30 }),
+    ];
+    const v = computeCausalVerdict(rows, THRESHOLD);
+    // Should fall through to "endpoint-specific" branch (overCount === 1).
+    expect(v.headline).toBe('a degraded alone — endpoint-specific.');
+    expect(v.worstEpId).toBe(rows[0].ep.id);
+  });
+});
+
+// ── Tied dominant phase → deterministic alphabetical tiebreak ──────────────
+describe('computeCausalVerdict — tied dominant phase', () => {
+  it('picks the alphabetically-earlier phase when counts tie', () => {
+    // Two endpoints on DNS, two on TCP — both tied at 2. Alphabetically, 'dns'
+    // comes before 'tcp' so the verdict should cite DNS.
+    const rows = [
+      makeRow({ id: 'a', label: 'a' }, { p50: 200, tier2Averages: tier2Dominating('dns') }),
+      makeRow({ id: 'b', label: 'b' }, { p50: 200, tier2Averages: tier2Dominating('dns') }),
+      makeRow({ id: 'c', label: 'c' }, { p50: 200, tier2Averages: tier2Dominating('tcp') }),
+      makeRow({ id: 'd', label: 'd' }, { p50: 200, tier2Averages: tier2Dominating('tcp') }),
+    ];
+    const v = computeCausalVerdict(rows, THRESHOLD);
+    expect(v.phase).toBe('dns');
+  });
+
+  it('tiebreak is stable regardless of input order', () => {
+    // Same counts as above, rows reversed. Same verdict expected.
+    const rows = [
+      makeRow({ id: 'd', label: 'd' }, { p50: 200, tier2Averages: tier2Dominating('tcp') }),
+      makeRow({ id: 'c', label: 'c' }, { p50: 200, tier2Averages: tier2Dominating('tcp') }),
+      makeRow({ id: 'b', label: 'b' }, { p50: 200, tier2Averages: tier2Dominating('dns') }),
+      makeRow({ id: 'a', label: 'a' }, { p50: 200, tier2Averages: tier2Dominating('dns') }),
+    ];
+    const v = computeCausalVerdict(rows, THRESHOLD);
+    expect(v.phase).toBe('dns');
+  });
+
+  it('within a single row, ties between tier2 phase values resolve alphabetically on the phase id', () => {
+    // All five phases tied at equal value — the dominant phase should be 'dns'.
+    const flat = { dnsLookup: 10, tcpConnect: 10, tlsHandshake: 10, ttfb: 10, contentTransfer: 10 };
+    const rows = [
+      makeRow({ id: 'a', label: 'a' }, { p50: 200, tier2Averages: flat }),
+      makeRow({ id: 'b', label: 'b' }, { p50: 200, tier2Averages: flat }),
+    ];
+    const v = computeCausalVerdict(rows, THRESHOLD);
+    expect(v.phase).toBe('dns');
+  });
+});
+
+// ── Branch 4: endpoint-specific (exactly 1 over) ────────────────────────────
+describe('computeCausalVerdict — endpoint-specific', () => {
+  it('names the offending endpoint when exactly one is over', () => {
+    const rows = [
+      makeRow({ id: 'a', label: 'auth-service' }, { p50: 200 }),
+      makeRow({ id: 'b', label: 'cdn' },         { p50: 30 }),
+      makeRow({ id: 'c', label: 'api' },         { p50: 40 }),
+    ];
+    const v = computeCausalVerdict(rows, THRESHOLD);
+    expect(v.headline).toBe('auth-service degraded alone — endpoint-specific.');
+    expect(v.worstEpId).toBe(rows[0].ep.id);
+  });
+});
+
+// ── Branch 5: packet loss ───────────────────────────────────────────────────
+describe('computeCausalVerdict — packet loss', () => {
+  it('cites packet loss when avg lossPercent > 1% and nobody is over threshold', () => {
+    const rows = [
+      makeRow({ id: 'a', label: 'a' }, { p50: 40, lossPercent: 3.0 }),
+      makeRow({ id: 'b', label: 'b' }, { p50: 50, lossPercent: 1.2 }),
+    ];
+    const v = computeCausalVerdict(rows, THRESHOLD);
+    expect(v.headline).toBe('Packet loss elevated to 2.1%.');
+  });
+
+  it('does not cite packet loss when exactly 1 endpoint is over — that branch wins first', () => {
+    const rows = [
+      makeRow({ id: 'a', label: 'a' }, { p50: 200, lossPercent: 10 }),
+      makeRow({ id: 'b', label: 'b' }, { p50: 30,  lossPercent: 0 }),
+    ];
+    const v = computeCausalVerdict(rows, THRESHOLD);
+    expect(v.headline).toContain('degraded alone');
+  });
+});
+
+// ── Branch 6: jitter ────────────────────────────────────────────────────────
+describe('computeCausalVerdict — jitter', () => {
+  it('cites jitter when avg stddev > 25ms and no other branch matched', () => {
+    const rows = [
+      makeRow({ id: 'a', label: 'a' }, { p50: 40, stddev: 30 }),
+      makeRow({ id: 'b', label: 'b' }, { p50: 50, stddev: 40 }),
+    ];
+    const v = computeCausalVerdict(rows, THRESHOLD);
+    expect(v.headline).toBe('Jitter elevated — σ 35.0ms.');
+  });
+
+  it('packet loss takes precedence over jitter when both elevated', () => {
+    const rows = [
+      makeRow({ id: 'a', label: 'a' }, { p50: 40, stddev: 40, lossPercent: 5 }),
+    ];
+    const v = computeCausalVerdict(rows, THRESHOLD);
+    expect(v.headline).toContain('Packet loss');
+  });
+});
+
+// ── Fallback branch (should be narrow) ─────────────────────────────────────
+describe('computeCausalVerdict — fallback', () => {
+  it('uses the count fallback when ≥2 over but no phase dominates and low loss/jit', () => {
+    // 2 rows over threshold but no tier2 data so no phase dominance.
+    const rows = [
+      makeRow({ id: 'a', label: 'a' }, { p50: 200, tier2Averages: undefined }),
+      makeRow({ id: 'b', label: 'b' }, { p50: 200, tier2Averages: undefined }),
+    ];
+    const v = computeCausalVerdict(rows, THRESHOLD);
+    expect(v.headline).toBe('2 endpoints above threshold.');
+  });
+
+  it('uses singular form when the fallback pluralization collapses to 1', () => {
+    // Contrived: tier2 missing, loss/jit fine, overCount=1. This should hit
+    // the endpoint-specific branch instead, proving the fallback is rare.
+    const rows = [
+      makeRow({ id: 'a', label: 'a' }, { p50: 200, tier2Averages: undefined }),
+    ];
+    const v = computeCausalVerdict(rows, THRESHOLD);
+    expect(v.headline).toBe('a degraded alone — endpoint-specific.');
+  });
+});
+
+// ── PHASE_LABELS sanity ─────────────────────────────────────────────────────
+describe('PHASE_LABELS', () => {
+  it('defines a label for every Tier2Phase', () => {
+    expect(PHASE_LABELS.dns).toBe('DNS');
+    expect(PHASE_LABELS.tcp).toBe('TCP handshake');
+    expect(PHASE_LABELS.tls).toBe('TLS handshake');
+    expect(PHASE_LABELS.ttfb).toBe('TTFB');
+    expect(PHASE_LABELS.transfer).toBe('Transfer');
+  });
+});


### PR DESCRIPTION
## Summary

Enriched Overview ships as an opt-in mode gated by `settings.overviewMode`. Classic stays default until a later release flips it. Phase 2.5 is **HIGH-risk** (schema migration + classifier territory + cross-phase invariant work); full self-review checklist below.

## What shipped

### Migration (test-first, per HIGH-risk policy)
- `CURRENT_VERSION: 5 → 6`. `stepV5toV6` seeds `Settings.overviewMode`. Migration test suite exhaustively covers v1/v2/v3/v4/v5/v6 entry points, including:
  - v4 → v5 → v6 two-hop chain
  - v5 → v6 one-hop
  - v6 pass-through
  - Unknown version / missing version / non-numeric version → null fallback
  - Garbage `overviewMode` value → coerced to `'classic'`
  - Forward-written `overviewMode` on a v5 payload → honored

### classify.ts / verdict.ts boundary (documented at file top in both)
- `classify.ts` — thin bucket classifier (answers *"which bucket does X land in?"*). Owns `classify`, `networkQuality`, `networkLevel`, `overviewVerdict`, and the three style palettes.
- `verdict.ts` (NEW) — causal diagnosis (answers *"why is X in that bucket?"*). Owns `computeCausalVerdict` with exhaustive branch coverage: calibrating, all-within-tolerance, shared-phase upstream (≥2 endpoints, 0.7×threshold rule), endpoint-specific, packet-loss (>1%), jitter (>25ms), count fallback. **Tied dominant phase** resolves deterministically on alphabetical phase id (tested both across rows and within a row).

### Dial v2 as a SIBLING (not a branch in v1)
- `ChronographDialV2.svelte` is a separate component that adds baseline arc, 60s quality trace, within-band / above / below label (included in `aria-label`), and breathing chrome via `@property`-registered custom properties. `ChronographDial.svelte` is unchanged from Phase 2.

### New components
- `CausalVerdictStrip.svelte` — one-sentence diagnosis + triptych (Median / Jitter / Loss) + drill CTA. `<dl>/<dt>/<dd>` semantics, `role="status"` polite live region, dot is decorative.
- `RacingStrip.svelte` — shared-latency-axis workbench. Per endpoint: p50→p95 band, 40-sample sparkline, live dot. Click drills to Lanes (placeholder until Phase 3's Live lands); shift-click reserved for Atlas.
- `EventFeed.svelte` — newest-loud, 5 rows, `feedArrive` animation (reduced-motion gated). Rank-based opacity fade.

### OverviewView (routes on `settings.overviewMode`)
- Classic branch identical to Phase 2.
- Enriched branch: 2-column grid with Dial V2 + Verdict Strip on the left, Racing Strip + Event Feed on the right.
- Event derivation (cross-up / cross-down / shift at %8 rounds) runs in-component. 12-event ring buffer; 5 shown.
- Baseline p25/median/p75 recomputes every 5s over last 120s of samples × `monitored`. Hidden when pool < 30 samples.
- Score history ring (60) appended per `roundCounter` change.
- All Enriched derivations short-circuit when `!isEnriched` so Classic users pay no CPU cost.

### Stats (additive)
- `EndpointStatistics.lossPercent` computed in both array and buffer paths. Zero when no samples; consumers gate on `ready`.

## Bundle delta

| | JS gzip | CSS gzip |
|---|---:|---:|
| Pre-Phase-2.5 | 63.93 KB | 10.19 KB |
| Phase 2.5 | **70.17 KB** | **11.72 KB** |
| Delta | **+6.24 KB** | **+1.53 KB** |

Sibling-dial policy accounts for most of the JS delta. 769/769 tests pass.

## Adversarial self-review (per HIGH-risk policy)

| Check | Result |
|---|---|
| `$effect` races on shared state (PATTERNS §1) | **Clean.** Score-history / event-derivation / baseline effects use distinct tracking flags (`lastSeenRound`, `lastSeenEventRound`, interval handle). No shared writable flag. |
| Cleanup-on-rerun cancelling timers | **Clean.** Baseline interval lives in `$effect` with guarded init, `onDestroy` teardown. EventFeed arrival timer cleared in `$effect` return + `onDestroy`. |
| Derivations iterating raw `endpointStore` (PATTERNS §3) | **Clean.** All Enriched aggregates iterate `monitored`: `samplesByEndpoint`, `verdictRows`, `baseline` pool, score-history trigger, event derivation. Racing / EventFeed receive `monitored` via props. |
| Reduced-motion — CSS + SVG + JS (PATTERNS §2) | **Clean.** Verdict dot pulse, EventFeed flash, Racing live-dot transition, DialV2 breathing chrome transitions — all `@media (prefers-reduced-motion: reduce)` gated. DialV2 inherits the three motion surfaces from the Classic dial pattern. |
| Store subscriptions before init | **Safe.** All effects are component-scoped; baseline interval is constructed *inside* the effect post-mount. `samplesByEndpoint` is `$derived` (lazy). |
| Migration fallback for unknown versions | **Explicit tests** — v99, missing version, non-numeric version all return null. |
| Reactive ordering across components | **Safe.** `overviewMode` is the single router; all Enriched derivations guard on `isEnriched`. |
| Token usage — no raw hex/px for token-covered values | **One exception acknowledged.** Baseline arc uses `rgba(255,255,255,.07)` inline per the spec's "normal band tone" description. Matches `--t5` numerically; could be tokenized as `--band-track` in a follow-up if CR wants it. |

## Flagged fork (not a blocker)

- **Racing strip drill currently routes to `'lanes'`** instead of `'live'` (Phase 3 target). Same pattern as existing TODOs in `EndpointRail.svelte` / `OverviewView.svelte`. Will flip when Live ships.
- **Screenshots at 1440×1000** (taller than earlier phases) because the enriched 2-column layout needs the extra height to show both columns without scroll.

## Screenshots

Follow-up comment — four states: Classic, Enriched-healthy, Enriched-verdict-populated, Enriched-events-populated.

## Per-policy CR wait

HIGH-risk → waiting for CR. 45-min backstop starts from the merge-commit push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced enriched overview mode with enhanced dial visualization, verdict strips displaying detailed metrics (median latency, jitter, loss), a real-time event feed for threshold crossings, and per-endpoint latency comparison.
  * Added loss percentage metric tracking to endpoint statistics.

* **Tests**
  * Added comprehensive test coverage for verdict computation and persistence migrations to version 6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->