### PR TITLE
feat(parity-2): soften endpoint rail pip glow to alpha-suffixed token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "chronoscope",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "lz-string": "^1.5.0"
       },

--- a/src/lib/components/EndpointRail.svelte
+++ b/src/lib/components/EndpointRail.svelte
@@ -75,7 +75,7 @@
         <span
           class="rail-pip"
           style:background={style.color}
-          style:box-shadow="0 0 8px {style.color}"
+          style:box-shadow="0 0 8px {style.glow}"
           aria-hidden="true"
         ></span>
         <span class="rail-row-body">


### PR DESCRIPTION
## Summary
- EndpointRail's status pip used the full-opacity health color for both dot fill and its box-shadow halo. Switch the halo to the dedicated \`--accent-*-glow\` token (33% alpha) so it matches the v2 prototype's softer-halo intent and aligns with how every other component in the codebase already does this.
- The \`unknown\` bucket's glow is \`transparent\`, so no-data pips now render without a halo (correct: nothing to signal).
- Slice #2 of the v2-parity umbrella (#56). Smallest possible change — single line.

## Test plan
- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npm test\` — 580 / 580 passing
- [ ] Visual: the rail's status dot keeps its full-color fill but its halo is softer; the unknown/no-data pip has no halo