### PR TITLE
Phase 3 — Live oscilloscope view

### DIFF
--- a/scripts/phase-3-screenshots.mjs
+++ b/scripts/phase-3-screenshots.mjs
@@ -1,0 +1,114 @@
+// Phase 3 Live view screenshots. Four states:
+//   1. full scope at rest          — no samples, idle
+//   2. scope with trace points     — seeded healthy latencies
+//   3. focused-endpoint state      — one endpoint focused, solo mode
+//   4. threshold-cross event       — samples crossing the trigger, chevrons
+import { chromium } from 'playwright';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+const OUT = path.resolve('screenshots/phase-3');
+await mkdir(OUT, { recursive: true });
+
+const browser = await chromium.launch();
+try {
+  const context = await browser.newContext({ viewport: { width: 1440, height: 900 }, deviceScaleFactor: 2 });
+  const page = await context.newPage();
+
+  await page.goto('http://127.0.0.1:5173/');
+  await page.evaluate(() => { localStorage.clear(); });
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+  await page.evaluate(async () => { await document.fonts.ready; });
+
+  await page.evaluate(async () => {
+    const uiMod = await import('/src/lib/stores/ui.ts');
+    uiMod.uiStore.setActiveView('live');
+  });
+  await page.waitForTimeout(300);
+
+  // Shot 1 — scope at rest, no samples.
+  await page.screenshot({ path: path.join(OUT, '1-at-rest.png'), type: 'png' });
+
+  // Materialise the per-endpoint sample arrays up front (array-of-arrays) so we
+  // can ship them to the browser as plain data — no function-serialisation.
+  async function seedSamplesFromProfiles(profiles) {
+    await page.evaluate(async (profiles) => {
+      const measMod = await import('/src/lib/stores/measurements.ts');
+      const epMod = await import('/src/lib/stores/endpoints.ts');
+      const eps = await new Promise((resolve) => {
+        let unsub;
+        unsub = epMod.endpointStore.subscribe((v) => { resolve(v); queueMicrotask(() => unsub?.()); });
+      });
+      measMod.measurementStore.reset();
+      for (let epIdx = 0; epIdx < eps.length; epIdx++) {
+        const ep = eps[epIdx];
+        measMod.measurementStore.initEndpoint(ep.id);
+        const samples = profiles[epIdx] ?? profiles[profiles.length - 1] ?? [];
+        const nowTs = Date.now();
+        for (let r = 0; r < samples.length; r++) {
+          const s = samples[r];
+          measMod.measurementStore.addSample(
+            ep.id, r + 1, s.lat, s.status, nowTs - (samples.length - r) * 1000,
+          );
+        }
+      }
+    }, profiles);
+    await page.waitForTimeout(300);
+  }
+
+  // Shot 2 — unified scope with four distinct traces.
+  {
+    const bases = [40, 70, 110, 155];
+    const profiles = bases.map((base, epIdx) => {
+      const out = [];
+      for (let r = 0; r < 60; r++) {
+        out.push({ lat: base + Math.sin(r * 0.4 + epIdx) * 8 + (r % 13), status: 'ok' });
+      }
+      return out;
+    });
+    await seedSamplesFromProfiles(profiles);
+  }
+  await page.screenshot({ path: path.join(OUT, '2-with-traces.png'), type: 'png' });
+
+  // Shot 3 — solo mode after focusing the second endpoint.
+  await page.evaluate(async () => {
+    const uiMod = await import('/src/lib/stores/ui.ts');
+    const epMod = await import('/src/lib/stores/endpoints.ts');
+    const eps = await new Promise((resolve) => {
+      let unsub;
+      unsub = epMod.endpointStore.subscribe((v) => { resolve(v); queueMicrotask(() => unsub?.()); });
+    });
+    if (eps[1]) uiMod.uiStore.setFocusedEndpoint(eps[1].id);
+  });
+  await page.waitForTimeout(300);
+  await page.screenshot({ path: path.join(OUT, '3-focused.png'), type: 'png' });
+
+  // Reset focus, then seed threshold-crossing samples for shot 4.
+  await page.evaluate(async () => {
+    const uiMod = await import('/src/lib/stores/ui.ts');
+    uiMod.uiStore.setFocusedEndpoint(null);
+  });
+  {
+    const profiles = [];
+    for (let epIdx = 0; epIdx < 4; epIdx++) {
+      const out = [];
+      for (let r = 0; r < 60; r++) {
+        if (epIdx === 0) out.push({ lat: 50 + Math.sin(r * 0.3) * 6, status: 'ok' });
+        else if (epIdx === 1) out.push({ lat: r > 35 ? 250 + (r % 7) * 5 : 80 + (r % 5), status: 'ok' });
+        else if (epIdx === 2) out.push({ lat: r > 45 ? 320 + (r % 4) * 3 : 100 + (r % 9), status: 'ok' });   // overflow
+        else {
+          if (r === 40) out.push({ lat: 0, status: 'timeout' });
+          else out.push({ lat: 90 + Math.sin(r * 0.25) * 12, status: 'ok' });
+        }
+      }
+      profiles.push(out);
+    }
+    await seedSamplesFromProfiles(profiles);
+  }
+  await page.screenshot({ path: path.join(OUT, '4-threshold-cross.png'), type: 'png' });
+
+  console.log('Screenshots written to', OUT);
+} finally {
+  await browser.close();
+}

--- a/src/lib/components/App.svelte
+++ b/src/lib/components/App.svelte
@@ -113,7 +113,8 @@
     root.style.setProperty('--tooltip-text-dim',     tokens.color.tooltip.textDim);
 
     // v2 SVG primitives (dial, orbit ring, scope)
