### PR TITLE
Phase 4 — Atlas diagnose (request waterfall)

### DIFF
--- a/scripts/phase-4-screenshots.mjs
+++ b/scripts/phase-4-screenshots.mjs
@@ -1,0 +1,135 @@
+// Phase 4 Atlas view screenshots. Four states:
+//   1. Waterfall with P50 (balanced phases)
+//   2. Waterfall with P95 (same data, p95 mode)
+//   3. Anomaly callout — TTFB dominant
+//   4. Empty state — no focused endpoint
+import { chromium } from 'playwright';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+
+const OUT = path.resolve('screenshots/phase-4');
+await mkdir(OUT, { recursive: true });
+
+const browser = await chromium.launch();
+try {
+  const context = await browser.newContext({ viewport: { width: 1440, height: 900 }, deviceScaleFactor: 2 });
+  const page = await context.newPage();
+
+  await page.goto('http://127.0.0.1:5173/');
+  await page.evaluate(() => { localStorage.clear(); });
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+  await page.evaluate(async () => { await document.fonts.ready; });
+
+  await page.evaluate(async () => {
+    const uiMod = await import('/src/lib/stores/ui.ts');
+    uiMod.uiStore.setActiveView('atlas');
+  });
+  await page.waitForTimeout(300);
+
+  // Shot 4 first (empty state — no focus)
+  await page.screenshot({ path: path.join(OUT, '4-empty.png'), type: 'png' });
+
+  // Seed samples with tier2 breakdowns. Focus the second endpoint for shots 1-3.
+  async function seedTier2(profiles) {
+    await page.evaluate(async (profiles) => {
+      const measMod = await import('/src/lib/stores/measurements.ts');
+      const epMod = await import('/src/lib/stores/endpoints.ts');
+      const eps = await new Promise((resolve) => {
+        let unsub;
+        unsub = epMod.endpointStore.subscribe((v) => { resolve(v); queueMicrotask(() => unsub?.()); });
+      });
+      measMod.measurementStore.reset();
+      for (let epIdx = 0; epIdx < eps.length; epIdx++) {
+        const ep = eps[epIdx];
+        measMod.measurementStore.initEndpoint(ep.id);
+        const samples = profiles[epIdx] ?? profiles[profiles.length - 1];
+        const nowTs = Date.now();
+        for (let r = 0; r < samples.length; r++) {
+          const s = samples[r];
+          measMod.measurementStore.addSample(
+            ep.id, r + 1, s.total, 'ok', nowTs - (samples.length - r) * 1000,
+            s.tier2,
+          );
+        }
+      }
+    }, profiles);
+    await page.waitForTimeout(400);
+  }
+
+  async function focusSecond() {
+    await page.evaluate(async () => {
+      const uiMod = await import('/src/lib/stores/ui.ts');
+      const epMod = await import('/src/lib/stores/endpoints.ts');
+      const eps = await new Promise((resolve) => {
+        let unsub;
+        unsub = epMod.endpointStore.subscribe((v) => { resolve(v); queueMicrotask(() => unsub?.()); });
+      });
+      if (eps[1]) uiMod.uiStore.setFocusedEndpoint(eps[1].id);
+    });
+    await page.waitForTimeout(200);
+  }
+
+  // Shots 1 & 2 — balanced phase mix (DNS 8ms, TCP 22ms, TLS 34ms, TTFB 90ms, Transfer 45ms).
+  // Total 199ms. TTFB is largest at ~45% → falls into the "no dominant" branch by default.
+  {
+    const balanced = Array.from({ length: 40 }, () => ({
+      total: 199,
+      tier2: {
+        total: 199,
+        dnsLookup: 8, tcpConnect: 22, tlsHandshake: 34, ttfb: 90, contentTransfer: 45,
+      },
+    }));
+    // Other endpoints get a neutral placeholder so the Rail shows them alive.
+    const neutral = Array.from({ length: 20 }, () => ({
+      total: 60,
+      tier2: {
+        total: 60, dnsLookup: 5, tcpConnect: 10, tlsHandshake: 10, ttfb: 30, contentTransfer: 5,
+      },
+    }));
+    await seedTier2([neutral, balanced, neutral, neutral]);
+  }
+  await focusSecond();
+
+  // P50 is the default; shot 1.
+  await page.screenshot({ path: path.join(OUT, '1-waterfall-p50.png'), type: 'png' });
+
+  // Flip to P95.
+  await page.evaluate(() => {
+    const buttons = Array.from(document.querySelectorAll('button'));
+    const p95 = buttons.find((b) => b.textContent?.trim() === 'P95');
+    p95?.click();
+  });
+  await page.waitForTimeout(200);
+  await page.screenshot({ path: path.join(OUT, '2-waterfall-p95.png'), type: 'png' });
+
+  // Shot 3 — TTFB-dominant anomaly.
+  {
+    // TTFB at 260ms of 310ms total ≈ 84% — triggers the "Slow TTFB" branch.
+    const ttfbHeavy = Array.from({ length: 40 }, () => ({
+      total: 310,
+      tier2: {
+        total: 310,
+        dnsLookup: 10, tcpConnect: 15, tlsHandshake: 20, ttfb: 260, contentTransfer: 5,
+      },
+    }));
+    const neutral = Array.from({ length: 20 }, () => ({
+      total: 60,
+      tier2: { total: 60, dnsLookup: 5, tcpConnect: 10, tlsHandshake: 10, ttfb: 30, contentTransfer: 5 },
+    }));
+    await seedTier2([neutral, ttfbHeavy, neutral, neutral]);
+  }
+  await focusSecond();
+  // Reset back to P50 for a clean shot.
+  await page.evaluate(() => {
+    const buttons = Array.from(document.querySelectorAll('button'));
+    const p50 = buttons.find((b) => b.textContent?.trim() === 'P50');
+    p50?.click();
+  });
+  await page.waitForTimeout(200);
+  await page.screenshot({ path: path.join(OUT, '3-anomaly-ttfb.png'), type: 'png' });
+
+  console.log('Screenshots written to', OUT);
+} finally {
+  await browser.close();
+}

