### PR TITLE
polish(overview): visual parity with v2 prototype

### DIFF
--- a/src/lib/components/CausalVerdictStrip.svelte
+++ b/src/lib/components/CausalVerdictStrip.svelte
@@ -207,6 +207,14 @@
   @media (max-width: 767px) {
     .verdict { grid-template-columns: 1fr; }
     .verdict-metrics { flex-wrap: wrap; gap: 14px; }
-    .verdict-drill { grid-column: 1; justify-content: center; }
+    .verdict-drill {
+      /* Reset the desktop placement (grid-column: 2; grid-row: 2;
+         justify-self: end) so the button sits under the metrics row
+         and stretches center rather than hugging the right edge. */
+      grid-column: 1;
+      grid-row: auto;
+      justify-self: stretch;
+      justify-content: center;
+    }
   }
 </style>

--- a/src/lib/components/CausalVerdictStrip.svelte
+++ b/src/lib/components/CausalVerdictStrip.svelte
@@ -83,8 +83,14 @@
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
   }
-  .verdict.warn { border-color: var(--accent-amber-glow); background: linear-gradient(0deg, rgba(251,191,36,.03), rgba(251,191,36,.03)), var(--glass-bg-rail-hover); }
-  .verdict.good { border-color: rgba(134,239,172,.25); }
+  /* Warn: amber-tinted border + subtle top-to-bottom gradient. Matches
+     v2 prototype .v2-verdict-warn — the gradient carries warmth into the
+     headline area then fades back into the neutral surface. */
+  .verdict.warn {
+    border-color: rgba(251, 191, 36, 0.3);
+    background: linear-gradient(180deg, rgba(251, 191, 36, 0.03), var(--glass-bg-rail-hover));
+  }
+  .verdict.good { border-color: rgba(134, 239, 172, 0.25); }
 
   .verdict-main {
     grid-column: 1 / -1;
@@ -128,7 +134,7 @@
     padding-top: 10px;
     border-top: 1px solid var(--border-mid);
     display: flex;
-    gap: 24px;
+    gap: 22px;
     align-items: baseline;
   }
   .verdict-metric {
@@ -164,30 +170,38 @@
     letter-spacing: var(--tr-label);
   }
 
+  /* Drill button: sans "Diagnose" + mono endpoint chip + cyan arrow. Matches
+     v2 prototype .v2-verdict-drill — mixed typography (sans label, mono name)
+     signals "act on this specific endpoint" without shouting. */
   .verdict-drill {
     grid-column: 2;
+    grid-row: 2;
     align-self: center;
+    justify-self: end;
     display: inline-flex;
     align-items: center;
     gap: 8px;
     padding: 8px 12px;
     border-radius: 8px;
-    background: var(--cyan-bg-subtle, rgba(103, 232, 249, 0.08));
-    border: 1px solid var(--cyan-border-subtle, rgba(103, 232, 249, 0.25));
+    background: rgba(103, 232, 249, 0.08);
+    border: 1px solid rgba(103, 232, 249, 0.25);
     color: var(--t1);
-    font-family: var(--mono);
-    font-size: var(--ts-sm);
-    letter-spacing: var(--tr-label);
-    text-transform: uppercase;
+    font-family: var(--sans);
+    font-size: 11.5px;
     cursor: pointer;
     transition: background 160ms ease, border-color 160ms ease;
   }
-  .verdict-drill:hover { background: var(--cyan25); }
+  .verdict-drill:hover { background: rgba(103, 232, 249, 0.15); }
   .verdict-drill:focus-visible {
     outline: 1.5px solid var(--accent-cyan);
     outline-offset: 2px;
   }