-    root.style.setProperty('--svg-grid-cyan',  tokens.color.svg.gridLineCyan);
+    root.style.setProperty('--svg-grid-line', tokens.color.svg.gridLine);
+    root.style.setProperty('--svg-grid-cyan', tokens.color.svg.gridLineCyan);
     root.style.setProperty('--svg-grid-major', tokens.color.svg.gridLineMajor);
     root.style.setProperty('--svg-tick-minor', tokens.color.svg.tickMinor);
     root.style.setProperty('--svg-tick-major', tokens.color.svg.tickMajor);

--- a/src/lib/components/EndpointRail.svelte
+++ b/src/lib/components/EndpointRail.svelte
@@ -21,8 +21,7 @@
 
   function handleDoubleClick(id: string): void {
     uiStore.setFocusedEndpoint(id);
-    // Drill to Lanes in Phase 1 — switch to 'live' once Phase 3 ships it.
-    uiStore.setActiveView('lanes');
+    uiStore.setActiveView('live');
   }
 
   // Keyboard parity for drill: Enter falls through to native button click

--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -14,6 +14,7 @@
   import EndpointRail from './EndpointRail.svelte';
   import ViewSwitcher from './ViewSwitcher.svelte';
   import OverviewView from './OverviewView.svelte';
+  import LiveView from './LiveView.svelte';
   import LanesView from './LanesView.svelte';
   import XAxisBar from './XAxisBar.svelte';
   import FooterBar from './FooterBar.svelte';
@@ -105,6 +106,8 @@
               {sampleTimestamps}
             />
           </div>
+        {:else if activeView === 'live'}
+          <LiveView />
         {:else}
           <OverviewView />
         {/if}

--- a/src/lib/components/LiveView.svelte
+++ b/src/lib/components/LiveView.svelte
@@ -89,16 +89,25 @@
       <div class="live-control" role="group" aria-label="Scope layout">
         <span class="live-control-label">Layout</span>
         <div class="live-segment">
+          <!--
+            Pressed state tracks `liveOptions.split` (the user's stashed
+            preference), not the current `mode`. In solo mode the scope is
+            always a single full-height canvas regardless of the toggle, so
+            we keep the toggle disabled + visually showing the stashed value
+            so clicks are advisory — the preference will apply on unfocus.
+          -->
           <button
             type="button" class="live-chip"
-            class:on={mode !== 'split'}
-            aria-pressed={mode !== 'split'}
+            class:on={!liveOptions.split}
+            aria-pressed={!liveOptions.split}
+            disabled={!!soloEndpoint}
             onclick={() => setSplit(false)}
           >Unified</button>
           <button
             type="button" class="live-chip"
-            class:on={mode === 'split'}
-            aria-pressed={mode === 'split'}
+            class:on={liveOptions.split}
+            aria-pressed={liveOptions.split}
+            disabled={!!soloEndpoint}
             onclick={() => setSplit(true)}
           >Split</button>
         </div>
@@ -112,7 +121,7 @@
             onclick={clearFocus}
             aria-label="Clear focus on {soloEndpoint.label}"
           >
-            Clear focus · ESC
+            Clear focus
           </button>
         </div>
       {/if}