--- a/src/lib/components/AtlasView.svelte
+++ b/src/lib/components/AtlasView.svelte
@@ -1,0 +1,593 @@
+<!-- src/lib/components/AtlasView.svelte -->
+<!-- Phase 4 Atlas view. For the rail-focused endpoint: horizontal phase-bar -->
+<!-- waterfall (dns / tcp / tls / ttfb / transfer) in P50 or P95 mode, a     -->
+<!-- one-sentence phase hypothesis, and the last 8 samples as mini phase    -->
+<!-- bars. Empty-state prompt when no endpoint is focused — the rail is     -->
+<!-- the only endpoint picker (Phase 1 non-negotiable).                     -->
+<script lang="ts">
+  import { monitoredEndpointsStore } from '$lib/stores/derived';
+  import { measurementStore } from '$lib/stores/measurements';
+  import { statisticsStore } from '$lib/stores/statistics';
+  import { uiStore } from '$lib/stores/ui';
+  import { phaseHypothesis, PHASE_LABELS, type PhaseBreakdown, type Tier2Phase } from '$lib/utils/verdict';
+  import { fmt } from '$lib/utils/format';
+  import { tokens } from '$lib/tokens';
+  import type { MeasurementSample } from '$lib/types';
+
+  const monitored = $derived($monitoredEndpointsStore);
+  const stats = $derived($statisticsStore);
+  const measurements = $derived($measurementStore);
+  const focusedId = $derived($uiStore.focusedEndpointId);
+
+  const focusedEndpoint = $derived(
+    focusedId === null ? null : monitored.find((ep) => ep.id === focusedId) ?? null,
+  );
+  const focusedStats = $derived(focusedEndpoint ? stats[focusedEndpoint.id] : undefined);
+
+  // ── Mode toggle ──────────────────────────────────────────────────────────
+  let mode = $state<'p50' | 'p95'>('p50');
+
+  // ── Phase breakdown (adapt EndpointStatistics field names → Atlas phase
+  // vocabulary). P50 uses tier2Averages (means); P95 uses tier2P95.
+  const phases: PhaseBreakdown | null = $derived.by(() => {
+    if (!focusedStats) return null;
+    const src = mode === 'p50' ? focusedStats.tier2Averages : focusedStats.tier2P95;
+    if (!src) return null;
+    return {
+      dns:      src.dnsLookup,
+      tcp:      src.tcpConnect,
+      tls:      src.tlsHandshake,
+      ttfb:     src.ttfb,
+      transfer: src.contentTransfer,
+    };
+  });
+  const phaseTotal = $derived(
+    phases === null ? 0 : phases.dns + phases.tcp + phases.tls + phases.ttfb + phases.transfer,
+  );
+  const hypothesis = $derived(phases === null ? null : phaseHypothesis(phases));
+
+  // ── Segments with computed widths for the hero bar ───────────────────────
+  const PHASE_ORDER: readonly Tier2Phase[] = ['dns', 'tcp', 'tls', 'ttfb', 'transfer'];
+  const PHASE_COLORS: Record<Tier2Phase, string> = {
+    dns:      tokens.color.tier2.dns,
+    tcp:      tokens.color.tier2.tcp,
+    tls:      tokens.color.tier2.tls,
+    ttfb:     tokens.color.tier2.ttfb,
+    transfer: tokens.color.tier2.transfer,
+  };
+  const SHORT_LABELS: Record<Tier2Phase, string> = {
+    dns:      'DNS',
+    tcp:      'TCP',
+    tls:      'TLS',
+    ttfb:     'SERVER',
+    transfer: 'TRANSFER',
+  };
+
+  interface Segment { phase: Tier2Phase; ms: number; pctWidth: number; color: string; short: string; pct: number; dominant: boolean; }
+  const segments: readonly Segment[] = $derived.by(() => {
+    if (phases === null || phaseTotal <= 0) return [];
+    return PHASE_ORDER.map((phase) => {
+      const ms = phases[phase];
+      return {
+        phase,
+        ms,
+        pctWidth: (ms / phaseTotal) * 100,
+        color: PHASE_COLORS[phase],
+        short: SHORT_LABELS[phase],
+        pct: ms / phaseTotal,
+        dominant: hypothesis !== null && hypothesis.verdictPhase === phase,
+      };
+    });
+  });
+
+  // ── Sample strip — last 8 samples, each a mini stacked bar ───────────────
+  const recentSamples: readonly MeasurementSample[] = $derived.by(() => {
+    if (!focusedEndpoint) return [];
+    const m = measurements.endpoints[focusedEndpoint.id];
+    if (!m) return [];
+    return m.samples.toArray().slice(-8);
+  });
+
+  interface SampleRow { round: number; total: number; segs: { phase: Tier2Phase; pctWidth: number; color: string; }[]; status: 'ok' | 'timeout' | 'error' | 'no-tier2'; }
+  const sampleRows: readonly SampleRow[] = $derived.by(() => {
+    return recentSamples.map((s) => {
+      if (s.status !== 'ok') {
+        return { round: s.round, total: s.latency ?? 0, segs: [], status: s.status };
+      }
+      const t2 = s.tier2;
+      if (!t2) {
+        return { round: s.round, total: s.latency, segs: [], status: 'no-tier2' as const };
+      }
+      const total = t2.dnsLookup + t2.tcpConnect + t2.tlsHandshake + t2.ttfb + t2.contentTransfer;
+      const segs = total <= 0 ? [] : PHASE_ORDER.map((phase) => {
+        const ms = phase === 'dns' ? t2.dnsLookup
+                 : phase === 'tcp' ? t2.tcpConnect
+                 : phase === 'tls' ? t2.tlsHandshake
+                 : phase === 'ttfb' ? t2.ttfb
+                 : t2.contentTransfer;
+        return { phase, pctWidth: (ms / total) * 100, color: PHASE_COLORS[phase] };
+      });
+      return { round: s.round, total, segs, status: 'ok' as const };
+    });
+  });
+
+  function handleBack(): void {
+    // Back-to-live: keep the focused endpoint but flip the view.
+    uiStore.setActiveView('live');
+  }
+
+  function handleSelectMode(next: 'p50' | 'p95'): void {
+    mode = next;
+  }
+
+  // ── Accessibility summary for the hero bar ────────────────────────────────
+  const heroAria = $derived(
+    phases === null
+      ? 'Request waterfall — no tier-2 data available.'
+      : `Request waterfall for ${focusedEndpoint?.label ?? 'focused endpoint'} at ${mode.toUpperCase()}: ${segments.map((s) => `${PHASE_LABELS[s.phase]} ${Math.round(s.ms)} ms`).join(', ')}. Total ${Math.round(phaseTotal)} ms.`
+  );
+</script>
+
+<section class="atlas" aria-label="Atlas diagnose">
+  <header class="atlas-header">
+    <div class="atlas-title-block">
+      <div class="atlas-kicker">Diagnose · Atlas · Request waterfall</div>
+      <h1 class="atlas-title">
+        {#if focusedEndpoint}
+          <span class="atlas-title-pip" style:background={focusedEndpoint.color || tokens.color.endpoint[0]} aria-hidden="true"></span>
+          <span class="atlas-title-name">{focusedEndpoint.label}</span>
+          <span class="atlas-title-url">{focusedEndpoint.url}</span>
+        {:else}
+          <span class="atlas-title-placeholder">—</span>
+        {/if}
+      </h1>
+    </div>
+
+    {#if focusedEndpoint}
+      <div class="atlas-actions">
+        <div class="atlas-segment" role="group" aria-label="Percentile mode">
+          <button
+            type="button" class="atlas-chip"
+            class:on={mode === 'p50'} aria-pressed={mode === 'p50'}
+            onclick={() => handleSelectMode('p50')}
+          >P50</button>
+          <button
+            type="button" class="atlas-chip"
+            class:on={mode === 'p95'} aria-pressed={mode === 'p95'}
+            onclick={() => handleSelectMode('p95')}
+          >P95</button>
+        </div>
+        <button
+          type="button" class="atlas-chip atlas-chip-action"
+          onclick={handleBack}
+          aria-label="Back to live"
+        >← Back to Live</button>
+      </div>
+    {/if}
+  </header>
+
+  {#if !focusedEndpoint}
+    <div class="atlas-empty" role="note">
+      <p class="atlas-empty-title">Select an endpoint from the left rail to diagnose a specific link.</p>
+      <p class="atlas-empty-hint">Atlas breaks one request into DNS · TCP · TLS · Server · Transfer phases and points at the slow one.</p>
+    </div>
+  {:else if phases === null}
+    <div class="atlas-empty" role="note">
+      <p class="atlas-empty-title">Awaiting tier-2 samples…</p>
+      <p class="atlas-empty-hint">Phase breakdown appears once the first tier-2 measurement lands.</p>
+    </div>
+  {:else}
+    <!-- Hero waterfall -->
+    <div class="atlas-waterfall" role="img" aria-label={heroAria}>
+      <div class="atlas-bar">
+        {#each segments as seg (seg.phase)}
+          <div
+            class="atlas-bar-seg"
+            class:dominant={seg.dominant}
+            style:width="{seg.pctWidth}%"
+            style:background={seg.color}
+          >
+            {#if seg.pctWidth >= 8}
+              <span class="atlas-bar-label" style:color={tokens.color.tier2.labelText}>
+                {seg.short} · {fmt(seg.ms)}<span class="atlas-bar-ms">ms</span>
+              </span>
+            {/if}
+          </div>
+        {/each}
+      </div>
+      <div class="atlas-bar-scale">
+        {#each segments as seg (seg.phase)}
+          <span class="atlas-bar-tick" style:flex="{seg.pctWidth}">
+            <span class="atlas-bar-tick-label">{seg.short}</span>
+          </span>
+        {/each}
+      </div>
+    </div>
+
+    <!-- Hypothesis + evidence -->
+    {#if hypothesis}
+      <section class="atlas-hypothesis" aria-label="Phase hypothesis">
+        <div class="atlas-hypothesis-kicker">Verdict</div>
+        <p class="atlas-hypothesis-text">{hypothesis.text}</p>
+
+        <div class="atlas-hypothesis-kicker">Evidence</div>
+        <ul class="atlas-evidence">
+          {#each segments as seg (seg.phase)}
+            <li class="atlas-evidence-row" class:dominant={seg.dominant}>
+              <span class="atlas-evidence-pip" style:background={seg.color} aria-hidden="true"></span>
+              <span class="atlas-evidence-name">{PHASE_LABELS[seg.phase]}</span>
+              <span class="atlas-evidence-ms">{fmt(seg.ms)} ms</span>
+              <span class="atlas-evidence-bar" aria-hidden="true">
+                <span class="atlas-evidence-fill" style:width="{seg.pctWidth}%" style:background={seg.color}></span>
+              </span>
+              <span class="atlas-evidence-pct">{Math.round(seg.pct * 100)}%</span>
+            </li>
+          {/each}
+        </ul>
+      </section>
+    {/if}
+
+    <!-- Sample strip -->
+    {#if recentSamples.length > 0}
+      <section class="atlas-samples" aria-label="Recent samples">
+        <div class="atlas-hypothesis-kicker">Last {recentSamples.length} sample{recentSamples.length === 1 ? '' : 's'}</div>
+        <table class="atlas-sample-table">
+          <thead class="sr-only">
+            <tr><th>Round</th><th>Phase breakdown</th><th>Total</th></tr>
+          </thead>
+          <tbody>
+            {#each sampleRows as row (row.round)}
+              <tr class="atlas-sample-row">
+                <td class="atlas-sample-round">R{row.round}</td>
+                <td class="atlas-sample-bar-cell">
+                  <div class="atlas-sample-bar">
+                    {#if row.status === 'ok' && row.segs.length > 0}
+                      {#each row.segs as seg (seg.phase)}
+                        <span class="atlas-sample-seg" style:width="{seg.pctWidth}%" style:background={seg.color} aria-hidden="true"></span>
+                      {/each}
+                    {:else if row.status === 'no-tier2'}
+                      <span class="atlas-sample-neutral" aria-label="No tier-2 breakdown available"></span>
+                    {:else if row.status === 'timeout'}
+                      <span class="atlas-sample-timeout" aria-label="Timeout">TIMEOUT</span>
+                    {:else}
+                      <span class="atlas-sample-timeout" aria-label="Error">ERROR</span>
+                    {/if}
+                  </div>
+                </td>
+                <td class="atlas-sample-total">{fmt(row.total)} ms</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </section>
+    {/if}
+  {/if}
+</section>
+
+<style>
+  .atlas {
+    padding: 18px 28px 40px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    min-height: 0;
+    overflow-y: auto;
+    flex: 1;
+  }
+
+  .atlas-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    gap: 20px;
+    flex-wrap: wrap;
+  }
+  .atlas-kicker {
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-kicker);
+    color: var(--accent-cyan);
+    text-transform: uppercase;
+    margin-bottom: 4px;
+  }
+  .atlas-title {
+    margin: 0;
+    font-size: var(--ts-2xl);
+    font-weight: 500;
+    letter-spacing: var(--tr-tight);
+    color: var(--t1);
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+  .atlas-title-pip {
+    width: 10px; height: 10px;
+    border-radius: 50%;
+    align-self: center;
+    box-shadow: 0 0 6px currentColor;
+  }
+  .atlas-title-url {
+    font-family: var(--mono);
+    font-size: var(--ts-sm);
+    color: var(--t3);
+    font-weight: 400;
+    letter-spacing: var(--tr-body);
+  }
+  .atlas-title-placeholder { color: var(--t4); font-weight: 300; }
+
+  .atlas-actions { display: flex; align-items: center; gap: 10px; }
+  .atlas-segment {
+    display: inline-flex;
+    padding: 2px;
+    background: rgba(255, 255, 255, 0.04);
+    border-radius: 7px;
+    border: 1px solid var(--border-mid);
+    gap: 2px;
+  }
+  .atlas-chip {
+    padding: 6px 12px;
+    border-radius: 5px;
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--t2);
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: 0.06em;
+    cursor: pointer;
+    transition: color 160ms ease, background 160ms ease, border-color 160ms ease;
+  }
+  .atlas-chip:hover { color: var(--t1); border-color: var(--border-bright); }
+  .atlas-chip.on {
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--t1);
+    border-color: transparent;
+  }
+  .atlas-chip:focus-visible {
+    outline: 1.5px solid var(--accent-cyan);
+    outline-offset: 2px;
+  }
+  .atlas-chip-action {
+    background: transparent;
+    border: 1px solid var(--border-mid);
+  }
+
+  /* Empty states */
+  .atlas-empty {
+    padding: 32px 24px;
+    border: 1px dashed var(--border-mid);
+    border-radius: 14px;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    background: var(--glass-bg-rail-hover);
+  }
+  .atlas-empty-title {
+    margin: 0;
+    color: var(--t1);
+    font-family: var(--sans);
+    font-size: var(--ts-base);
+    font-weight: 500;
+  }
+  .atlas-empty-hint {
+    margin: 0;
+    color: var(--t3);
+    font-family: var(--mono);
+    font-size: var(--ts-sm);
+    letter-spacing: 0.02em;
+  }
+
+  /* Hero waterfall */
+  .atlas-waterfall {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .atlas-bar {
+    display: flex;
+    width: 100%;
+    height: 80px;
+    border-radius: 10px;
+    overflow: hidden;
+    background: var(--surface-raised);
+    border: 1px solid var(--border-mid);
+  }
+  .atlas-bar-seg {
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2px;
+    position: relative;
+    transition: filter 160ms ease;
+  }
+  .atlas-bar-seg:hover { filter: brightness(1.1); }
+  .atlas-bar-seg.dominant {
+    box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.25);
+  }
+  .atlas-bar-label {
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-label);
+    font-variant-numeric: tabular-nums;
+    font-weight: 500;
+    white-space: nowrap;
+  }
+  .atlas-bar-ms {
+    font-weight: 400;
+    margin-left: 2px;
+    opacity: 0.8;
+  }
+  .atlas-bar-scale {
+    display: flex;
+    gap: 0;
+  }
+  .atlas-bar-tick {
+    text-align: center;
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-label);
+    color: var(--t4);
+    text-transform: uppercase;
+    min-width: 0;
+  }
+
+  /* Hypothesis */
+  .atlas-hypothesis {
+    background: var(--glass-bg-rail-hover);
+    border: 1px solid var(--border-mid);
+    border-radius: 14px;
+    padding: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+  }
+  .atlas-hypothesis-kicker {
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-kicker);
+    color: var(--t4);
+    text-transform: uppercase;
+  }
+  .atlas-hypothesis-text {
+    margin: 0 0 8px;
+    color: var(--t1);
+    font-family: var(--sans);
+    font-size: var(--ts-lg);
+    font-weight: 500;
+    letter-spacing: var(--tr-tight);
+  }
+
+  .atlas-evidence {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .atlas-evidence-row {
+    display: grid;
+    grid-template-columns: 10px 140px 80px 1fr 40px;
+    gap: 10px;
+    align-items: center;
+    color: var(--t3);
+    font-family: var(--mono);
+    font-size: var(--ts-sm);
+    font-variant-numeric: tabular-nums;
+    padding: 2px 4px;
+    border-radius: 4px;
+  }
+  .atlas-evidence-row.dominant {
+    color: var(--t1);
+    background: rgba(255, 255, 255, 0.03);
+  }
+  .atlas-evidence-pip {
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    align-self: center;
+  }
+  .atlas-evidence-name { color: inherit; }
+  .atlas-evidence-ms { color: var(--t1); }
+  .atlas-evidence-bar {
+    position: relative;
+    height: 6px;
+    background: rgba(255, 255, 255, 0.04);
+    border-radius: 3px;
+    overflow: hidden;
+  }
+  .atlas-evidence-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    border-radius: 3px;
+  }
+  .atlas-evidence-pct {
+    text-align: right;
+    color: var(--t4);
+    letter-spacing: var(--tr-label);
+  }
+
+  /* Samples */
+  .atlas-samples {
+    background: var(--glass-bg-rail-hover);
+    border: 1px solid var(--border-mid);
+    border-radius: 14px;
+    padding: 14px 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+  }
+  .atlas-sample-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  .atlas-sample-row td {
+    padding: 3px 0;
+    vertical-align: middle;
+  }
+  .atlas-sample-round {
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    color: var(--t4);
+    letter-spacing: var(--tr-label);
+    width: 58px;
+  }
+  .atlas-sample-bar-cell { width: 100%; padding: 3px 10px; }
+  .atlas-sample-bar {
+    display: flex;
+    height: 14px;
+    border-radius: 4px;
+    overflow: hidden;
+    background: rgba(255, 255, 255, 0.03);
+  }
+  .atlas-sample-seg { height: 100%; min-width: 1px; }
+  .atlas-sample-neutral {
+    display: block;
+    width: 100%; height: 100%;
+    background: var(--t5, rgba(255, 255, 255, 0.07));
+  }
+  .atlas-sample-timeout {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%; height: 100%;
+    background: rgba(249, 168, 212, 0.2);
+    color: var(--accent-pink);
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-label);
+  }
+  .atlas-sample-total {
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    color: var(--t2);
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    width: 80px;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px; height: 1px;
+    padding: 0; margin: -1px; overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap; border: 0;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .atlas-chip, .atlas-bar-seg { transition: none; }
+  }
+
+  @media (max-width: 767px) {
+    .atlas { padding: 12px; gap: 12px; }
+    .atlas-header { flex-direction: column; align-items: flex-start; }
+    .atlas-evidence-row { grid-template-columns: 10px 110px 70px 1fr 40px; }
+  }
+</style>

--- a/src/lib/components/AtlasView.svelte
+++ b/src/lib/components/AtlasView.svelte
@@ -75,7 +75,10 @@
         color: PHASE_COLORS[phase],
         short: SHORT_LABELS[phase],
         pct: ms / phaseTotal,
-        dominant: hypothesis !== null && hypothesis.verdictPhase === phase,
+        // Use dominantPhases set membership (not verdictPhase equality) so the
+        // pair-dominance branch — which reports verdictPhase === 'mixed' — still
+        // lights up both cited phases.
+        dominant: hypothesis !== null && hypothesis.dominantPhases.includes(phase),
       };
     });
   });