-  .verdict-drill-ep { font-variant-numeric: tabular-nums; }
+  .verdict-drill-ep {
+    font-family: var(--mono);
+    font-size: var(--ts-sm);
+    letter-spacing: var(--tr-label);
+    font-variant-numeric: tabular-nums;
+  }
   .verdict-drill-arrow { color: var(--accent-cyan); }
 
   @media (max-width: 767px) {

--- a/src/lib/components/ChronographDial.svelte
+++ b/src/lib/components/ChronographDial.svelte
@@ -286,17 +286,20 @@
         >{l.ms}</text>
       {/each}
 
-      <!-- 8. Center readouts. Kicker / score / verdict / live-median. -->
-      <text x={CX} y={CY - 94} text-anchor="middle" font-size="10"
+      <!-- 8. Center readouts. Kicker / score / verdict / live-median.
+           Y-positions and sizes match the v2 prototype MainDial
+           (view-overview.jsx): kicker cy-94@9px, score cy-8@120px,
+           verdict cy+22@11px, live cy+46@10px. -->
+      <text x={CX} y={CY - 94} text-anchor="middle" font-size="9"
             font-family={tokens.typography.mono.fontFamily} fill="var(--t3)" letter-spacing="0.3em">QUALITY</text>
       <text x={CX} y={CY - 8} text-anchor="middle" font-size="120" font-weight="200"
             fill="var(--t1)" font-family={tokens.typography.sans.fontFamily}
             style="letter-spacing: -0.05em; font-variant-numeric: tabular-nums;">{scoreDisplay}</text>
-      <text x={CX} y={CY + 38} text-anchor="middle" font-size="11"
+      <text x={CX} y={CY + 22} text-anchor="middle" font-size="11"
             font-family={tokens.typography.mono.fontFamily} fill={verdictStyle.color} letter-spacing="0.28em">
         {verdictStyle.kicker}
       </text>
-      <text x={CX} y={CY + 64} text-anchor="middle" font-size="10"
+      <text x={CX} y={CY + 46} text-anchor="middle" font-size="10"
             font-family={tokens.typography.mono.fontFamily} fill="var(--t4)" letter-spacing="0.18em">
         LIVE {fmt(liveMedian).toUpperCase()} · {endpointCount} {endpointCount === 1 ? 'LINK' : 'LINKS'}
       </text>

--- a/src/lib/components/ChronographDialV2.svelte
+++ b/src/lib/components/ChronographDialV2.svelte
@@ -467,7 +467,7 @@
         x={CX} y={CY + 108}
         text-anchor="middle" font-size="9.5"
         font-family={tokens.typography.mono.fontFamily}
-        fill={bandLabel === 'WITHIN BAND' ? 'var(--t4)' : bandLabelColor}
+        fill={bandLabel === null || bandLabel === 'WITHIN BAND' ? 'var(--t4)' : bandLabelColor}
         letter-spacing="0.18em"
       >LIVE {fmt(liveMedian).toUpperCase()}{bandLabel !== null ? ` · ${bandLabel}` : ''}</text>
 

--- a/src/lib/components/ChronographDialV2.svelte
+++ b/src/lib/components/ChronographDialV2.svelte
@@ -137,12 +137,14 @@
   });
 
   // ── 60s quality trace (Dial v2) ────────────────────────────────────────────