--- a/src/lib/components/LiveView.svelte
+++ b/src/lib/components/LiveView.svelte
@@ -1,0 +1,361 @@
+<!-- src/lib/components/LiveView.svelte -->
+<!-- Phase 3 Live view — oscilloscope surface. Header (title + Unified/Split     -->
+<!-- toggle + TRIG readout), ScopeCanvas (one unified or N split), LiveFooter    -->
+<!-- (per-endpoint stats chips). Solo mode when `focusedEndpointId` is set.      -->
+<script lang="ts">
+  import { uiStore } from '$lib/stores/ui';
+  import { measurementStore } from '$lib/stores/measurements';
+  import { statisticsStore } from '$lib/stores/statistics';
+  import { settingsStore } from '$lib/stores/settings';
+  import { monitoredEndpointsStore } from '$lib/stores/derived';
+  import { fmt } from '$lib/utils/format';
+  import { tokens } from '$lib/tokens';
+  import ScopeCanvas from './ScopeCanvas.svelte';
+  import type { MeasurementSample } from '$lib/types';
+
+  // PATTERNS.md §3 — user-facing metric derivations iterate monitoredEndpoints.
+  const monitored = $derived($monitoredEndpointsStore);
+  const measurements = $derived($measurementStore);
+  const stats = $derived($statisticsStore);
+  const threshold = $derived($settingsStore.healthThreshold);
+  const liveOptions = $derived($uiStore.liveOptions);
+  const focusedId = $derived($uiStore.focusedEndpointId);
+
+  // When an endpoint is focused from the rail, Live enters "solo mode" — one
+  // scope showing only that endpoint. Reverts to the toggle-driven layout
+  // (unified vs split) when focus clears.
+  const soloEndpoint = $derived(
+    focusedId === null ? null : monitored.find((ep) => ep.id === focusedId) ?? null,
+  );
+  const visibleEndpoints = $derived(soloEndpoint ? [soloEndpoint] : monitored);
+
+  // Pull per-endpoint sample tails once per render. 60-round window matches
+  // the scope's X axis; tail-slicing is zero-alloc on the ring buffer path.
+  const samplesByEndpoint = $derived.by<Record<string, readonly MeasurementSample[]>>(() => {
+    const out: Record<string, readonly MeasurementSample[]> = {};
+    for (const ep of visibleEndpoints) {
+      const m = measurements.endpoints[ep.id];
+      if (!m) { out[ep.id] = []; continue; }
+      const all = m.samples.toArray();
+      out[ep.id] = all.slice(-tokens.lane.chartWindow);
+    }
+    return out;
+  });
+
+  const currentRound = $derived(measurements.roundCounter || tokens.lane.chartWindow);
+  const mode: 'solo' | 'unified' | 'split' = $derived(
+    soloEndpoint ? 'solo' : liveOptions.split ? 'split' : 'unified',
+  );
+  const scopeHeight = $derived(mode === 'split' ? 220 : 540);
+
+  function handleDrill(epId: string): void {
+    uiStore.setFocusedEndpoint(epId);
+    // Phase 3 exits with drill-to-Atlas pending (Phase 4). Stay in Live (solo)
+    // after click — keeps the user on the scope they were reading.
+  }
+
+  function setSplit(split: boolean): void {
+    uiStore.setLiveSplit(split);
+  }
+
+  function clearFocus(): void {
+    uiStore.setFocusedEndpoint(null);
+  }
+
+  // Per-endpoint footer chips. Each shows endpoint color pip + label + live
+  // latency + p95 badge. Clicking the chip focuses that endpoint (solo).
+  function handleChipClick(epId: string): void {
+    uiStore.setFocusedEndpoint(focusedId === epId ? null : epId);
+  }
+</script>
+
+<section class="live-wrap" aria-label="Live oscilloscope">
+  <header class="live-header">
+    <div class="live-title-block">
+      <div class="live-kicker">Live · Oscilloscope</div>
+      <h1 class="live-title">
+        {#if soloEndpoint}
+          <span class="live-title-solo">
+            <span class="live-title-pip" style:background={soloEndpoint.color} aria-hidden="true"></span>
+            {soloEndpoint.label}
+          </span>
+        {:else}
+          Real-time trace
+        {/if}
+      </h1>
+    </div>
+
+    <div class="live-controls">
+      <div class="live-control" role="group" aria-label="Scope layout">
+        <span class="live-control-label">Layout</span>
+        <div class="live-segment">
+          <button
+            type="button" class="live-chip"
+            class:on={mode !== 'split'}
+            aria-pressed={mode !== 'split'}
+            onclick={() => setSplit(false)}
+          >Unified</button>
+          <button
+            type="button" class="live-chip"
+            class:on={mode === 'split'}
+            aria-pressed={mode === 'split'}
+            onclick={() => setSplit(true)}
+          >Split</button>
+        </div>
+      </div>
+
+      {#if soloEndpoint}
+        <div class="live-control">
+          <span class="live-control-label">Focus</span>
+          <button
+            type="button" class="live-chip live-chip-action"
+            onclick={clearFocus}
+            aria-label="Clear focus on {soloEndpoint.label}"
+          >
+            Clear focus · ESC
+          </button>
+        </div>
+      {/if}
+
+      <div class="live-control live-control-trig" aria-label="Trigger threshold, {threshold} milliseconds">
+        <span class="live-control-label">Trig</span>
+        <div class="trig-display">
+          {threshold}<span>ms</span>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  {#if mode === 'split'}
+    <div class="scope-stack">
+      {#each visibleEndpoints as ep (ep.id)}
+        <ScopeCanvas
+          endpoints={[ep]}
+          samplesByEndpoint={{ [ep.id]: samplesByEndpoint[ep.id] ?? [] }}
+          {threshold}
+          {currentRound}
+          height={scopeHeight}
+          focusedEndpointId={null}
+          onDrill={handleDrill}
+        />
+      {/each}
+    </div>
+  {:else}
+    <ScopeCanvas
+      endpoints={visibleEndpoints}
+      {samplesByEndpoint}
+      {threshold}
+      {currentRound}
+      height={scopeHeight}
+      focusedEndpointId={soloEndpoint ? null : focusedId}
+      onDrill={handleDrill}
+    />
+  {/if}
+
+  <footer class="live-footer" aria-label="Endpoint summary">
+    <span class="live-footer-kicker">Endpoints</span>
+    {#each monitored as ep (ep.id)}
+      {@const m = measurements.endpoints[ep.id]}
+      {@const last = m?.lastLatency ?? null}
+      {@const s = stats[ep.id]}
+      {@const color = ep.color || tokens.color.endpoint[0]}
+      <button
+        type="button" class="live-footer-chip"
+        class:on={focusedId === ep.id}
+        aria-pressed={focusedId === ep.id}
+        onclick={() => handleChipClick(ep.id)}
+      >
+        <span class="live-footer-pip" style:background={color} aria-hidden="true"></span>
+        <span class="live-footer-name">{ep.label}</span>
+        <span class="live-footer-val">{fmt(last)} ms</span>
+        {#if s?.ready}
+          <span class="live-footer-p95">p95 {fmt(s.p95)}</span>
+        {/if}
+      </button>
+    {/each}
+  </footer>
+</section>
+
+<style>
+  .live-wrap {
+    padding: 18px 24px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    min-height: 0;
+    overflow-y: auto;
+    flex: 1;
+  }
+
+  .live-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    gap: 20px;
+    flex-wrap: wrap;
+  }
+  .live-kicker {
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-kicker);
+    color: var(--accent-cyan);
+    text-transform: uppercase;
+    margin-bottom: 4px;
+  }
+  .live-title {
+    margin: 0;
+    font-size: var(--ts-2xl);
+    font-weight: 500;
+    letter-spacing: var(--tr-tight);
+    color: var(--t1);
+  }
+  .live-title-solo { display: inline-flex; align-items: center; gap: 10px; }
+  .live-title-pip {
+    width: 10px; height: 10px; border-radius: 50%;
+    box-shadow: 0 0 6px currentColor;
+  }
+
+  .live-controls { display: flex; align-items: flex-end; gap: 14px; flex-wrap: wrap; }
+  .live-control { display: flex; flex-direction: column; gap: 4px; }
+  .live-control-label {
+    font-family: var(--mono);
+    font-size: 8.5px;
+    letter-spacing: 0.2em;
+    color: var(--t4);
+    text-transform: uppercase;
+  }
+  .live-segment {
+    display: inline-flex;
+    padding: 2px;
+    background: rgba(255, 255, 255, 0.04);
+    border-radius: 7px;
+    border: 1px solid var(--border-mid);
+    gap: 2px;
+  }
+  .live-chip {
+    padding: 6px 12px;
+    border-radius: 5px;
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--t2);
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: 0.06em;
+    cursor: pointer;
+    transition: color 160ms ease, background 160ms ease, border-color 160ms ease;
+  }
+  .live-chip:hover {
+    color: var(--t1);
+    border-color: var(--border-bright);
+  }
+  .live-chip.on {
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--t1);
+    border-color: transparent;
+  }
+  .live-chip:focus-visible {
+    outline: 1.5px solid var(--accent-cyan);
+    outline-offset: 2px;
+  }
+  .live-chip-action {
+    background: transparent;
+    border: 1px solid var(--border-mid);
+    color: var(--t2);
+  }
+
+  .trig-display {
+    padding: 5px 10px;
+    border-radius: 6px;
+    background: rgba(251, 191, 36, 0.1);
+    border: 1px solid rgba(251, 191, 36, 0.3);
+    color: var(--accent-amber);
+    font-family: var(--mono);
+    font-size: var(--ts-md);
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+  }
+  .trig-display span {
+    font-size: var(--ts-xs);
+    color: rgba(251, 191, 36, 0.7);
+    margin-left: 3px;
+    letter-spacing: var(--tr-label);
+  }
+
+  .scope-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .live-footer {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+    padding: 10px 12px;
+    background: var(--glass-bg-rail-hover);
+    border: 1px solid var(--border-mid);
+    border-radius: 10px;
+  }
+  .live-footer-kicker {
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-kicker);
+    color: var(--t3);
+    text-transform: uppercase;
+    margin-right: 6px;
+  }
+  .live-footer-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 10px;
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid var(--border-mid);
+    color: var(--t2);
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: 0.06em;
+    cursor: pointer;
+    transition: color 160ms ease, background 160ms ease, border-color 160ms ease;
+  }
+  .live-footer-chip:hover {
+    color: var(--t1);
+    border-color: var(--border-bright);
+  }
+  .live-footer-chip.on {
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--t1);
+    border-color: var(--border-bright);
+  }
+  .live-footer-chip:focus-visible {
+    outline: 1.5px solid var(--accent-cyan);
+    outline-offset: 2px;
+  }
+  .live-footer-pip {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+  }
+  .live-footer-name { color: inherit; }
+  .live-footer-val {
+    font-variant-numeric: tabular-nums;
+    color: var(--t3);
+    margin-left: 3px;
+  }
+  .live-footer-p95 {
+    color: var(--t4);
+    margin-left: 6px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .live-chip, .live-footer-chip { transition: none; }
+  }
+
+  @media (max-width: 767px) {
+    .live-wrap { padding: 12px; gap: 10px; }
+    .live-header { flex-direction: column; align-items: flex-start; gap: 10px; }
+  }
+</style>