@@ -173,8 +176,15 @@
     </div>
   {:else if phases === null}
     <div class="atlas-empty" role="note">
-      <p class="atlas-empty-title">Awaiting tier-2 samples…</p>
-      <p class="atlas-empty-hint">Phase breakdown appears once the first tier-2 measurement lands.</p>
+      {#if mode === 'p95' && focusedStats?.tier2Averages}
+        <!-- P50 data exists, P95 hasn't been computed yet. Without this branch -->
+        <!-- the view reads as a regression when the user toggles to P95.      -->
+        <p class="atlas-empty-title">P95 phase breakdown not yet available.</p>
+        <p class="atlas-empty-hint">Switch to P50 to view the current breakdown, or wait for more samples.</p>
+      {:else}
+        <p class="atlas-empty-title">Awaiting tier-2 samples…</p>
+        <p class="atlas-empty-hint">Phase breakdown appears once the first tier-2 measurement lands.</p>
+      {/if}
     </div>
   {:else}
     <!-- Hero waterfall -->

--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -15,6 +15,7 @@
   import ViewSwitcher from './ViewSwitcher.svelte';
   import OverviewView from './OverviewView.svelte';
   import LiveView from './LiveView.svelte';
+  import AtlasView from './AtlasView.svelte';
   import LanesView from './LanesView.svelte';
   import XAxisBar from './XAxisBar.svelte';
   import FooterBar from './FooterBar.svelte';
@@ -108,6 +109,8 @@
           </div>
         {:else if activeView === 'live'}
           <LiveView />
+        {:else if activeView === 'atlas'}
+          <AtlasView />
         {:else}
           <OverviewView />
         {/if}

--- a/src/lib/components/OverviewView.svelte
+++ b/src/lib/components/OverviewView.svelte
@@ -99,8 +99,7 @@
 
   function handleClassicDrill(): void {
     if (worst) uiStore.setFocusedEndpoint(worst.id);
-    // Phase 2 fallback: drill to Lanes since Atlas (Phase 4) isn't built yet.
-    uiStore.setActiveView('lanes');
+    uiStore.setActiveView('atlas');
   }
 
   // ── Enriched-only spine ────────────────────────────────────────────────────
@@ -282,8 +281,7 @@
 
   function handleEnrichedDrill(epId: string): void {
     uiStore.setFocusedEndpoint(epId);
-    // Phase 2.5 fallback: drill to Lanes until Atlas (Phase 4) ships.
-    uiStore.setActiveView('lanes');
+    uiStore.setActiveView('atlas');
   }
 
   function handleEventDrill(epId: string): void {

--- a/src/lib/components/RacingStrip.svelte
+++ b/src/lib/components/RacingStrip.svelte
@@ -76,9 +76,8 @@
 
   function handleClick(event: MouseEvent, ep: Endpoint): void {
     uiStore.setFocusedEndpoint(ep.id);
-    // Click → Live (Phase 3); Shift+click → Lanes for now (Atlas is Phase 4).
-    // Flip the shift-branch to 'atlas' once it ships.
-    uiStore.setActiveView(event.shiftKey ? 'lanes' : 'live');
+    // Click → Live; Shift+click → Atlas (diagnose).
+    uiStore.setActiveView(event.shiftKey ? 'atlas' : 'live');
   }
 </script>
 
@@ -88,7 +87,7 @@
       <h3 class="racing-title">Per-endpoint comparison</h3>
       <p class="racing-sub">Live latencies on shared axis</p>
     </div>
-    <p class="racing-hint">Click → Live · ⇧ → Lanes</p>
+    <p class="racing-hint">Click → Live · ⇧ → Atlas</p>
   </header>
 
   <div class="racing-axis" aria-hidden="true">

--- a/src/lib/components/ViewSwitcher.svelte
+++ b/src/lib/components/ViewSwitcher.svelte
@@ -21,7 +21,7 @@
   const VIEWS: readonly ViewDef[] = [
     { id: 'overview', key: '1', label: 'Overview', hint: 'At a glance',         enabled: true  },
     { id: 'live',     key: '2', label: 'Live',     hint: 'Real-time scope',     enabled: true  },
-    { id: 'atlas',    key: '3', label: 'Atlas',    hint: 'Phase breakdown',     enabled: false },
+    { id: 'atlas',    key: '3', label: 'Atlas',    hint: 'Phase breakdown',     enabled: true  },
     { id: 'strata',   key: '4', label: 'Strata',   hint: 'Distribution',        enabled: false },
     { id: 'terminal', key: '5', label: 'Terminal', hint: 'Event log',           enabled: false },
     { id: 'lanes',    key: '6', label: 'Lanes',    hint: 'Glass lanes · legacy',enabled: true  },

--- a/src/lib/utils/verdict.ts
+++ b/src/lib/utils/verdict.ts
@@ -192,3 +192,67 @@ function mean(values: readonly number[]): number {
   for (const v of values) sum += v;
   return sum / values.length;
 }
+
+// ── Atlas phase-dominance hypothesis ───────────────────────────────────────
+// Single-endpoint diagnosis for AtlasView: given a 5-phase breakdown, name
+// the dominant phase (if any) in one sentence. Distinct from the network-wide
+// `computeCausalVerdict` above because this runs on one endpoint's tier2
+// averages, not across the fleet. Reuses PHASE_LABELS and Tier2Phase.
+//
+//   top > 60% of total  →  "Slow {phase} — N% of total time."
+//   top+2nd > 80%       →  "{A} and {B} dominate — N% together."
+//   neither              →  "No single phase dominates — investigate
+//                            overall network conditions."
+export interface PhaseBreakdown {
+  readonly dns: number;
+  readonly tcp: number;
+  readonly tls: number;
+  readonly ttfb: number;
+  readonly transfer: number;
+}
+
+export interface PhaseHypothesis {
+  readonly verdictPhase: Tier2Phase | 'mixed';
+  readonly text: string;
+  readonly dominantPct: number;
+}
+
+export function phaseHypothesis(phases: PhaseBreakdown): PhaseHypothesis {
+  const total = phases.dns + phases.tcp + phases.tls + phases.ttfb + phases.transfer;
+  if (total <= 0) {
+    return { verdictPhase: 'mixed', text: 'Awaiting tier-2 samples.', dominantPct: 0 };
+  }
+  const entries: [Tier2Phase, number][] = [
+    ['dns',      phases.dns],
+    ['tcp',      phases.tcp],
+    ['tls',      phases.tls],
+    ['ttfb',     phases.ttfb],
+    ['transfer', phases.transfer],
+  ];
+  // Sort descending by ms. Ties break by the declared order above (dns first),
+  // which is stable under Array.prototype.sort in modern V8/JSC.
+  entries.sort((a, b) => b[1] - a[1]);
+  const [topName, topMs] = entries[0];
+  const topPct = topMs / total;
+  if (topPct > 0.6) {
+    return {
+      verdictPhase: topName,
+      text: `Slow ${PHASE_LABELS[topName]} — ${Math.round(topPct * 100)}% of total time.`,
+      dominantPct: topPct,
+    };
+  }
+  const [secondName, secondMs] = entries[1];
+  const pairPct = (topMs + secondMs) / total;
+  if (pairPct > 0.8) {
+    return {
+      verdictPhase: 'mixed',
+      text: `${PHASE_LABELS[topName]} and ${PHASE_LABELS[secondName]} dominate — ${Math.round(pairPct * 100)}% together.`,
+      dominantPct: pairPct,
+    };
+  }
+  return {
+    verdictPhase: 'mixed',
+    text: 'No single phase dominates — investigate overall network conditions.',
+    dominantPct: 0,
+  };
+}

--- a/src/lib/utils/verdict.ts
+++ b/src/lib/utils/verdict.ts
@@ -215,12 +215,18 @@ export interface PhaseHypothesis {
   readonly verdictPhase: Tier2Phase | 'mixed';
   readonly text: string;
   readonly dominantPct: number;
+  // Phases that callers should visually emphasize. Empty on "no dominance",
+  // single-element on the top-phase branch, two-element on the pair branch.
+  // Consumers use membership (`includes`) rather than verdictPhase equality
+  // because the pair branch reports `verdictPhase: 'mixed'` but still has
+  // two concrete phases to highlight.
+  readonly dominantPhases: readonly Tier2Phase[];
 }
 
 export function phaseHypothesis(phases: PhaseBreakdown): PhaseHypothesis {
   const total = phases.dns + phases.tcp + phases.tls + phases.ttfb + phases.transfer;
   if (total <= 0) {
-    return { verdictPhase: 'mixed', text: 'Awaiting tier-2 samples.', dominantPct: 0 };
+    return { verdictPhase: 'mixed', text: 'Awaiting tier-2 samples.', dominantPct: 0, dominantPhases: [] };
   }
   const entries: [Tier2Phase, number][] = [
     ['dns',      phases.dns],
@@ -239,6 +245,7 @@ export function phaseHypothesis(phases: PhaseBreakdown): PhaseHypothesis {
       verdictPhase: topName,
       text: `Slow ${PHASE_LABELS[topName]} — ${Math.round(topPct * 100)}% of total time.`,
       dominantPct: topPct,
+      dominantPhases: [topName],
     };
   }
   const [secondName, secondMs] = entries[1];
@@ -248,11 +255,13 @@ export function phaseHypothesis(phases: PhaseBreakdown): PhaseHypothesis {
       verdictPhase: 'mixed',
       text: `${PHASE_LABELS[topName]} and ${PHASE_LABELS[secondName]} dominate — ${Math.round(pairPct * 100)}% together.`,
       dominantPct: pairPct,
+      dominantPhases: [topName, secondName],
     };
   }
   return {
     verdictPhase: 'mixed',
     text: 'No single phase dominates — investigate overall network conditions.',
     dominantPct: 0,
+    dominantPhases: [],
   };
 }

--- a/tests/unit/verdict.test.ts
+++ b/tests/unit/verdict.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { computeCausalVerdict, PHASE_LABELS, type VerdictRow } from '../../src/lib/utils/verdict';
+import {
+  computeCausalVerdict,
+  phaseHypothesis,
+  PHASE_LABELS,
+  type PhaseBreakdown,
+  type VerdictRow,
+} from '../../src/lib/utils/verdict';
 import type { Endpoint, EndpointStatistics } from '../../src/lib/types';
 
 // ── Fixture helpers ─────────────────────────────────────────────────────────
@@ -240,5 +246,55 @@ describe('PHASE_LABELS', () => {
     expect(PHASE_LABELS.tls).toBe('TLS handshake');
     expect(PHASE_LABELS.ttfb).toBe('TTFB');
     expect(PHASE_LABELS.transfer).toBe('Transfer');
+  });
+});
+
+// ── phaseHypothesis (Atlas single-endpoint diagnosis) ──────────────────────
+function mkPhases(over: Partial<PhaseBreakdown>): PhaseBreakdown {
+  return { dns: 0, tcp: 0, tls: 0, ttfb: 0, transfer: 0, ...over };
+}
+
+describe('phaseHypothesis()', () => {
+  it('returns "Awaiting tier-2 samples." when total is zero', () => {
+    const v = phaseHypothesis(mkPhases({}));
+    expect(v.verdictPhase).toBe('mixed');
+    expect(v.text).toBe('Awaiting tier-2 samples.');
+    expect(v.dominantPct).toBe(0);
+  });
+
+  it('flags a single-phase bottleneck when top > 60% of total', () => {
+    // TTFB is 180 of 254 total ≈ 71%.
+    const v = phaseHypothesis(mkPhases({ dns: 8, tcp: 22, tls: 34, ttfb: 180, transfer: 10 }));
+    expect(v.verdictPhase).toBe('ttfb');
+    expect(v.text).toBe('Slow TTFB — 71% of total time.');
+    expect(v.dominantPct).toBeCloseTo(0.708, 2);
+  });
+
+  it('flags top-pair dominance when top+2 > 80% of total', () => {
+    // dns=120, ttfb=80, rest=5+5+10 → top+2 = 200/220 ≈ 91%.
+    const v = phaseHypothesis(mkPhases({ dns: 120, tcp: 5, tls: 5, ttfb: 80, transfer: 10 }));
+    expect(v.verdictPhase).toBe('mixed');
+    expect(v.text).toBe('DNS and TTFB dominate — 91% together.');
+    expect(v.dominantPct).toBeGreaterThan(0.8);
+  });
+
+  it('falls through to "No single phase dominates" when spread is flat', () => {
+    const v = phaseHypothesis(mkPhases({ dns: 20, tcp: 20, tls: 20, ttfb: 20, transfer: 20 }));
+    expect(v.verdictPhase).toBe('mixed');
+    expect(v.text).toBe('No single phase dominates — investigate overall network conditions.');
+    expect(v.dominantPct).toBe(0);
+  });
+
+  it('ties break deterministically by declared phase order (dns wins dns=tcp)', () => {
+    const v = phaseHypothesis(mkPhases({ dns: 70, tcp: 70, tls: 5, ttfb: 5, transfer: 5 }));
+    // Top pair = dns + tcp = 140/155 ≈ 90% → pair branch cites DNS first.
+    expect(v.text).toContain('DNS and TCP handshake dominate');
+  });
+
+  it('single-phase totals report that phase at 100%', () => {
+    const v = phaseHypothesis(mkPhases({ ttfb: 250 }));
+    expect(v.verdictPhase).toBe('ttfb');
+    expect(v.text).toBe('Slow TTFB — 100% of total time.');
+    expect(v.dominantPct).toBe(1);
   });
 });