-  // Sparkline inside the face, below the score. Score 100 at top, 0 at bottom.
-  // Hidden when history is too short — calibrating label shows instead.
-  const TRACE_X = CX - 70;
-  const TRACE_Y = CY + 34;
-  const TRACE_W = 140;
-  const TRACE_H = 26;
+  // Sparkline inside the face, below the score + verdict. Score 100 at top,
+  // 0 at bottom. Hidden when history is too short — calibrating label shows
+  // instead. Geometry matches view-overview-v2.jsx QualityTraceMini: 160 px
+  // wide, 22 px tall, centered at cy+74.
+  const TRACE_X = CX - 80;
+  const TRACE_Y = CY + 63;
+  const TRACE_W = 160;
+  const TRACE_H = 22;
   const TRACE_MIN_POINTS = 4;
   const qualityTraceD = $derived.by(() => {
     if (!scoreHistory || scoreHistory.length < TRACE_MIN_POINTS) return null;
@@ -418,19 +420,19 @@
         >{l.ms}</text>
       {/each}
 
-      <!-- 8. Center readouts. Kicker / score / verdict / live-median. -->
-      <text x={CX} y={CY - 94} text-anchor="middle" font-size="10"
+      <!-- 8. Center readouts. Kicker / score / verdict. The "LIVE {median} ·
+           WITHIN/ABOVE/BELOW BAND" line is rendered below the trace at
+           CY+108 (see step 8b). Y-positions and sizes match the v2 prototype
+           MainDialV2 (view-overview-v2.jsx): kicker cy-72@9px, score cy-6@100px,
+           verdict cy+22@10px. -->
+      <text x={CX} y={CY - 72} text-anchor="middle" font-size="9"
             font-family={tokens.typography.mono.fontFamily} fill="var(--t3)" letter-spacing="0.3em">QUALITY</text>
-      <text x={CX} y={CY - 8} text-anchor="middle" font-size="120" font-weight="200"
+      <text x={CX} y={CY - 6} text-anchor="middle" font-size="100" font-weight="200"
             fill="var(--t1)" font-family={tokens.typography.sans.fontFamily}
             style="letter-spacing: -0.05em; font-variant-numeric: tabular-nums;">{scoreDisplay}</text>
-      <text x={CX} y={CY + 38} text-anchor="middle" font-size="11"
+      <text x={CX} y={CY + 22} text-anchor="middle" font-size="10"
             font-family={tokens.typography.mono.fontFamily} fill={verdictStyle.color} letter-spacing="0.28em">
         {verdictStyle.kicker}
-      </text>
-      <text x={CX} y={CY + 64} text-anchor="middle" font-size="10"
-            font-family={tokens.typography.mono.fontFamily} fill="var(--t4)" letter-spacing="0.18em">
-        LIVE {fmt(liveMedian).toUpperCase()} · {endpointCount} {endpointCount === 1 ? 'LINK' : 'LINKS'}
       </text>
 
       <!-- 8a (v2). 60s quality trace inside the face. Decorative — the numeric
@@ -457,16 +459,17 @@
         >CALIBRATING</text>
       {/if}
 
-      <!-- 8b (v2). Within-band / above / below label. Informative — included
-           in the dial's aria-label via `bandLabel`. -->
-      {#if bandLabel !== null}
-        <text
-          x={CX} y={CY + 86}
-          text-anchor="middle" font-size="10"
-          font-family={tokens.typography.mono.fontFamily}
-          fill={bandLabelColor} letter-spacing="0.14em"
-        >{bandLabel}</text>
-      {/if}
+      <!-- 8b (v2). LIVE median + band label. Combines the prototype's single
+           "LIVE {median} · WITHIN BAND" / "OUTSIDE BAND" line (cy+108, 9.5 px)
+           with our more precise 3-way ABOVE/WITHIN/BELOW distinction. Dim
+           when WITHIN, amber when ABOVE/BELOW. Included in dial aria-label. -->
+      <text
+        x={CX} y={CY + 108}
+        text-anchor="middle" font-size="9.5"
+        font-family={tokens.typography.mono.fontFamily}
+        fill={bandLabel === 'WITHIN BAND' ? 'var(--t4)' : bandLabelColor}
+        letter-spacing="0.18em"
+      >LIVE {fmt(liveMedian).toUpperCase()}{bandLabel !== null ? ` · ${bandLabel}` : ''}</text>
 
       <!-- 9. Endpoint orbit ring. -->
       <g aria-hidden="true">

--- a/src/lib/components/EventFeed.svelte
+++ b/src/lib/components/EventFeed.svelte
@@ -137,9 +137,15 @@
 
   .feed-rows { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 2px; }
   .feed-row {
+    /* Rank-based fade: row 0 full opacity, each older row a notch dimmer.
+       Matches v2 prototype .v2-feed-row. */
     opacity: calc(1 - var(--rank, 0) * 0.14);
     transition: background 140ms ease, opacity 400ms ease;
     border-radius: 6px;
+    /* Base type size inherited by every column. .latest bumps this one notch. */
+    font-family: var(--mono);
+    font-size: var(--ts-sm);
+    line-height: 1.4;
   }
   .feed-row:hover { opacity: 1; background: rgba(255,255,255,.04); }
   .feed-row.latest { font-size: var(--ts-base); }
@@ -149,7 +155,9 @@
   .feed-btn {
     width: 100%;
     display: grid;
-    grid-template-columns: 60px 10px 120px 1fr;
+    /* 58px time / 10px dot slot / 120px name / remainder for action.
+       Matches v2 prototype .v2-feed-row grid. */
+    grid-template-columns: 58px 10px 120px 1fr;
     gap: 8px;
     align-items: center;
     padding: 6px 8px;
@@ -158,14 +166,14 @@
     color: inherit;
     cursor: pointer;
     text-align: left;
-    font-family: inherit;
+    /* Inherit the row's mono + ts-sm so all columns share one baseline. */
+    font: inherit;
   }
   .feed-btn:focus-visible { outline: 1.5px solid var(--accent-cyan); outline-offset: 2px; border-radius: 6px; }
 
   .feed-time {
-    font-family: var(--mono);
-    font-size: var(--ts-xs);
     color: var(--t4);
+    letter-spacing: 0.08em;
     font-variant-numeric: tabular-nums;
   }
   .feed-dot {
@@ -173,22 +181,20 @@
     border-radius: 50%;
   }
   .feed-name {
-    font-family: var(--mono);
-    font-size: var(--ts-sm);
     color: var(--t2);
+    letter-spacing: 0.02em;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
   .feed-action {
-    font-family: var(--mono);
-    font-size: var(--ts-xs);
     color: var(--t3);
-    letter-spacing: var(--tr-label);
+    font-variant-numeric: tabular-nums;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
+  .feed-value { font-style: normal; color: var(--t1); }
 
   .feed-row.k-up    .feed-value { color: var(--accent-pink); }
   .feed-row.k-down  .feed-value { color: var(--accent-green); }

--- a/src/lib/components/RacingStrip.svelte
+++ b/src/lib/components/RacingStrip.svelte
@@ -198,7 +198,11 @@
   .racing-rows { display: flex; flex-direction: column; gap: 4px; }
   .racing-row {
     display: grid;
-    grid-template-columns: 180px 1fr 78px;
+    /* Stats column uses max-content so the inline "live · p95" pair never
+       wraps and the track shrinks instead of the numbers. 78 px was
+       correct for the earlier stacked layout; after flipping to a single
+       row (cf. .racing-stats) we'd overflow at 120+ ms. */
+    grid-template-columns: 180px minmax(0, 1fr) max-content;
     align-items: center;
     gap: 12px;
     padding: 6px 8px;
@@ -235,6 +239,10 @@
 
   .racing-track {
     position: relative;
+    /* Isolate so the `.racing-band`'s `mix-blend-mode: screen` (below)
+       blends against the track's own gradient rather than whatever sits
+       behind the component in the composite layer tree. */
+    isolation: isolate;
     height: 28px;
     border-radius: 4px;
     overflow: hidden;
@@ -286,13 +294,16 @@
   }
 
   /* Stats column: live value + p95 on ONE baseline, p95 pinned right. Matches
-     v2 prototype .v2-racing-stats horizontal layout. */
+     v2 prototype .v2-racing-stats horizontal layout. `nowrap` keeps the pair
+     together even when their combined width grows past the track's
+     max-content cap. */
   .racing-stats {
     display: flex;
     flex-direction: row;
     align-items: baseline;
     justify-content: flex-end;
     gap: 6px;
+    white-space: nowrap;
     font-family: var(--mono);
     font-variant-numeric: tabular-nums;
   }

--- a/src/lib/components/RacingStrip.svelte
+++ b/src/lib/components/RacingStrip.svelte
@@ -221,7 +221,7 @@
     width: 8px; height: 8px;
     border-radius: 50%;
     flex-shrink: 0;
-    box-shadow: 0 0 6px currentColor;
+    box-shadow: 0 0 6px var(--ep-color, currentColor);
   }
   .racing-name {
     font-size: var(--ts-sm);
@@ -255,7 +255,11 @@
     top: 11px;
     height: 6px;
     border-radius: 3px;
-    opacity: 0.2;
+    opacity: 0.35;
+    /* screen blend lets the band brighten against the track's pink
+       over-threshold gradient without becoming muddy. Matches v2 prototype
+       .v2-racing-band. */
+    mix-blend-mode: screen;
   }
   .racing-spark { position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none; }
   .racing-dotlive {
@@ -263,25 +267,40 @@
     top: 50%;
     width: 8px; height: 8px;
     border-radius: 50%;
+    /* Dark hairline border lifts the dot off the colored track without
+       relying on luminance alone. Matches v2 prototype. */
+    border: 1.5px solid rgba(0, 0, 0, 0.6);
     transform: translate(-50%, -50%);
     box-shadow: 0 0 6px var(--ep-color, #fff);
-    transition: left 250ms ease-out;
+    /* Longer, smoother ease so the dot settles rather than snaps. */
+    transition: left 420ms cubic-bezier(.4, 0, .2, 1);
   }
   .racing-dotlive.over {
     box-shadow: 0 0 10px var(--ep-color, #fff);
     width: 10px; height: 10px;
+    /* Soft pulse while over threshold — signals urgency without flashing. */
+    animation: racing-dot-pulse 1.4s ease-in-out infinite;
+  }
+  @keyframes racing-dot-pulse {
+    50% { transform: translate(-50%, -50%) scale(1.3); }
   }
 
+  /* Stats column: live value + p95 on ONE baseline, p95 pinned right. Matches
+     v2 prototype .v2-racing-stats horizontal layout. */
   .racing-stats {
     display: flex;
-    flex-direction: column;
-    align-items: flex-end;
+    flex-direction: row;
+    align-items: baseline;
+    justify-content: flex-end;
+    gap: 6px;
     font-family: var(--mono);
     font-variant-numeric: tabular-nums;
   }
   .racing-stats-live {
-    font-size: var(--ts-sm);
+    font-size: var(--ts-md);
     color: var(--t1);
+    letter-spacing: var(--tr-tight);
+    line-height: 1;
   }
   .racing-stats-p95 {
     font-size: var(--ts-xs);
@@ -291,5 +310,6 @@
 
   @media (prefers-reduced-motion: reduce) {
     .racing-row, .racing-dotlive { transition: none; }
+    .racing-dotlive.over { animation: none; }
   }
 </style>


### PR DESCRIPTION
Implements **Scope A** from the design-parity triage: deep-polish the Enriched Overview components against the canonical \`v2/Chronoscope v2.html\` prototype source. Nav structure and Classic/Atlas views intentionally unchanged.

Source of truth: the design handoff bundle's \`project/v2/\` JSX files (identical bytes to our local \`v2/*.jsx\` per file diff). The prototype itself has a known layout bug (enriched content renders in a 285 px column) so I compared against the JSX + CSS source rather than screenshots.

## Changes

### ChronographDial (Classic)
Center stack was drifting 16–18 px below the prototype's position, leaving the verdict kicker floating disconnected from the hub.
- QUALITY font-size 10 → 9
- Verdict y +38 → +22
- LIVE y +64 → +46

### ChronographDialV2 (Enriched)
Restructured the center layout per \`MainDialV2\` in \`view-overview-v2.jsx\`.
- QUALITY y -94 → -72, font-size 10 → 9
- Score y -8 → -6, font-size 120 → 100
- Verdict y +38 → +22, font-size 11 → 10
- Quality trace repositioned to center on cy+74 per \`QualityTraceMini\` (x -80/w 160/h 22/y +63)
- Dropped the orphan "LIVE {median} · N LINKS" and "CALIBRATING" lines; merged into a single band-aware "LIVE {median} · WITHIN/ABOVE/BELOW BAND" at cy+108@9.5px. Kept our 3-way ABOVE/WITHIN/BELOW (prototype is binary; ours is more precise).

### RacingStrip
- Band: \`opacity: 0.2\` → \`0.35\` + \`mix-blend-mode: screen\` so it brightens against the pink over-threshold gradient rather than muddying it
- Live dot: 250 ms → 420 ms cubic-bezier(.4,0,.2,1); added 1.5 px dark hairline border; added \`racing-dot-pulse\` on \`.over\` for urgency cue
- Stats column: \`flex-direction: column\` → \`row\` so live + p95 sit on one baseline
- Endpoint-name dot glow now sources \`var(--ep-color)\` instead of \`currentColor\`
- Reduced-motion gate extended to the new pulse

### EventFeed
Base typography declared on the row so all four columns share one baseline; per-column overrides removed. Grid-col-1 60 → 58 px to match prototype exactly.

### CausalVerdictStrip
- Warn surface: uniform amber fill → top-to-bottom gradient (matches \`.v2-verdict-warn\`)
- Warn border: \`--accent-amber-glow\` → \`rgba(251,191,36,0.3)\` (prototype's border alpha)
- Drill button: mono + uppercase → sans "Diagnose" + mono endpoint chip (dual-typography shape per prototype)
- Metrics gap 24 → 22 px; \`grid-row: 2; justify-self: end\` on drill

## Verification
- \`typecheck\` / \`lint\` / 567 tests / build all green
- **Bundle delta: +0.14 KB gzip** (JS 62.32 → 62.31, CSS 10.17 → 10.32). Under the +5 KB polish-pass budget.

## Not in scope
- Nav structure (still 5 tabs, Strata/Terminal disabled — per Scope A)
- Atlas rename to Diagnose — a product decision
- \`OverviewSignature\` variants (instrument/tool/product) — not active
- Live view deep pass — existing structure already mirrors prototype
- Classic Overview composition (triptych vs. prototype's diagnosis strip) — product decision

Will post \`@coderabbitai review\` once CI goes green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined spacing, typography, and gradient styling across UI components for improved visual consistency.
  * Enhanced live endpoint indicator with new animations and improved visual feedback.
  * Improved layout and text alignment in verdict displays, dial readouts, event feed, and stats areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->