--- a/src/lib/components/OverviewView.svelte
+++ b/src/lib/components/OverviewView.svelte
@@ -288,8 +288,7 @@
 
   function handleEventDrill(epId: string): void {
     uiStore.setFocusedEndpoint(epId);
-    // Phase 2.5 fallback: drill to Lanes until Live (Phase 3) ships.
-    uiStore.setActiveView('lanes');
+    uiStore.setActiveView('live');
   }
 
   // Rerender clock for the event feed's relative-time labels. Ticks every

--- a/src/lib/components/RacingStrip.svelte
+++ b/src/lib/components/RacingStrip.svelte
@@ -76,11 +76,9 @@
 
   function handleClick(event: MouseEvent, ep: Endpoint): void {
     uiStore.setFocusedEndpoint(ep.id);
-    // Phase 2.5 fallback: both taps route to Lanes because Live (Phase 3) and
-    // Atlas (Phase 4) aren't shipped yet. Keep the single-target wiring until
-    // the hint can honestly advertise `Click → Live · ⇧ → Diagnose`.
-    void event;
-    uiStore.setActiveView('lanes');
+    // Click → Live (Phase 3); Shift+click → Lanes for now (Atlas is Phase 4).
+    // Flip the shift-branch to 'atlas' once it ships.
+    uiStore.setActiveView(event.shiftKey ? 'lanes' : 'live');
   }
 </script>
 
@@ -90,7 +88,7 @@
       <h3 class="racing-title">Per-endpoint comparison</h3>
       <p class="racing-sub">Live latencies on shared axis</p>
     </div>
-    <p class="racing-hint">Click → Lanes</p>
+    <p class="racing-hint">Click → Live · ⇧ → Lanes</p>
   </header>
 
   <div class="racing-axis" aria-hidden="true">

