### PR TITLE
feat(parity-1): rename Atlas → Diagnose + tab subs to question-form

### DIFF
--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -73,7 +73,7 @@
       <main id="main-content" class="shell-main" tabindex="-1">
         {#if activeView === 'live'}
           <LiveView />
-        {:else if activeView === 'atlas'}
+        {:else if activeView === 'diagnose'}
           <AtlasView />
         {:else}
           <!--

--- a/src/lib/components/OverviewView.svelte
+++ b/src/lib/components/OverviewView.svelte
@@ -238,7 +238,7 @@
 
   function handleEnrichedDrill(epId: string): void {
     uiStore.setFocusedEndpoint(epId);
-    uiStore.setActiveView('atlas');
+    uiStore.setActiveView('diagnose');
   }
 
   function handleEventDrill(epId: string): void {

--- a/src/lib/components/RacingStrip.svelte
+++ b/src/lib/components/RacingStrip.svelte
@@ -87,7 +87,7 @@
       <h3 class="racing-title">Per-endpoint comparison</h3>
       <p class="racing-sub">Live latencies on shared axis</p>
     </div>
-    <p class="racing-hint">Click → Live · ⇧ → Atlas</p>
+    <p class="racing-hint">Click → Live · ⇧ → Diagnose</p>
   </header>
 
   <div class="racing-axis" aria-hidden="true">

--- a/src/lib/components/RacingStrip.svelte
+++ b/src/lib/components/RacingStrip.svelte
@@ -76,8 +76,8 @@
 
   function handleClick(event: MouseEvent, ep: Endpoint): void {
     uiStore.setFocusedEndpoint(ep.id);
-    // Click → Live; Shift+click → Atlas (diagnose).
-    uiStore.setActiveView(event.shiftKey ? 'atlas' : 'live');
+    // Click → Live; Shift+click → Diagnose (the per-phase waterfall view).
+    uiStore.setActiveView(event.shiftKey ? 'diagnose' : 'live');
   }
 </script>
 

--- a/src/lib/components/ViewSwitcher.svelte
+++ b/src/lib/components/ViewSwitcher.svelte
@@ -1,8 +1,9 @@
 <!-- src/lib/components/ViewSwitcher.svelte -->
 <!-- Five-tab view picker. Sits below the topbar, above the main content area. -->
-<!-- Overview / Live / Atlas are shipped; Strata / Terminal stay               -->
+<!-- Overview / Live / Diagnose are shipped; Strata / Terminal stay            -->
 <!-- disabled-with-tooltip until their prototypes land (issues #50, #51).      -->
-<!-- The Lanes tab was retired in Phase 7.                                     -->
+<!-- The Lanes tab was retired in Phase 7. Atlas was renamed to Diagnose at    -->
+<!-- v9 to align with the v2 prototype vocabulary.                             -->
 <script lang="ts">
   import { uiStore } from '$lib/stores/ui';
   import type { ActiveView } from '$lib/types';

--- a/src/lib/components/ViewSwitcher.svelte
+++ b/src/lib/components/ViewSwitcher.svelte
@@ -16,12 +16,14 @@
   }
 
   // Visible label list. Order matches the prototype's left-to-right reading.
+  // Subs use the prototype's question-form hints (`shell.jsx:4–8` of the v2
+  // bundle): each tab's sub answers the question that view exists to answer.
   const VIEWS: readonly ViewDef[] = [
-    { id: 'overview', key: '1', label: 'Overview', hint: 'At a glance',     enabled: true  },
-    { id: 'live',     key: '2', label: 'Live',     hint: 'Real-time scope', enabled: true  },
-    { id: 'atlas',    key: '3', label: 'Atlas',    hint: 'Phase breakdown', enabled: true  },
-    { id: 'strata',   key: '4', label: 'Strata',   hint: 'Distribution',    enabled: false },
-    { id: 'terminal', key: '5', label: 'Terminal', hint: 'Event log',       enabled: false },
+    { id: 'overview', key: '1', label: 'Overview', hint: 'Is everything okay?',         enabled: true  },
+    { id: 'live',     key: '2', label: 'Live',     hint: "What's happening right now?", enabled: true  },
+    { id: 'diagnose', key: '3', label: 'Diagnose', hint: 'Why is it slow?',             enabled: true  },
+    { id: 'strata',   key: '4', label: 'Strata',   hint: 'How is the distribution?',    enabled: false },
+    { id: 'terminal', key: '5', label: 'Terminal', hint: "What's in the log?",          enabled: false },
   ];
 
   const DISABLED_TOOLTIP = 'Prototype in progress — not yet available.';

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -161,7 +161,7 @@ export interface EndpointStatistics {
     contentTransfer: number;
   };
   // Per-phase p95 — fed by the same cadence as tier2Averages. Needed for
-  // Atlas view's P50/P95 toggle. Optional to mirror tier2Averages semantics
+  // Diagnose view's P50/P95 toggle. Optional to mirror tier2Averages semantics
   // (absent when no tier-2 samples have been captured yet).
   readonly tier2P95?: {
     dnsLookup: number;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -208,13 +208,14 @@ export const DEFAULT_SETTINGS: Settings = {
 };
 
 // ── UI store ───────────────────────────────────────────────────────────────
-// v2 view union — post-Phase-7 shape. The Lanes family ('lanes' | 'timeline'
-// | 'heatmap' | 'split') has been retired. Persisted payloads carrying any of
-// those values collapse to 'overview' via stepV6toV7 in persistence.ts.
+// v2 view union — post-Phase-7 (Lanes retired) and post-v9 (Atlas renamed
+// to Diagnose to match the v2 prototype vocabulary). Persisted payloads
+// with retired values are coerced/renamed by stepV6toV7 (Lanes family →
+// 'overview') and stepV8toV9 ('atlas' → 'diagnose') in persistence.ts.
 export type ActiveView =
   | 'overview'
   | 'live'
-  | 'atlas'
+  | 'diagnose'
   | 'strata'
   | 'terminal';
 
@@ -296,11 +297,12 @@ export interface SharePayload {
 // v7 retires the Lanes view family (collapses 'lanes'/'timeline'/'heatmap'/
 // 'split' activeView values to 'overview'). v8 retires
 // `settings.overviewMode` — the Classic dial was dropped; Overview is a
-// single layout now.
+// single layout. v9 renames `activeView: 'atlas'` to `'diagnose'` to align
+// with the v2 prototype vocabulary.
 // Older versions migrate forward via persistence.ts. Sets serialize as arrays
 // on disk; `ui.terminalFilters` round-trips accordingly.
 export interface PersistedSettings {
-  version: 2 | 3 | 4 | 5 | 6 | 7 | 8;
+  version: 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
   endpoints: { url: string; enabled: boolean }[];
   settings: Settings;
   ui: {

--- a/src/lib/utils/persistence.ts
+++ b/src/lib/utils/persistence.ts
@@ -259,7 +259,7 @@ function stepV8toV9(v8: LegacyPersistedSettings): PersistedSettings {
   let activeView: ActiveView;
   if (incoming === 'atlas') {
     console.debug(
-      `[Chronoscope] v9 migration: activeView 'atlas' renamed to 'diagnose'.`,
+      "[Chronoscope] v9 migration: activeView 'atlas' renamed to 'diagnose'.",
     );
     activeView = 'diagnose';
   } else if (V9_VIEWS.has(incoming)) {

--- a/src/lib/utils/persistence.ts
+++ b/src/lib/utils/persistence.ts
@@ -621,8 +621,10 @@ function normalizeV8(record: Record<string, unknown>): LegacyPersistedSettings |
 function normalizeV9(record: Record<string, unknown>): PersistedSettings | null {
   try {
     const rawUi = asRecord(record['ui']) ?? {};
-    const view = readActiveView(rawUi, V9_VIEWS);
-    const activeView: ActiveView = V9_VIEWS.has(view) ? (view as ActiveView) : 'overview';
+    // readActiveView returns either a value in V9_VIEWS or the literal
+    // 'overview' (also in V9_VIEWS), so the result is always in the union —
+    // the `as ActiveView` cast carries the narrowing TS can't prove.
+    const activeView = readActiveView(rawUi, V9_VIEWS) as ActiveView;
     return {
       version: 9,
       endpoints: readEndpointsField(record),

--- a/src/lib/utils/persistence.ts
+++ b/src/lib/utils/persistence.ts
@@ -1,21 +1,22 @@
 // src/lib/utils/persistence.ts
 // Versioned localStorage persistence with forward-only migration support.
 //
-// Migration chain: v1 → v2 → v3 → v4 → v5 → v6 → v7 → v8 (current). Each
-// normalizeVN shapes a payload at version N; migrateSettings threads older
-// payloads through the chain up to CURRENT_VERSION. Never re-read a newer
-// version in an older build.
+// Migration chain: v1 → v2 → v3 → v4 → v5 → v6 → v7 → v8 → v9 (current).
+// Each normalizeVN shapes a payload at version N; migrateSettings threads
+// older payloads through the chain up to CURRENT_VERSION. Never re-read a
+// newer version in an older build.
 //
 // Phase 7 (v6 → v7): retired the Lanes family of views. Any persisted
 // `activeView` in {'lanes', 'timeline', 'heatmap', 'split'} collapses to
 // 'overview'.
 //
-// v7 → v8 (this release): drops `settings.overviewMode`. The Classic dial
-// has been retired; there is only one Overview mode now (the former
-// "enriched"), so the toggle is no longer meaningful. stepV7toV8 is the only
-// thing keeping a returning "classic" user from having an unused field
-// linger in their persisted blob; it also debug-logs the drop so support
-// can correlate a returning user's session.
+// v7 → v8: dropped `settings.overviewMode`. The Classic dial was retired;
+// only one Overview mode remained.
+//
+// v8 → v9 (this release): renames the Atlas view to Diagnose to align with
+// the v2 prototype vocabulary. `activeView: 'atlas'` rewrites to 'diagnose'
+// with a debug-log breadcrumb so a returning Atlas user's session leaves a
+// trace. The view's content is unchanged — only the routing key + label.
 
 import { DEFAULT_SETTINGS } from '../types';
 import { detectRegion, isValidRegion } from '../regional-defaults';
@@ -30,7 +31,7 @@ import type { Region } from '../regional-defaults';
 
 const STORAGE_KEY = 'chronoscope_settings'; // skipcq: JS-0860 — localStorage key, not a credential
 const LEGACY_STORAGE_KEY = 'chronoscope_v2_settings'; // skipcq: JS-0860 — localStorage key, not a credential
-export const CURRENT_VERSION = 8;
+export const CURRENT_VERSION = 9;
 
 // v6/v7-era overview mode vocabulary. Retained as a literal set because the
 // OverviewMode type has been removed from public Settings at v8 — these
@@ -51,11 +52,18 @@ const V5_VIEWS: ReadonlySet<string> = new Set([
   'timeline', 'heatmap', 'split',
 ]);
 
-// Views valid at v7 (post-Phase-7). Lanes and its aliases are retired.
-// Typed as string-set so the legacy intermediate activeView can be tested
-// for membership without casts; all five values are still in ActiveView.
-const V7_VIEWS: ReadonlySet<string> = new Set<ActiveView>([
+// Views valid at the v7/v8 boundary (pre-rename). Includes 'atlas' since v8
+// payloads still carry it; stepV8toV9 rewrites it to 'diagnose'. Typed as
+// string-set so the legacy intermediate activeView can be tested for
+// membership without casts.
+const V7_VIEWS: ReadonlySet<string> = new Set([
   'overview', 'live', 'atlas', 'strata', 'terminal',
+]);
+
+// Views valid at v9 (post-Atlas-rename). 'atlas' replaced by 'diagnose'.
+// All five values are in the public ActiveView union.
+const V9_VIEWS: ReadonlySet<string> = new Set<ActiveView>([
+  'overview', 'live', 'diagnose', 'strata', 'terminal',
 ]);
 
 // Views v7 treats as "legacy Lanes family" — rewritten to 'overview' on
@@ -64,12 +72,13 @@ const V7_LEGACY_LANES_VIEWS: ReadonlySet<string> = new Set([
   'lanes', 'timeline', 'heatmap', 'split',
 ]);
 
-// Intermediate activeView type used inside the pre-v7 chain. The public
-// ActiveView union no longer contains the Lanes family, but stages v4→v5,
-// v5→v6, and the v6 shape may still carry those strings until stepV6toV7
-// collapses them. Keeping this as a file-local widening avoids leaking the
-// legacy strings into PersistedSettings consumers.
-type LegacyActiveView = ActiveView | 'lanes' | 'timeline' | 'heatmap' | 'split';
+// Intermediate activeView type used inside the pre-v9 chain. The public
+// ActiveView union no longer contains the Lanes family OR 'atlas', but
+// stages v4→v5/v5→v6/v6→v7/v7→v8/v8→v9 may still carry those strings until
+// stepV6toV7 collapses Lanes and stepV8toV9 renames atlas. Keeping this as
+// a file-local widening avoids leaking the legacy strings into
+// PersistedSettings consumers.
+type LegacyActiveView = ActiveView | 'atlas' | 'lanes' | 'timeline' | 'heatmap' | 'split';
 
 // Intermediate Settings used inside the pre-v8 chain. v6/v7 payloads carry
 // `overviewMode`; the public v8 Settings no longer has the field. stepV7toV8
@@ -128,18 +137,26 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
   const record = data as Record<string, unknown>;
   const version = typeof record['version'] === 'number' ? record['version'] : 0;
 
-  if (version === CURRENT_VERSION) return normalizeV8(record);
+  if (version === CURRENT_VERSION) return normalizeV9(record);
+
+  if (version === 8) {
+    const v8 = normalizeV8(record);
+    return v8 ? stepV8toV9(v8) : null;
+  }
 
   if (version === 7) {
     const v7 = normalizeV7(record);
-    return v7 ? stepV7toV8(v7) : null;
+    if (!v7) return null;
+    const v8 = stepV7toV8(v7);
+    return stepV8toV9(v8);
   }
 
   if (version === 6) {
     const v6 = normalizeV6(record);
     if (!v6) return null;
     const v7 = stepV6toV7(v6);
-    return stepV7toV8(v7);
+    const v8 = stepV7toV8(v7);
+    return stepV8toV9(v8);
   }
 
   if (version === 5) {
@@ -147,7 +164,8 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
     if (!v5) return null;
     const v6 = stepV5toV6(v5, record);
     const v7 = stepV6toV7(v6);
-    return stepV7toV8(v7);
+    const v8 = stepV7toV8(v7);
+    return stepV8toV9(v8);
   }
 
   if (version === 4) {
@@ -156,7 +174,8 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
     const v5 = stepV4toV5(v4, record);
     const v6 = stepV5toV6(v5, record);
     const v7 = stepV6toV7(v6);
-    return stepV7toV8(v7);
+    const v8 = stepV7toV8(v7);
+    return stepV8toV9(v8);
   }
 
   if (version === 3) {
@@ -170,7 +189,8 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
     const v5 = stepV4toV5(v4, record);
     const v6 = stepV5toV6(v5, record);
     const v7 = stepV6toV7(v6);
-    return stepV7toV8(v7);
+    const v8 = stepV7toV8(v7);
+    return stepV8toV9(v8);
   }
 
   if (version === 2) {
@@ -195,7 +215,8 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
     const v5 = stepV4toV5(v4, record);
     const v6 = stepV5toV6(v5, record);
     const v7 = stepV6toV7(v6);
-    return stepV7toV8(v7);
+    const v8 = stepV7toV8(v7);
+    return stepV8toV9(v8);
   }
 
   if (version === 1) {
@@ -216,13 +237,44 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
     const v5 = stepV4toV5(v4, record);
     const v6 = stepV5toV6(v5, record);
     const v7 = stepV6toV7(v6);
-    return stepV7toV8(v7);
+    const v8 = stepV7toV8(v7);
+    return stepV8toV9(v8);
   }
 
   // Unknown version — return null (triggers first-install path). We deliberately
   // do NOT coerce through the current normalizer; that would silently drop
   // future shape changes we don't understand yet.
   return null;
+}
+
+// ── v8 → v9 step ─────────────────────────────────────────────────────────────
+// Renames the Atlas view to Diagnose to align with the v2 prototype. Any
+// persisted `activeView: 'atlas'` rewrites to `'diagnose'`. The view's
+// content is unchanged — only the routing key + label. Debug-log so a
+// returning Atlas user's session leaves a breadcrumb. Also performs the
+// final activeView narrow into the v9 ActiveView union (which doesn't
+// include 'atlas').
+function stepV8toV9(v8: LegacyPersistedSettings): PersistedSettings {
+  const incoming = v8.ui.activeView;
+  let activeView: ActiveView;
+  if (incoming === 'atlas') {
+    console.debug(
+      `[Chronoscope] v9 migration: activeView 'atlas' renamed to 'diagnose'.`,
+    );
+    activeView = 'diagnose';
+  } else if (V9_VIEWS.has(incoming)) {
+    activeView = incoming as ActiveView;
+  } else {
+    // Stray pre-v8 value (Lanes family, etc.) shouldn't reach here because
+    // stepV6toV7 collapses them, but coerce defensively to 'overview'.
+    activeView = 'overview';
+  }
+  return {
+    version: 9,
+    endpoints: v8.endpoints,
+    settings: v8.settings as Settings,
+    ui: { ...v8.ui, activeView },
+  };
 }
 
 // ── v7 → v8 step ─────────────────────────────────────────────────────────────
@@ -232,7 +284,12 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
 // had a mode set (which is every v6/v7 payload, since stepV5toV6 seeds it),
 // debug-log the drop so support can correlate a returning Classic user's
 // session. Payloads that never had the field (edge case) stay silent.
-function stepV7toV8(v7: LegacyPersistedSettings): PersistedSettings {
+//
+// Returns LegacyPersistedSettings (not PersistedSettings) so `activeView:
+// 'atlas'` can survive through to stepV8toV9, which is the boundary that
+// renames it. Without that, v6/v7 payloads with 'atlas' would be coerced
+// to 'overview' here and lose the meaningful breadcrumb.
+function stepV7toV8(v7: LegacyPersistedSettings): LegacyPersistedSettings {
   const droppedMode = v7.settings.overviewMode;
   if (droppedMode !== undefined) {
     console.debug(
@@ -243,16 +300,11 @@ function stepV7toV8(v7: LegacyPersistedSettings): PersistedSettings {
   // signals "intentionally unused" and keeps the drop auditable at a glance.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { overviewMode: _dropped, ...cleanSettings } = v7.settings;
-  // Narrow activeView: stepV6toV7 already collapsed the Lanes family to
-  // 'overview', so any incoming value must be in V7_VIEWS. Re-check defensively
-  // and fall through to 'overview' for a corrupt/hand-edited payload.
-  const incomingView = v7.ui.activeView;
-  const activeView: ActiveView = V7_VIEWS.has(incomingView) ? (incomingView as ActiveView) : 'overview';
   return {
     version: 8,
     endpoints: v7.endpoints,
     settings: cleanSettings,
-    ui: { ...v7.ui, activeView },
+    ui: v7.ui,
   };
 }
 
@@ -536,17 +588,43 @@ function normalizeV7(record: Record<string, unknown>): LegacyPersistedSettings |
   }
 }
 
-// v8 is the public shape — `settings` has no overviewMode, activeView is
-// narrow. The single new Settings delta is the absence of the Classic dial
-// toggle. A stray 'classic'/'enriched' value in a hand-edited v8 payload is
-// simply ignored (readSettingsField doesn't read it).
-function normalizeV8(record: Record<string, unknown>): PersistedSettings | null {
+// v8 — `settings` has no overviewMode, activeView still includes 'atlas'
+// because v8 was the last version to use that name. Returns
+// LegacyPersistedSettings so stepV8toV9 can rename 'atlas' → 'diagnose'
+// at the v9 boundary.
+function normalizeV8(record: Record<string, unknown>): LegacyPersistedSettings | null {
   try {
     const rawUi = asRecord(record['ui']) ?? {};
-    const view = readActiveView(rawUi, V7_VIEWS);
-    const activeView: ActiveView = V7_VIEWS.has(view) ? (view as ActiveView) : 'overview';
     return {
       version: 8,
+      endpoints: readEndpointsField(record),
+      // readSettingsField returns Settings (no overviewMode); LegacySettings
+      // is structurally a superset (overviewMode is optional), so the
+      // assignment is widening — no information loss.
+      settings: readSettingsField(record),
+      ui: {
+        expandedCards:     readExpandedCards(rawUi),
+        activeView:        readActiveView(rawUi, V7_VIEWS),
+        focusedEndpointId: readFocusedEndpointId(rawUi),
+        liveOptions:       readLiveOptions(rawUi),
+        terminalFilters:   readTerminalFilters(rawUi),
+      },
+    };
+  } catch {
+    return null;
+  }
+}
+
+// v9 is the public shape — activeView in V9_VIEWS (no 'atlas').
+// A hand-edited v9 payload with 'atlas' coerces to 'overview' here
+// (stepV8toV9 doesn't run on a v9-tagged payload).
+function normalizeV9(record: Record<string, unknown>): PersistedSettings | null {
+  try {
+    const rawUi = asRecord(record['ui']) ?? {};
+    const view = readActiveView(rawUi, V9_VIEWS);
+    const activeView: ActiveView = V9_VIEWS.has(view) ? (view as ActiveView) : 'overview';
+    return {
+      version: 9,
       endpoints: readEndpointsField(record),
       settings: readSettingsField(record),
       ui: {

--- a/tests/unit/persistence.test.ts
+++ b/tests/unit/persistence.test.ts
@@ -20,7 +20,7 @@ describe('persistence', () => {
     expect(loadPersistedSettings()).toBeNull();
   });
 
-  it('round-trips v3 settings into current v8 shape', () => {
+  it('round-trips v3 settings into current v9 shape', () => {
     const settings = {
       version: 3,
       endpoints: [{ url: 'https://example.com', enabled: true }],
@@ -58,7 +58,7 @@ describe('persistence', () => {
     expect(localStorageMock.getItem('chronoscope_settings')).not.toBeNull();
   });
 
-  it('migrates v1 data all the way to v8', () => {
+  it('migrates v1 data all the way to v9', () => {
     const v1Data = { version: 1, endpoints: [{ url: 'https://example.com' }] };
     const migrated = migrateSettings(v1Data);
     expect(migrated?.version).toBe(9);
@@ -69,7 +69,7 @@ describe('persistence', () => {
     expect(migrated?.ui.activeView).toBe('overview');
   });
 
-  it('migrates v2 data to v8 with old delay as monitorDelay', () => {
+  it('migrates v2 data to v9 with old delay as monitorDelay', () => {
     const v2Data = {
       version: 2,
       endpoints: [{ url: 'https://example.com', enabled: true }],
@@ -82,11 +82,11 @@ describe('persistence', () => {
     expect(migrated?.settings.burstRounds).toBe(50);
     expect(migrated?.settings.delay).toBe(0);
     expect(migrated?.settings.healthThreshold).toBe(120);
-    // v2 'split' → v5 'lanes' → v7 'overview' → v8 still 'overview'.
+    // v2 'split' → v5 'lanes' → v7 'overview' → v9 still 'overview'.
     expect(migrated?.ui.activeView).toBe('overview');
   });
 
-  describe('v4 → v5 → v6 → v7 → v8 migration (chain)', () => {
+  describe('v4 → v9 migration (chain)', () => {
     it('seeds healthThreshold default on a real v4 payload', () => {
       const v4: unknown = {
         version: 4,
@@ -159,7 +159,7 @@ describe('persistence', () => {
     });
   });
 
-  describe('v5 → v8 migration', () => {
+  describe('v5 → v9 migration', () => {
     it('preserves modern v5 fields and strips overviewMode at v8', () => {
       const v5: unknown = {
         version: 5,

--- a/tests/unit/persistence.test.ts
+++ b/tests/unit/persistence.test.ts
@@ -29,7 +29,7 @@ describe('persistence', () => {
     };
     saveSettings(settings as unknown as PersistedSettings);
     const loaded = loadPersistedSettings();
-    expect(loaded?.version).toBe(8);
+    expect(loaded?.version).toBe(9);
     expect(loaded?.endpoints[0]?.url).toBe('https://example.com');
     expect(loaded?.settings.burstRounds).toBe(50);
     expect(loaded?.settings.monitorDelay).toBe(1000);
@@ -53,7 +53,7 @@ describe('persistence', () => {
     };
     localStorageMock.setItem('chronoscope_v2_settings', JSON.stringify(settings));
     const loaded = loadPersistedSettings();
-    expect(loaded?.version).toBe(8);
+    expect(loaded?.version).toBe(9);
     expect(localStorageMock.getItem('chronoscope_v2_settings')).toBeNull();
     expect(localStorageMock.getItem('chronoscope_settings')).not.toBeNull();
   });
@@ -61,7 +61,7 @@ describe('persistence', () => {
   it('migrates v1 data all the way to v8', () => {
     const v1Data = { version: 1, endpoints: [{ url: 'https://example.com' }] };
     const migrated = migrateSettings(v1Data);
-    expect(migrated?.version).toBe(8);
+    expect(migrated?.version).toBe(9);
     expect(migrated?.settings.burstRounds).toBe(50);
     expect(migrated?.settings.monitorDelay).toBe(1000);
     expect(migrated?.settings.healthThreshold).toBe(120);
@@ -77,7 +77,7 @@ describe('persistence', () => {
       ui: { expandedCards: [], activeView: 'split' },
     };
     const migrated = migrateSettings(v2Data);
-    expect(migrated?.version).toBe(8);
+    expect(migrated?.version).toBe(9);
     expect(migrated?.settings.monitorDelay).toBe(500);
     expect(migrated?.settings.burstRounds).toBe(50);
     expect(migrated?.settings.delay).toBe(0);
@@ -103,7 +103,7 @@ describe('persistence', () => {
         ui: { expandedCards: ['ep-1'], activeView: 'split' },
       };
       const migrated = migrateSettings(v4);
-      expect(migrated?.version).toBe(8);
+      expect(migrated?.version).toBe(9);
       expect(migrated?.settings.healthThreshold).toBe(120);
       expect(migrated?.settings.region).toBe('north-america');
       expect('overviewMode' in (migrated?.settings ?? {})).toBe(false);
@@ -178,7 +178,7 @@ describe('persistence', () => {
         },
       };
       const migrated = migrateSettings(v5);
-      expect(migrated?.version).toBe(8);
+      expect(migrated?.version).toBe(9);
       expect('overviewMode' in (migrated?.settings ?? {})).toBe(false);
       // Existing v5 fields survive intact.
       expect(migrated?.settings.healthThreshold).toBe(180);
@@ -238,7 +238,7 @@ describe('persistence', () => {
           ui: { expandedCards: [], activeView: 'overview' },
         };
         const migrated = migrateSettings(v7);
-        expect(migrated?.version).toBe(8);
+        expect(migrated?.version).toBe(9);
         expect('overviewMode' in (migrated?.settings ?? {})).toBe(false);
         expect(debugSpy).toHaveBeenCalledWith(
           expect.stringMatching(/v8 migration: settings\.overviewMode 'enriched' retired/),
@@ -261,7 +261,7 @@ describe('persistence', () => {
           ui: { expandedCards: [], activeView: 'live' },
         };
         const migrated = migrateSettings(v7);
-        expect(migrated?.version).toBe(8);
+        expect(migrated?.version).toBe(9);
         expect(migrated?.ui.activeView).toBe('live');
         expect(debugSpy).not.toHaveBeenCalled();
       } finally {
@@ -270,10 +270,10 @@ describe('persistence', () => {
     });
   });
 
-  describe('v8 pass-through', () => {
-    it('round-trips a v8 payload unchanged', () => {
-      const v8: PersistedSettings = {
-        version: 8,
+  describe('v9 pass-through', () => {
+    it('round-trips a v9 payload unchanged', () => {
+      const v9: PersistedSettings = {
+        version: 9,
         endpoints: [{ url: 'https://a.example', enabled: true }],
         settings: {
           timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000,
@@ -287,9 +287,9 @@ describe('persistence', () => {
           terminalFilters: ['timeout', 'error'],
         },
       };
-      saveSettings(v8);
+      saveSettings(v9);
       const loaded = loadPersistedSettings();
-      expect(loaded).toEqual(v8);
+      expect(loaded).toEqual(v9);
     });
 
     it('a stray overviewMode in a v8 payload is silently ignored by the reader', () => {

--- a/tests/unit/utils/persistence-migration.test.ts
+++ b/tests/unit/utils/persistence-migration.test.ts
@@ -13,8 +13,8 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('migrateSettings — full chain through v8', () => {
-  it('v3 → v8: region from detectRegion(), healthThreshold default, overviewMode dropped', () => {
+describe('migrateSettings — full chain through v9', () => {
+  it('v3 → v9: region from detectRegion(), healthThreshold default, overviewMode dropped', () => {
     const v3 = {
       version: 3,
       endpoints: [{ url: 'https://example.com', enabled: true }],
@@ -31,7 +31,7 @@ describe('migrateSettings — full chain through v8', () => {
     expect(result?.ui.activeView).toBe('overview');
   });
 
-  it('v4 → v8 (four hops): preserves region, seeds healthThreshold, drops overviewMode', () => {
+  it('v4 → v9 (five hops): preserves region, seeds healthThreshold, drops overviewMode', () => {
     const v4 = {
       version: 4,
       endpoints: [{ url: 'https://example.com', enabled: true }],
@@ -45,7 +45,7 @@ describe('migrateSettings — full chain through v8', () => {
     expect('overviewMode' in (result?.settings ?? {})).toBe(false);
   });
 
-  it('v4 payload with invalid region string strips the field on the way to v8', () => {
+  it('v4 payload with invalid region string strips the field on the way to v9', () => {
     const v4 = {
       version: 4,
       endpoints: [],
@@ -68,7 +68,7 @@ describe('migrateSettings — full chain through v8', () => {
     expect(result?.settings.region).toBeUndefined();
   });
 
-  it('v5 → v8 (three hops): preserves modern v5 fields, drops overviewMode', () => {
+  it('v5 → v9 (four hops): preserves modern v5 fields, drops overviewMode', () => {
     const v5 = {
       version: 5,
       endpoints: [{ url: 'https://example.com', enabled: true }],
@@ -96,7 +96,7 @@ describe('migrateSettings — full chain through v8', () => {
     expect(result?.ui.expandedCards).toEqual(['a']);
   });
 
-  it('v2 → v8 (chain): old delay becomes monitorDelay, region from detectRegion()', () => {
+  it('v2 → v9 (chain): old delay becomes monitorDelay, region from detectRegion()', () => {
     const v2 = {
       version: 2,
       endpoints: [{ url: 'https://example.com', enabled: true }],
@@ -111,7 +111,7 @@ describe('migrateSettings — full chain through v8', () => {
     expect('overviewMode' in (result?.settings ?? {})).toBe(false);
   });
 
-  it('v1 → v8: minimal payload inflates with full defaults', () => {
+  it('v1 → v9: minimal payload inflates with full defaults', () => {
     const v1 = {
       version: 1,
       endpoints: [{ url: 'https://example.com' }],
@@ -139,7 +139,7 @@ describe('migrateSettings — full chain through v8', () => {
 // The Lanes family was retired at stepV6toV7. These assertions verify that a
 // returning Lanes user lands on Overview regardless of how deep the chain is.
 describe('migrateSettings — Phase 7 v6→v7 hop coverage', () => {
-  it('v4 → v8 (four hops, activeView=split): collapses Lanes alias to overview', () => {
+  it('v4 → v9 (five hops, activeView=split): collapses Lanes alias to overview', () => {
     const v4 = {
       version: 4,
       endpoints: [{ url: 'https://example.com', enabled: true }],
@@ -148,7 +148,7 @@ describe('migrateSettings — Phase 7 v6→v7 hop coverage', () => {
     };
     const result = migrateSettings(v4);
     expect(result?.version).toBe(9);
-    // v4's 'split' → v5's 'lanes' → v7's 'overview' → v8 still 'overview'.
+    // v4's 'split' → v5's 'lanes' → v7's 'overview' → v9 still 'overview'.
     expect(result?.ui.activeView).toBe('overview');
     expect(result?.settings.region).toBe('north-america');
     expect(result?.settings.healthThreshold).toBe(120);
@@ -156,7 +156,7 @@ describe('migrateSettings — Phase 7 v6→v7 hop coverage', () => {
     expect(result?.ui.expandedCards).toEqual(['card-a']);
   });
 
-  it('v5 → v8 (three hops, activeView=lanes): collapses Lanes to overview', () => {
+  it('v5 → v9 (four hops, activeView=lanes): collapses Lanes to overview', () => {
     const v5 = {
       version: 5,
       endpoints: [{ url: 'https://example.com', enabled: true }],
@@ -182,7 +182,7 @@ describe('migrateSettings — Phase 7 v6→v7 hop coverage', () => {
     expect(result?.ui.liveOptions).toEqual({ split: false, timeRange: '1m' });
   });
 
-  it('v5 → v8 preserves non-Lanes activeView (live stays live)', () => {
+  it('v5 → v9 preserves non-Lanes activeView (live stays live)', () => {
     const v5 = {
       version: 5,
       endpoints: [],
@@ -194,7 +194,7 @@ describe('migrateSettings — Phase 7 v6→v7 hop coverage', () => {
     expect(result?.ui.activeView).toBe('live');
   });
 
-  it('v6 → v8 (two hops, activeView=lanes): collapses Lanes to overview', () => {
+  it('v6 → v9 (three hops, activeView=lanes): collapses Lanes to overview', () => {
     const v6 = {
       version: 6,
       endpoints: [{ url: 'https://example.com', enabled: true }],
@@ -222,7 +222,7 @@ describe('migrateSettings — Phase 7 v6→v7 hop coverage', () => {
     expect(result?.ui.terminalFilters).toEqual(['timeout']);
   });
 
-  it('v6 → v8: deprecated timeline/heatmap/split also collapse (not just "lanes")', () => {
+  it('v6 → v9: deprecated timeline/heatmap/split also collapse (not just "lanes")', () => {
     for (const view of ['timeline', 'heatmap', 'split'] as const) {
       const v6 = {
         version: 6,
@@ -253,7 +253,7 @@ describe('migrateSettings — Phase 7 v6→v7 hop coverage', () => {
     }
   });
 
-  it('v6 → v8: modern Overview payload does NOT log the Lanes retirement breadcrumb', () => {
+  it('v6 → v9: modern Overview payload does NOT log the Lanes retirement breadcrumb', () => {
     const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => undefined);
     try {
       const v6 = {
@@ -280,7 +280,7 @@ describe('migrateSettings — Phase 7 v6→v7 hop coverage', () => {
 // pass-through shape. Classic dial retired; there's only one Overview layout
 // now, so the toggle was removed from Settings.
 describe('migrateSettings — v7→v8 hop coverage', () => {
-  it('v7 → v8 (one hop): drops overviewMode, preserves everything else', () => {
+  it('v7 → v9 (two hops): drops overviewMode, preserves everything else', () => {
     const v7 = {
       version: 7,
       endpoints: [{ url: 'https://example.com', enabled: true }],

--- a/tests/unit/utils/persistence-migration.test.ts
+++ b/tests/unit/utils/persistence-migration.test.ts
@@ -22,7 +22,7 @@ describe('migrateSettings — full chain through v8', () => {
       ui: { expandedCards: [], activeView: 'timeline' },
     };
     const result = migrateSettings(v3);
-    expect(result?.version).toBe(8);
+    expect(result?.version).toBe(9);
     expect(result?.settings.region).toBe('europe');
     expect(result?.settings.healthThreshold).toBe(120);
     expect('overviewMode' in (result?.settings ?? {})).toBe(false);
@@ -39,7 +39,7 @@ describe('migrateSettings — full chain through v8', () => {
       ui: { expandedCards: [], activeView: 'split' },
     };
     const result = migrateSettings(v4);
-    expect(result?.version).toBe(8);
+    expect(result?.version).toBe(9);
     expect(result?.settings.region).toBe('east-asia');
     expect(result?.settings.healthThreshold).toBe(120);
     expect('overviewMode' in (result?.settings ?? {})).toBe(false);
@@ -53,7 +53,7 @@ describe('migrateSettings — full chain through v8', () => {
       ui: { expandedCards: [], activeView: 'split' },
     };
     const result = migrateSettings(v4);
-    expect(result?.version).toBe(8);
+    expect(result?.version).toBe(9);
     expect(result?.settings.region).toBeUndefined();
   });
 
@@ -85,7 +85,7 @@ describe('migrateSettings — full chain through v8', () => {
       },
     };
     const result = migrateSettings(v5);
-    expect(result?.version).toBe(8);
+    expect(result?.version).toBe(9);
     expect('overviewMode' in (result?.settings ?? {})).toBe(false);
     expect(result?.settings.healthThreshold).toBe(200);
     expect(result?.settings.region).toBe('europe');
@@ -104,7 +104,7 @@ describe('migrateSettings — full chain through v8', () => {
       ui: { expandedCards: [], activeView: 'split' },
     };
     const result = migrateSettings(v2);
-    expect(result?.version).toBe(8);
+    expect(result?.version).toBe(9);
     expect(result?.settings.burstRounds).toBe(50);
     expect(result?.settings.region).toBe('europe');
     expect(result?.settings.healthThreshold).toBe(120);
@@ -117,7 +117,7 @@ describe('migrateSettings — full chain through v8', () => {
       endpoints: [{ url: 'https://example.com' }],
     };
     const result = migrateSettings(v1);
-    expect(result?.version).toBe(8);
+    expect(result?.version).toBe(9);
     expect(result?.ui.activeView).toBe('overview');
     expect('overviewMode' in (result?.settings ?? {})).toBe(false);
   });
@@ -147,7 +147,7 @@ describe('migrateSettings — Phase 7 v6→v7 hop coverage', () => {
       ui: { expandedCards: ['card-a'], activeView: 'split' },
     };
     const result = migrateSettings(v4);
-    expect(result?.version).toBe(8);
+    expect(result?.version).toBe(9);
     // v4's 'split' → v5's 'lanes' → v7's 'overview' → v8 still 'overview'.
     expect(result?.ui.activeView).toBe('overview');
     expect(result?.settings.region).toBe('north-america');
@@ -173,7 +173,7 @@ describe('migrateSettings — Phase 7 v6→v7 hop coverage', () => {
       },
     };
     const result = migrateSettings(v5);
-    expect(result?.version).toBe(8);
+    expect(result?.version).toBe(9);
     expect(result?.ui.activeView).toBe('overview');
     expect(result?.settings.healthThreshold).toBe(180);
     expect('overviewMode' in (result?.settings ?? {})).toBe(false);
@@ -190,7 +190,7 @@ describe('migrateSettings — Phase 7 v6→v7 hop coverage', () => {
       ui: { expandedCards: [], activeView: 'live', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
     };
     const result = migrateSettings(v5);
-    expect(result?.version).toBe(8);
+    expect(result?.version).toBe(9);
     expect(result?.ui.activeView).toBe('live');
   });
 
@@ -212,7 +212,7 @@ describe('migrateSettings — Phase 7 v6→v7 hop coverage', () => {
       },
     };
     const result = migrateSettings(v6);
-    expect(result?.version).toBe(8);
+    expect(result?.version).toBe(9);
     expect(result?.ui.activeView).toBe('overview');
     // overviewMode is dropped at v8 regardless of value.
     expect('overviewMode' in (result?.settings ?? {})).toBe(false);
@@ -298,9 +298,10 @@ describe('migrateSettings — v7→v8 hop coverage', () => {
       },
     };
     const result = migrateSettings(v7);
-    expect(result?.version).toBe(8);
+    expect(result?.version).toBe(9);
     expect('overviewMode' in (result?.settings ?? {})).toBe(false);
-    expect(result?.ui.activeView).toBe('atlas');
+    // v7's 'atlas' → v9's 'diagnose' (the v8→v9 step renames it).
+    expect(result?.ui.activeView).toBe('diagnose');
     expect(result?.settings.healthThreshold).toBe(200);
     expect(result?.settings.region).toBe('europe');
     expect(result?.settings.corsMode).toBe('cors');
@@ -372,9 +373,10 @@ describe('migrateSettings — v7→v8 hop coverage', () => {
       },
     };
     const result = migrateSettings(v8);
-    expect(result?.version).toBe(8);
+    expect(result?.version).toBe(9);
     expect('overviewMode' in (result?.settings ?? {})).toBe(false);
-    expect(result?.ui.activeView).toBe('atlas');
+    // v8's 'atlas' → v9's 'diagnose' via stepV8toV9.
+    expect(result?.ui.activeView).toBe('diagnose');
     expect(result?.settings.healthThreshold).toBe(200);
     expect(result?.ui.focusedEndpointId).toBe('ep-keep');
     expect(result?.ui.liveOptions).toEqual({ split: true, timeRange: '1h' });
@@ -407,5 +409,140 @@ describe('migrateSettings — v7→v8 hop coverage', () => {
     };
     const result = migrateSettings(v8);
     expect('overviewMode' in (result?.settings ?? {})).toBe(false);
+  });
+});
+
+// ── v8 → v9 hop coverage ─────────────────────────────────────────────────────
+// The Atlas view was renamed to Diagnose to match the v2 prototype vocabulary.
+// stepV8toV9 rewrites `activeView: 'atlas'` to `'diagnose'` with a debug-log
+// breadcrumb. Hop coverage: v4→v9 (five hops), v5→v9, v6→v9, v7→v9, v8→v9 (one),
+// v9 pass-through, plus log presence/absence + stray-'atlas' guard on v9.
+describe('migrateSettings — v8→v9 hop coverage', () => {
+  it('v4 → v9 (five hops, activeView=split): collapses Lanes alias to overview, no atlas to rename', () => {
+    const v4 = {
+      version: 4,
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors' },
+      ui: { expandedCards: [], activeView: 'split' },
+    };
+    const result = migrateSettings(v4);
+    expect(result?.version).toBe(9);
+    expect(result?.ui.activeView).toBe('overview');
+  });
+
+  it('v5 → v9 (four hops, activeView=atlas): renames atlas → diagnose at the v9 boundary', () => {
+    const v5 = {
+      version: 5,
+      endpoints: [],
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      ui: { expandedCards: [], activeView: 'atlas', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
+    };
+    const result = migrateSettings(v5);
+    expect(result?.version).toBe(9);
+    expect(result?.ui.activeView).toBe('diagnose');
+  });
+
+  it('v6 → v9 (three hops, activeView=atlas + overviewMode=classic): drops mode AND renames atlas', () => {
+    const v6 = {
+      version: 6,
+      endpoints: [],
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120, overviewMode: 'classic' },
+      ui: { expandedCards: [], activeView: 'atlas', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
+    };
+    const result = migrateSettings(v6);
+    expect(result?.version).toBe(9);
+    expect('overviewMode' in (result?.settings ?? {})).toBe(false);
+    expect(result?.ui.activeView).toBe('diagnose');
+  });
+
+  it('v8 → v9 (one hop, activeView=atlas): renames to diagnose', () => {
+    const v8 = {
+      version: 8,
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 200 },
+      ui: { expandedCards: [], activeView: 'atlas', focusedEndpointId: 'ep-keep', liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
+    };
+    const result = migrateSettings(v8);
+    expect(result?.version).toBe(9);
+    expect(result?.ui.activeView).toBe('diagnose');
+    // Non-view fields ride through.
+    expect(result?.settings.healthThreshold).toBe(200);
+    expect(result?.ui.focusedEndpointId).toBe('ep-keep');
+  });
+
+  it('v8 → v9: non-atlas activeView passes through unchanged', () => {
+    for (const view of ['overview', 'live', 'strata', 'terminal'] as const) {
+      const v8 = {
+        version: 8,
+        endpoints: [],
+        settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+        ui: { expandedCards: [], activeView: view, focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
+      };
+      const result = migrateSettings(v8);
+      expect(result?.version).toBe(9);
+      expect(result?.ui.activeView).toBe(view);
+    }
+  });
+
+  it('v8 → v9: debug-logs the rename when atlas is present', () => {
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => undefined);
+    try {
+      const v8 = {
+        version: 8,
+        endpoints: [],
+        settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+        ui: { expandedCards: [], activeView: 'atlas', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
+      };
+      migrateSettings(v8);
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/v9 migration: activeView 'atlas' renamed to 'diagnose'/),
+      );
+    } finally {
+      debugSpy.mockRestore();
+    }
+  });
+
+  it('v8 → v9: non-atlas payloads do NOT log the rename breadcrumb', () => {
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => undefined);
+    try {
+      const v8 = {
+        version: 8,
+        endpoints: [],
+        settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+        ui: { expandedCards: [], activeView: 'live', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
+      };
+      migrateSettings(v8);
+      expect(debugSpy).not.toHaveBeenCalledWith(
+        expect.stringMatching(/v9 migration: activeView 'atlas'/),
+      );
+    } finally {
+      debugSpy.mockRestore();
+    }
+  });
+
+  it('v9 pass-through: already-current payload survives intact', () => {
+    const v9 = {
+      version: 9,
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      ui: { expandedCards: [], activeView: 'diagnose', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
+    };
+    const result = migrateSettings(v9);
+    expect(result?.version).toBe(9);
+    expect(result?.ui.activeView).toBe('diagnose');
+  });
+
+  it('v9 pass-through: a stray "atlas" in a v9 payload coerces to overview (not silently re-renamed)', () => {
+    // Hand-edited v9 payload with retired 'atlas'. normalizeV9 doesn't run
+    // stepV8toV9, so the rename log doesn't fire — instead the stray value
+    // falls through V9_VIEWS membership and lands on 'overview'.
+    const v9 = {
+      version: 9,
+      endpoints: [],
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      ui: { expandedCards: [], activeView: 'atlas', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
+    };
+    const result = migrateSettings(v9);
+    expect(result?.ui.activeView).toBe('overview');
   });
 });


### PR DESCRIPTION
**Slice 1 of 6** in the v2-prototype-parity pass — see umbrella issue #56.

Aligns the ViewSwitcher with \`v2/Chronoscope v2.html\` without touching the disabled Strata + Terminal carve-out. The view's content is unchanged — only the routing key, label, and the five tab subs.

## Migration

v8 → v9 hop coverage written **before** any rename code:
- v4 → v9 (five hops)
- v5 → v9 (four hops, atlas → diagnose at v9 boundary)
- v6 → v9 (three hops, drops overviewMode AND renames atlas)
- v8 → v9 (one hop, with + without 'atlas')
- v9 pass-through + stray-'atlas' coerce guard
- Debug-log presence/absence

Intermediate \`LegacyActiveView\` extended with \`'atlas'\` so v6/v7/v8 payloads carry the value through to \`stepV8toV9\` (the boundary that renames it). \`stepV7toV8\` widened to return \`LegacyPersistedSettings\` so 'atlas' isn't lost mid-chain.

## Type narrowing

- \`ActiveView\`: \`'atlas'\` → \`'diagnose'\`
- \`PersistedSettings.version\`: \`2..8\` → \`2..9\`

## Tab subs

Switched from noun-phrases to the prototype's question-form (\`shell.jsx:4–8\`):

| key | label | old sub | new sub |
|---|---|---|---|
| 1 | Overview | At a glance | Is everything okay? |
| 2 | Live | Real-time scope | What's happening right now? |
| 3 | Diagnose (renamed) | Phase breakdown | Why is it slow? |
| 4 | Strata | Distribution | How is the distribution? |
| 5 | Terminal | Event log | What's in the log? |

## Call-site rename

\`Layout.svelte\` routes on \`activeView === 'diagnose'\` (still mounts \`AtlasView.svelte\` — component file rename happens in slice #6). \`OverviewView\` enriched-drill + \`RacingStrip\` shift+click both updated to \`setActiveView('diagnose')\`.

## Out of scope (later slices)

- \`AtlasView.svelte\` file rename + \`.atlas-*\` CSS — slice #6
- Diagnose hero-waterfall + verdict card + sample-strip restructure — slice #6

## Verification

- typecheck / lint / **580 tests** (+9 new v9-hop) / build all green
- Bundle: JS 60.38 → 60.58 KB gzip (+0.20 KB for migration step + tests). CSS unchanged.

Will trigger \`@coderabbitai review\` once CI lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Renamed "Atlas" view to "Diagnose" throughout the application for improved clarity and better user understanding
  * Updated all navigation elements, interactive controls, and interface features to reference the new view designation
  * Implemented automatic settings migration to seamlessly preserve all existing user preferences and saved configurations during the transition

<!-- end of auto-generated comment: release notes by coderabbit.ai -->