--- a/tests/unit/verdict.test.ts
+++ b/tests/unit/verdict.test.ts
@@ -260,6 +260,7 @@ describe('phaseHypothesis()', () => {
     expect(v.verdictPhase).toBe('mixed');
     expect(v.text).toBe('Awaiting tier-2 samples.');
     expect(v.dominantPct).toBe(0);
+    expect(v.dominantPhases).toEqual([]);
   });
 
   it('flags a single-phase bottleneck when top > 60% of total', () => {
@@ -268,6 +269,7 @@ describe('phaseHypothesis()', () => {
     expect(v.verdictPhase).toBe('ttfb');
     expect(v.text).toBe('Slow TTFB — 71% of total time.');
     expect(v.dominantPct).toBeCloseTo(0.708, 2);
+    expect(v.dominantPhases).toEqual(['ttfb']);
   });
 
   it('flags top-pair dominance when top+2 > 80% of total', () => {
@@ -276,6 +278,9 @@ describe('phaseHypothesis()', () => {
     expect(v.verdictPhase).toBe('mixed');
     expect(v.text).toBe('DNS and TTFB dominate — 91% together.');
     expect(v.dominantPct).toBeGreaterThan(0.8);
+    // Both cited phases must be in the emphasis set so the UI can highlight
+    // them via membership; verdictPhase === 'mixed' is not enough on its own.
+    expect(v.dominantPhases).toEqual(['dns', 'ttfb']);
   });
 
   it('falls through to "No single phase dominates" when spread is flat', () => {
@@ -283,6 +288,7 @@ describe('phaseHypothesis()', () => {
     expect(v.verdictPhase).toBe('mixed');
     expect(v.text).toBe('No single phase dominates — investigate overall network conditions.');
     expect(v.dominantPct).toBe(0);
+    expect(v.dominantPhases).toEqual([]);
   });
 
   it('ties break deterministically by declared phase order (dns wins dns=tcp)', () => {


### PR DESCRIPTION
## Summary

Atlas view replaces the Phase 1 stub for diagnostic drill-in. For the rail-focused endpoint: a 5-phase waterfall (DNS / TCP / TLS / Server / Transfer), a one-sentence phase hypothesis with evidence, and the last 8 samples as mini phase bars. Empty state prompts the user to click an endpoint in the Rail when nothing's focused. MEDIUM-risk, light mode.

## What shipped

- **`AtlasView.svelte`** — header (kicker + endpoint title + P50/P95 toggle + Back-to-Live), hero waterfall as a flex row of colored segments with in-bar labels when segment ≥ 8% wide and a subtle inset outline on the dominant phase, evidence card with colored phase pips + fill bar + pct (dominant row lifted to t1 + tinted background), sample strip as a `<table>` with mini 14px phase bars per row + totals on the right (timeout / error / no-tier2 fallbacks).
- **`verdict.ts`** — new `phaseHypothesis(phases)` for single-endpoint diagnosis (top>60% | top+2>80% | neither). Reuses `Tier2Phase` + `PHASE_LABELS` vocabulary from Phase 2.5. No new classifier; `classify.ts` untouched.
- **Routing + drill destination updates**:
  - `Layout.svelte` branches `activeView === 'atlas'` → `AtlasView`.
  - `ViewSwitcher` flips Atlas's `enabled: true`.
  - `OverviewView` Diagnose CTAs (Classic + Enriched) now route to `'atlas'` (were `'lanes'`).
  - `RacingStrip` shift-click now routes to `'atlas'`. Header hint updated to *"Click → Live · ⇧ → Atlas"*.

## Bundle delta

| | JS gzip | CSS gzip |
|---|---:|---:|
| Pre-Phase-4 | 73.57 KB | 12.43 KB |
| Phase 4 | **76.19 KB** | **13.24 KB** |
| Delta | **+2.62 KB** | **+0.81 KB** |

Total **+3.43 KB gzip**, well under the +15 KB Phase 4 budget.

## Non-negotiables checked

- **Rail is the only endpoint picker** — `AtlasView` reads `focusedEndpointId` and renders an empty-state prompt when null. No in-view picker.
- **verdict.ts reuse, no new classifier** — `phaseHypothesis` sits alongside `computeCausalVerdict` in the same file, shares `Tier2Phase` / `PHASE_LABELS`, takes the 5-phase breakdown directly. `classify.ts` unchanged.
- **Bundle delta < +15 KB gzip** ✓
- **Atlas ViewSwitcher button enabled** ✓
- **PATTERNS.md §3 (monitoredEndpoints)** — focused-endpoint resolution iterates `$monitoredEndpointsStore`; no raw `$endpointStore` read.
- **PATTERNS.md §2 (prefers-reduced-motion)** — only transitions are chip hovers and bar-segment brightness; both `@media (prefers-reduced-motion: reduce)` gated.

## Tests

775 / 775 pass. 6 new for `phaseHypothesis` (empty, single-phase bottleneck, top-pair dominance, flat distribution, tie-break ordering, single-phase totals).

## Screenshots

Follow-up comment — four states: P50 waterfall, P95 waterfall, TTFB-dominant anomaly, empty state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Atlas view, a new diagnostic interface displaying request waterfalls with phase breakdown (DNS, TCP, TLS, server response, transfer) for each endpoint
  * Added P50/P95 percentile mode switching within Atlas view
  * Enabled navigation to Atlas view through endpoint drilling and shift-click interactions on performance metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->