--- a/src/lib/components/ScopeCanvas.svelte
+++ b/src/lib/components/ScopeCanvas.svelte
@@ -1,0 +1,404 @@
+<!-- src/lib/components/ScopeCanvas.svelte -->
+<!-- Real-time oscilloscope renderer. SVG polylines (matches the prototype; -->
+<!-- 600 points/frame at 10 × 60 comfortably 60fps). One trace per endpoint -->
+<!-- on a shared 0–300ms Y axis, last 60 rounds on the X axis. Threshold    -->
+<!-- line, overflow chevrons, status-break gaps, hover crosshair tooltip.   -->
+<script lang="ts">
+  import { tokens } from '$lib/tokens';
+  import { fmt } from '$lib/utils/format';
+  import type { Endpoint, MeasurementSample } from '$lib/types';
+
+  interface Props {
+    endpoints: readonly Endpoint[];
+    samplesByEndpoint: Record<string, readonly MeasurementSample[]>;
+    threshold: number;
+    currentRound: number;
+    /** Pixel height of the scope. 540 for unified/solo, 220 for split. */
+    height: number;
+    /** When set, highlight this endpoint's trace and dim the others. */
+    focusedEndpointId: string | null;
+    onDrill?: (endpointId: string) => void;
+  }
+
+  let { endpoints, samplesByEndpoint, threshold, currentRound, height, focusedEndpointId, onDrill }: Props = $props();
+
+  // ── Geometry ────────────────────────────────────────────────────────────
+  const VB_W = 1440;
+  const VB_H = 640;
+  const PAD_X = 48;
+  const PAD_Y = 24;
+  const MAX_MS = 300;
+  const WINDOW = tokens.lane.chartWindow; // 60 rounds
+
+  const plotX0 = PAD_X;
+  const plotX1 = VB_W - PAD_X;
+  const plotY0 = PAD_Y;
+  const plotY1 = VB_H - PAD_Y;
+
+  function xOf(round: number): number {
+    // Right edge = currentRound; left edge = currentRound - WINDOW + 1.
+    const start = Math.max(1, currentRound - WINDOW + 1);
+    const span = Math.max(WINDOW - 1, 1);
+    const t = (round - start) / span;
+    return plotX0 + Math.max(0, Math.min(1, t)) * (plotX1 - plotX0);
+  }
+
+  function yOf(latency: number): number {
+    const clamped = Math.max(0, Math.min(MAX_MS, latency));
+    return plotY1 - (clamped / MAX_MS) * (plotY1 - plotY0);
+  }
+
+  // ── Precomputed grid lines ──────────────────────────────────────────────
+  interface HLine { ms: number; y: number; major: boolean; }
+  const hGrid: readonly HLine[] = (() => {
+    const lines: HLine[] = [];
+    for (let ms = 0; ms <= MAX_MS; ms += 15) {
+      lines.push({ ms, y: yOf(ms), major: ms % 60 === 0 });
+    }
+    return lines;
+  })();
+
+  const thresholdY = $derived(yOf(threshold));
+
+  // X axis ticks — every 10 rounds within the visible window; major every 30.
+  interface XTick { round: number; x: number; major: boolean; }
+  const xTicks: readonly XTick[] = $derived.by(() => {
+    const start = Math.max(1, currentRound - WINDOW + 1);
+    const end = Math.max(start + WINDOW - 1, currentRound);
+    const out: XTick[] = [];
+    const firstTick = Math.ceil(start / 10) * 10;
+    for (let r = firstTick; r <= end; r += 10) {
+      out.push({ round: r, x: xOf(r), major: r % 30 === 0 });
+    }
+    return out;
+  });
+
+  // ── Trace path per endpoint ─────────────────────────────────────────────
+  interface Trace { id: string; color: string; d: string; overflow: { x: number }[]; breaks: { x: number; kind: 'timeout' | 'error' }[]; dimmed: boolean; }
+  const traces: readonly Trace[] = $derived.by(() => {
+    const out: Trace[] = [];
+    const start = Math.max(1, currentRound - WINDOW + 1);
+    for (const ep of endpoints) {
+      const samples = samplesByEndpoint[ep.id] ?? [];
+      const recent = samples.filter((s) => s.round >= start);
+      let d = '';
+      let prevWasGap = true;
+      const overflow: { x: number }[] = [];
+      const breaks: { x: number; kind: 'timeout' | 'error' }[] = [];
+      for (const s of recent) {
+        const x = xOf(s.round);
+        if (s.status !== 'ok') {
+          breaks.push({ x, kind: s.status === 'timeout' ? 'timeout' : 'error' });
+          prevWasGap = true;
+          continue;
+        }
+        if (!Number.isFinite(s.latency)) { prevWasGap = true; continue; }
+        if (s.latency > MAX_MS) overflow.push({ x });
+        const y = yOf(s.latency);
+        d += `${prevWasGap ? 'M' : 'L'} ${x.toFixed(1)} ${y.toFixed(1)} `;
+        prevWasGap = false;
+      }
+      out.push({
+        id: ep.id,
+        color: ep.color || tokens.color.endpoint[0],
+        d: d.trim(),
+        overflow,
+        breaks,
+        dimmed: focusedEndpointId !== null && ep.id !== focusedEndpointId,
+      });
+    }
+    return out;
+  });
+
+  // ── Hover crosshair / tooltip ───────────────────────────────────────────
+  let hoverX = $state<number | null>(null);
+  let hoverRound = $state<number | null>(null);
+  let tipX = $state(0);
+  let tipY = $state(0);
+  let svgEl: SVGSVGElement | undefined = $state();
+
+  function handleMouseMove(event: MouseEvent): void {
+    if (!svgEl) return;
+    const rect = svgEl.getBoundingClientRect();
+    const cssX = event.clientX - rect.left;
+    const cssY = event.clientY - rect.top;
+    // Convert CSS pixel → viewBox coordinate.
+    const vbX = (cssX / rect.width) * VB_W;
+    if (vbX < plotX0 || vbX > plotX1) {
+      hoverX = null;
+      hoverRound = null;
+      return;
+    }
+    const start = Math.max(1, currentRound - WINDOW + 1);
+    const span = Math.max(WINDOW - 1, 1);
+    const t = (vbX - plotX0) / (plotX1 - plotX0);
+    const round = Math.round(start + t * span);
+    hoverX = xOf(round);
+    hoverRound = round;
+    tipX = cssX;
+    tipY = cssY;
+  }
+
+  function handleMouseLeave(): void {
+    hoverX = null;
+    hoverRound = null;
+  }
+
+  interface HoverRow { id: string; color: string; label: string; latency: number | null; status: string; }
+  const hoverRows: readonly HoverRow[] = $derived.by(() => {
+    if (hoverRound === null) return [];
+    const rows: HoverRow[] = [];
+    for (const ep of endpoints) {
+      const s = (samplesByEndpoint[ep.id] ?? []).find((x) => x.round === hoverRound);
+      rows.push({
+        id: ep.id,
+        color: ep.color || tokens.color.endpoint[0],
+        label: ep.label,
+        latency: s && s.status === 'ok' ? s.latency : null,
+        status: s?.status ?? 'no sample',
+      });
+    }
+    return rows;
+  });
+
+  // ── A11y: polite live-region that describes the current scope state. Throttled
+  // to once per 2s so the reader doesn't narrate every tick.
+  let liveRegionText = $state('');
+  let liveThrottleTs = 0;
+  $effect(() => {
+    // Re-run whenever samples change; read but throttle output.
+    void samplesByEndpoint;
+    const now = Date.now();
+    if (now - liveThrottleTs < 2000) return;
+    liveThrottleTs = now;
+    const parts: string[] = [];
+    for (const ep of endpoints) {
+      const samples = samplesByEndpoint[ep.id] ?? [];
+      const last = samples[samples.length - 1];
+      if (!last) continue;
+      if (last.status === 'ok') {
+        parts.push(`${ep.label} ${Math.round(last.latency)} ms${last.latency > threshold ? ', over threshold' : ''}`);
+      } else {
+        parts.push(`${ep.label} ${last.status}`);
+      }
+    }
+    liveRegionText = parts.length === 0 ? 'Awaiting samples.' : parts.join('. ');
+  });
+
+  const ariaLabel = $derived(
+    `Live latency scope — ${endpoints.length} endpoint${endpoints.length === 1 ? '' : 's'}, last ${WINDOW} rounds, threshold ${threshold} ms.`
+  );
+
+  function handleClickTrace(epId: string): void {
+    onDrill?.(epId);
+  }
+
+  const hasAnySample = $derived(traces.some((t) => t.d.length > 0));
+</script>
+
+<div class="scope-wrap" style:height="{height}px">
+  <svg
+    bind:this={svgEl}
+    class="scope-svg"
+    viewBox="0 0 {VB_W} {VB_H}"
+    preserveAspectRatio="none"
+    role="img"
+    aria-label={ariaLabel}
+    onmousemove={handleMouseMove}
+    onmouseleave={handleMouseLeave}
+  >
+    <!-- Horizontal grid (latency buckets) -->
+    <g aria-hidden="true">
+      {#each hGrid as line (line.ms)}
+        <line
+          x1={plotX0} y1={line.y} x2={plotX1} y2={line.y}
+          stroke={line.major ? 'var(--svg-grid-major)' : 'var(--svg-grid-line)'}
+          stroke-width={line.major ? 0.5 : 0.3}
+        />
+      {/each}
+      {#each [0, 60, 120, 180, 240, 300] as ms (ms)}
+        <text
+          x={plotX0 - 8} y={yOf(ms) + 3}
+          text-anchor="end" font-size="9" font-family={tokens.typography.mono.fontFamily}
+          fill="var(--t4)" letter-spacing="0.1em"
+        >{ms}</text>
+      {/each}
+    </g>
+
+    <!-- Vertical grid (round ticks) -->
+    <g aria-hidden="true">
+      {#each xTicks as tick (tick.round)}
+        <line
+          x1={tick.x} y1={plotY0} x2={tick.x} y2={plotY1}
+          stroke="var(--svg-grid-line)" stroke-width={tick.major ? 0.4 : 0.2}
+        />
+        {#if tick.major}
+          <text
+            x={tick.x} y={plotY1 + 14}
+            text-anchor="middle" font-size="9" font-family={tokens.typography.mono.fontFamily}
+            fill="var(--t4)" letter-spacing="0.1em"
+          >R{tick.round}</text>
+        {/if}
+      {/each}
+    </g>
+
+    <!-- Threshold line -->
+    <line
+      x1={plotX0} y1={thresholdY} x2={plotX1} y2={thresholdY}
+      stroke="var(--svg-threshold)" stroke-width="1" stroke-dasharray="4 4" opacity="0.6"
+      aria-hidden="true"
+    />
+    <text
+      x={plotX1 - 4} y={thresholdY - 4}
+      text-anchor="end" font-size="9" font-family={tokens.typography.mono.fontFamily}
+      fill="var(--svg-threshold)" letter-spacing="0.1em"
+      aria-hidden="true"
+    >TRIG {threshold}</text>
+
+    <!-- Traces -->
+    {#each traces as trace (trace.id)}
+      {#if trace.d.length > 0}
+        <path
+          d={trace.d}
+          fill="none"
+          stroke={trace.color}
+          stroke-width={trace.dimmed ? 1 : 1.5}
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          opacity={trace.dimmed ? 0.35 : 1}
+          style:cursor="pointer"
+          onclick={() => handleClickTrace(trace.id)}
+        />
+      {/if}
+      {#each trace.overflow as o, i (i)}
+        <path
+          d="M {o.x - 4} {plotY0 + 6} L {o.x} {plotY0} L {o.x + 4} {plotY0 + 6}"
+          fill="none" stroke={trace.color} stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"
+          opacity={trace.dimmed ? 0.35 : 0.9}
+          aria-hidden="true"
+        />
+      {/each}
+      {#each trace.breaks as b, i (i)}
+        <path
+          d="M {b.x - 4} {plotY0 + 6} L {b.x} {plotY0} L {b.x + 4} {plotY0 + 6}"
+          fill="none"
+          stroke={b.kind === 'timeout' ? 'var(--accent-pink)' : 'var(--status-timeout)'}
+          stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+          opacity={trace.dimmed ? 0.35 : 0.85}
+          aria-hidden="true"
+        />
+      {/each}
+    {/each}
+
+    <!-- Hover crosshair -->
+    {#if hoverX !== null}
+      <line
+        x1={hoverX} y1={plotY0} x2={hoverX} y2={plotY1}
+        stroke="var(--t3)" stroke-width="0.5" opacity="0.6"
+        aria-hidden="true"
+      />
+    {/if}
+
+    <!-- Idle state -->
+    {#if !hasAnySample}
+      <text
+        x={VB_W / 2} y={VB_H / 2}
+        text-anchor="middle" font-size="12" font-family={tokens.typography.mono.fontFamily}
+        fill="var(--t4)" letter-spacing="0.25em"
+        aria-hidden="true"
+      >AWAITING SAMPLES</text>
+    {/if}
+  </svg>
+
+  {#if hoverRound !== null}
+    <div
+      class="scope-tooltip"
+      style:left="{tipX + 12}px"
+      style:top="{tipY + 12}px"
+      role="presentation"
+    >
+      <div class="scope-tooltip-time">Round {hoverRound}</div>
+      <ul class="scope-tooltip-list">
+        {#each hoverRows as row (row.id)}
+          <li class="scope-tooltip-row" class:dim={row.latency === null}>
+            <span class="scope-tooltip-pip" style:background={row.color} aria-hidden="true"></span>
+            <span class="scope-tooltip-name">{row.label}</span>
+            <span class="scope-tooltip-val">
+              {row.latency === null ? row.status : `${fmt(row.latency)} ms`}
+            </span>
+          </li>
+        {/each}
+      </ul>
+    </div>
+  {/if}
+
+  <div class="scope-sr-live" role="status" aria-live="polite" aria-atomic="true">{liveRegionText}</div>
+</div>
+
+<style>
+  .scope-wrap {
+    position: relative;
+    background: #030509;
+    border: 1px solid rgba(103, 232, 249, 0.18);
+    border-radius: 14px;
+    overflow: hidden;
+    box-shadow: inset 0 0 60px rgba(103, 232, 249, 0.04);
+  }
+  .scope-svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+    cursor: crosshair;
+  }
+
+  .scope-tooltip {
+    position: absolute;
+    background: var(--tooltip-bg-deep);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    border: 1px solid var(--tooltip-border);
+    border-radius: var(--radius-sm, 8px);
+    padding: 10px 12px;
+    min-width: 180px;
+    pointer-events: none;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.6);
+    z-index: 40;
+  }
+  .scope-tooltip-time {
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-kicker);
+    color: var(--accent-cyan);
+    text-transform: uppercase;
+    margin-bottom: 6px;
+  }
+  .scope-tooltip-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .scope-tooltip-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-family: var(--mono);
+    font-size: var(--ts-sm);
+    font-variant-numeric: tabular-nums;
+  }
+  .scope-tooltip-row.dim { color: var(--t4); }
+  .scope-tooltip-pip { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+  .scope-tooltip-name { color: var(--t2); flex: 1; }
+  .scope-tooltip-val { color: var(--tooltip-text); }
+  .scope-tooltip-row.dim .scope-tooltip-val { color: var(--t4); }
+
+  .scope-sr-live {
+    position: absolute;
+    width: 1px; height: 1px;
+    padding: 0; margin: -1px; overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap; border: 0;
+  }
+</style>

--- a/src/lib/components/ScopeCanvas.svelte
+++ b/src/lib/components/ScopeCanvas.svelte
@@ -4,6 +4,7 @@
 <!-- on a shared 0–300ms Y axis, last 60 rounds on the X axis. Threshold    -->
 <!-- line, overflow chevrons, status-break gaps, hover crosshair tooltip.   -->
 <script lang="ts">
+  import { onDestroy } from 'svelte';
   import { tokens } from '$lib/tokens';
   import { fmt } from '$lib/utils/format';
   import type { Endpoint, MeasurementSample } from '$lib/types';
@@ -161,16 +162,18 @@
     return rows;
   });
 
-  // ── A11y: polite live-region that describes the current scope state. Throttled
-  // to once per 2s so the reader doesn't narrate every tick.
+  // ── A11y: polite live-region that describes the current scope state.
+  // Throttled to once per 2s so the reader doesn't narrate every tick.
+  // Trailing-edge semantics — if the throttle window is open, schedule the
+  // update rather than dropping it. Otherwise the first sample on mount
+  // can "stick" forever with SR saying "Awaiting samples." when real data
+  // has already arrived.
+  const LIVE_REGION_THROTTLE_MS = 2000;
   let liveRegionText = $state('');
   let liveThrottleTs = 0;
-  $effect(() => {
-    // Re-run whenever samples change; read but throttle output.
-    void samplesByEndpoint;
-    const now = Date.now();
-    if (now - liveThrottleTs < 2000) return;
-    liveThrottleTs = now;
+  let liveThrottleTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function buildLiveRegionText(): string {
     const parts: string[] = [];
     for (const ep of endpoints) {
       const samples = samplesByEndpoint[ep.id] ?? [];
@@ -182,7 +185,37 @@
         parts.push(`${ep.label} ${last.status}`);
       }
     }
-    liveRegionText = parts.length === 0 ? 'Awaiting samples.' : parts.join('. ');
+    return parts.length === 0 ? 'Awaiting samples.' : parts.join('. ');
+  }
+
+  function publishLiveRegionText(): void {
+    liveThrottleTs = Date.now();
+    liveRegionText = buildLiveRegionText();
+  }
+
+  $effect(() => {
+    // Re-run whenever the scope inputs change; publish now if we're past the
+    // throttle window, otherwise schedule a trailing-edge publish so the
+    // final state within a burst still lands in the live region.
+    void samplesByEndpoint;
+    void endpoints;
+    void threshold;
+    const now = Date.now();
+    const elapsed = now - liveThrottleTs;
+    if (elapsed >= LIVE_REGION_THROTTLE_MS) {
+      if (liveThrottleTimer !== null) { clearTimeout(liveThrottleTimer); liveThrottleTimer = null; }
+      publishLiveRegionText();
+      return;
+    }
+    if (liveThrottleTimer !== null) return; // already scheduled for the tail
+    liveThrottleTimer = setTimeout(() => {
+      liveThrottleTimer = null;
+      publishLiveRegionText();
+    }, LIVE_REGION_THROTTLE_MS - elapsed);
+  });
+
+  onDestroy(() => {
+    if (liveThrottleTimer !== null) clearTimeout(liveThrottleTimer);
   });
 
   const ariaLabel = $derived(
@@ -193,7 +226,23 @@
     onDrill?.(epId);
   }
 
-  const hasAnySample = $derived(traces.some((t) => t.d.length > 0));
+  function handleKeyTrace(event: KeyboardEvent, epId: string): void {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onDrill?.(epId);
+    }
+  }
+
+  function endpointLabel(epId: string): string {
+    return endpoints.find((e) => e.id === epId)?.label ?? epId;
+  }
+
+  // Include breaks (timeouts/errors) and overflow chevrons in the visibility
+  // check — a window with only bad samples has zero polyline data but still
+  // renders real chevrons, which shouldn't be covered by "AWAITING SAMPLES".
+  const hasAnySample = $derived(
+    traces.some((t) => t.d.length > 0 || t.breaks.length > 0 || t.overflow.length > 0),
+  );
 </script>
 
 <div class="scope-wrap" style:height="{height}px">
@@ -267,7 +316,11 @@
           stroke-linejoin="round"
           opacity={trace.dimmed ? 0.35 : 1}
           style:cursor="pointer"
+          role="button"
+          tabindex="0"
+          aria-label="Drill into {endpointLabel(trace.id)}"
           onclick={() => handleClickTrace(trace.id)}
+          onkeydown={(e) => handleKeyTrace(e, trace.id)}
         />
       {/if}
       {#each trace.overflow as o, i (i)}

--- a/src/lib/components/ViewSwitcher.svelte
+++ b/src/lib/components/ViewSwitcher.svelte
@@ -20,7 +20,7 @@
   // "keep all 6 legacy views working until Phase 7").
   const VIEWS: readonly ViewDef[] = [
     { id: 'overview', key: '1', label: 'Overview', hint: 'At a glance',         enabled: true  },
-    { id: 'live',     key: '2', label: 'Live',     hint: 'Real-time scope',     enabled: false },
+    { id: 'live',     key: '2', label: 'Live',     hint: 'Real-time scope',     enabled: true  },
     { id: 'atlas',    key: '3', label: 'Atlas',    hint: 'Phase breakdown',     enabled: false },
     { id: 'strata',   key: '4', label: 'Strata',   hint: 'Distribution',        enabled: false },
     { id: 'terminal', key: '5', label: 'Terminal', hint: 'Event log',           enabled: false },


### PR DESCRIPTION
## Summary

Live view replaces the Phase 1 stub. Real-time oscilloscope showing the last 60 rounds of latency as a polyline per endpoint, with a threshold trigger line, overflow chevrons, timeout/error gaps, and a hover tooltip. MEDIUM-risk (new view composition, new derivations) — shipped light mode per policy; no schema, no classifier, no new stores.

## What shipped

- **`ScopeCanvas.svelte`** — SVG polyline renderer at 1440 × 640 design space. Horizontal grid (15 ms minor / 60 ms major), vertical round grid (every 10, major every 30 with `R{n}` labels), dashed threshold line with `TRIG N` label, one polyline per endpoint (explicit `prevWasGap` M/L toggle — reuses the RacingStrip sparkline fix pattern from PR #47), overflow chevrons at the top edge for > 300 ms samples, pink/violet chevrons for timeout/error with polyline breaks, hover crosshair + tooltip, `AWAITING SAMPLES` placeholder. `role="img"` with descriptive `aria-label`, off-screen polite live region throttled to 2 s.
- **`LiveView.svelte`** — header (title + Unified/Split toggle + clear-focus chip in solo mode + amber TRIG readout), scope (unified / split stack / solo), per-endpoint footer chips. PATTERNS.md §3 — every derivation iterates `monitoredEndpoints`.

## Routing + drill updates

- `Layout.svelte` branches on `activeView === 'live'`.
- `ViewSwitcher.svelte` flips Live's `enabled: true` — matches the PHASE_NOTES.md §Phase 1 template.
- `EndpointRail` double-click + Space keydown → `'live'` (was `'lanes'`).
- `OverviewView` event-feed drill → `'live'` (Diagnose CTAs still fall back to `'lanes'` until Atlas/Phase 4 ships).
- `RacingStrip` click → `'live'`, shift-click → `'lanes'` (same fallback). Hint text now honest: *"Click → Live · ⇧ → Lanes"*.

## Bundle delta

| | JS gzip | CSS gzip |
|---|---:|---:|
| Pre-Phase-3 | 70.19 KB | 11.72 KB |
| Phase 3 | **73.40 KB** | **12.43 KB** |
| Delta | **+3.21 KB** | **+0.71 KB** |

Total **+3.92 KB gzip**, well under the +20 KB Phase 3 budget.

## Non-negotiables checked

- **PATTERNS.md §3 (monitoredEndpoints)** — `LiveView` iterates `$monitoredEndpointsStore` for rail-footer chips, scope endpoints, sample map, solo-mode resolution. Zero raw `$endpointStore` iteration in any metric derivation.
- **PATTERNS.md §2 (prefers-reduced-motion)** — all UI transitions (live-chip hover, live-footer-chip hover, scope-tooltip) are `@media (prefers-reduced-motion: reduce)` gated. The scope itself has no JS-driven animation — traces update on data change, not via lerp.
- **No new stores** — `LiveView` composes from existing `measurementStore`, `statisticsStore`, `settingsStore`, `uiStore`, and the derived `monitoredEndpointsStore`.
- **Bundle delta < +20 KB gzip** ✓

## Tests / CI

769/769 tests pass. Typecheck / lint / build all green.

## Screenshots

Follow-up comment — four states at 1440 × 900 @ 2× DPI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launched new "Live" view mode featuring real-time oscilloscope visualization for endpoint latency monitoring.
  * Added interactive trace display with per-endpoint latency samples, threshold indicators, and visual overflow markers.
  * Updated navigation behavior: clicking endpoints now opens Live view; Shift+click routes to Lanes view.
  * Enabled Live tab in the view switcher for seamless mode switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->