### PR TITLE
feat(parity-3): collapse topbar status pill + run-state into single run-status

### DIFF
--- a/src/lib/components/Topbar.svelte
+++ b/src/lib/components/Topbar.svelte
@@ -1,12 +1,14 @@
 <!-- src/lib/components/Topbar.svelte -->
-<!-- v2 chrome — pixel-aligned to v2/Chronoscope v2.html. Preserves every       -->
-<!-- existing control (endpoints / settings / share / start-stop) and adds the -->
-<!-- networkQualityStore-driven status pill required by the Phase 1 brief.     -->
+<!-- v2 chrome — pixel-aligned to v2/Chronoscope v2.html. Brand on the left,    -->
+<!-- combined `run-status` (lifecycle dot + label + tick) inline next to it,    -->
+<!-- and the action cluster (endpoints / settings / share / start-stop) on     -->
+<!-- the right. The network-quality severity pill the older brief asked for    -->
+<!-- was removed at the v2-parity refactor: the chronograph dial in Overview   -->
+<!-- already carries the at-a-glance health verdict, so the pill duplicated    -->
+<!-- that signal in a less expressive form.                                    -->
 <script lang="ts">
   import { measurementStore } from '$lib/stores/measurements';
   import { uiStore } from '$lib/stores/ui';
-  import { networkQualityStore } from '$lib/stores/derived';
-  import { LEVEL_STYLES, networkLevel } from '$lib/utils/classify';
   import type { TestLifecycleState } from '$lib/types';
 
   let { onStart, onStop }: {
@@ -40,11 +42,6 @@
     lifecycle === 'idle' || lifecycle === 'stopped' || lifecycle === 'completed',
   );
 
-  // Status pill — driven by networkQualityStore, mapped through networkLevel().
-  const score = $derived($networkQualityStore);
-  const level = $derived(networkLevel(score));
-  const pillStyle = $derived(LEVEL_STYLES[level]);
-
   function handleStartStop(): void {
     if (lifecycle === 'running') onStop?.();
     else if (isStartButton) onStart?.();
@@ -58,7 +55,7 @@
   function handleEndpoints(): void { uiStore.toggleEndpoints(); }
 </script>
 
-<header class="topbar" data-level={level}>
+<header class="topbar">
   <div class="brand">
     <div class="brand-mark" aria-hidden="true">
       <svg viewBox="0 0 24 24" width="22" height="22">
@@ -74,25 +71,17 @@
     </div>
   </div>
 
-  <div class="topbar-divider brand-divider" aria-hidden="true"></div>
+  <div class="topbar-divider" aria-hidden="true"></div>
 
   <div
-    class="status-pill"
+    class="run-status"
     role="status"
     aria-live="polite"
-    aria-label="Network quality: {pillStyle.label}{score !== null ? `, score ${score}` : ''}"
-    style:--pill-color={pillStyle.color}
-    style:--pill-glow={pillStyle.glow}
+    aria-label="{runText}, round {roundCounter}"
   >
-    <span class="status-dot" class:on={isRunning && level !== 'unknown'}></span>
-    <span class="status-label">{pillStyle.label}</span>
-    <span class="status-tick" aria-hidden="true">{tickText}</span>
-  </div>
-
-  <div class="topbar-divider run-divider" aria-hidden="true"></div>
-
-  <div class="run-state">
-    <span class="run-state-label">{runText}</span>
+    <span class="run-dot" class:on={isRunning}></span>
+    <span class="run-label">{runText}</span>
+    <span class="run-tick">{tickText}</span>
   </div>
 
   <div class="spacer"></div>
@@ -209,43 +198,39 @@
     flex-shrink: 0;
   }
 
-  .status-pill {
-    display: inline-flex; align-items: center; gap: 8px;
-    padding: 6px 10px; border-radius: 999px;
-    background: rgba(255,255,255,.03);
-    border: 1px solid var(--border-mid);
+  .run-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .run-dot {
+    width: 7px; height: 7px;
+    border-radius: 50%;
+    background: var(--t4);
+    transition: background 200ms ease, box-shadow 200ms ease;
+  }
+  .run-dot.on {
+    background: var(--accent-green);
+    box-shadow: 0 0 10px var(--green-glow);
+    animation: pulse 1.8s ease-in-out infinite;
+  }
+  @keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.45; }
+  }
+  .run-label {
     font-family: var(--mono);
     font-size: var(--ts-sm);
     color: var(--t2);
     letter-spacing: var(--tr-label);
     text-transform: uppercase;
   }
-  .status-dot {
-    width: 7px; height: 7px;
-    border-radius: 50%;
-    background: var(--pill-color);
-    box-shadow: 0 0 8px var(--pill-glow);
-    transition: background 200ms ease, box-shadow 200ms ease;
-  }
-  .status-dot.on { animation: pulse 1.8s ease-in-out infinite; }
-  @keyframes pulse {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.45; }
-  }
-  .status-label { color: var(--t2); }
-  .status-tick {
+  .run-tick {
+    font-family: var(--mono);
+    font-size: var(--ts-sm);
     color: var(--t3);
     font-variant-numeric: tabular-nums;
-    letter-spacing: 0;
-  }
-
-  .run-state { display: flex; align-items: center; }
-  .run-state-label {
-    font-family: var(--mono);
-    font-size: var(--ts-xs);
-    color: var(--t3);
-    letter-spacing: var(--tr-label);
-    text-transform: uppercase;
+    margin-left: 2px;
   }
 
   .spacer { flex: 1; }
@@ -300,16 +285,13 @@
   .run-btn-icon { font-size: var(--ts-xs); }
 
   @media (prefers-reduced-motion: reduce) {
-    .status-dot, .icon-btn, .run-btn { animation: none !important; transition: none; }
+    .run-dot, .icon-btn, .run-btn { animation: none !important; transition: none; }
   }
 
-  /* Mobile narrow: collapse the run-state label and brand-sub to keep the topbar
-     usable below 768px. Status pill + action icons stay visible.
-     Hides .run-divider explicitly — selector is class-based because the brand
-     element is also a <div> and `:nth-of-type(2)` would match the wrong one.  */
+  /* Mobile narrow: hide brand-sub, label, and tick under 768px so the dot
+     and action cluster stay visible without horizontal overflow.            */
   @media (max-width: 767px) {
-    .brand-sub, .run-state, .run-divider { display: none; }
+    .brand-sub, .run-label, .run-tick { display: none; }
     .topbar { gap: 8px; padding: 0 12px; }
-    .status-pill { padding: 6px 8px; }
   }
 </style>

--- a/src/lib/components/Topbar.svelte
+++ b/src/lib/components/Topbar.svelte
@@ -73,15 +73,10 @@
 
   <div class="topbar-divider" aria-hidden="true"></div>
 
-  <div
-    class="run-status"
-    role="status"
-    aria-live="polite"
-    aria-label="{runText}, round {roundCounter}"
-  >
-    <span class="run-dot" class:on={isRunning}></span>
-    <span class="run-label">{runText}</span>
-    <span class="run-tick">{tickText}</span>
+  <div class="run-status" aria-label={runText}>
+    <span class="run-dot" class:on={isRunning} aria-hidden="true"></span>
+    <span class="run-label" role="status" aria-live="polite">{runText}</span>
+    <span class="run-tick" aria-hidden="true">{tickText}</span>
   </div>
 
   <div class="spacer"></div>

--- a/src/lib/stores/derived.ts
+++ b/src/lib/stores/derived.ts
@@ -25,8 +25,7 @@ export const monitoredEndpointsStore: Readable<readonly Endpoint[]> = derived(
 
 /**
  * Aggregate 0–100 score across monitored endpoints — null until at least one
- * endpoint's statistics are `ready`. Subscribed by Topbar status and the
- * chronograph dial's main hand.
+ * endpoint's statistics are `ready`. Drives the chronograph dial's main hand.
  */
 export const networkQualityStore: Readable<number | null> = derived(
   [monitoredEndpointsStore, statisticsStore, settingsStore],

--- a/src/lib/utils/classify.ts
+++ b/src/lib/utils/classify.ts
@@ -4,9 +4,9 @@
 // bucket does X land in?" it lives here; if it answers "why is X in that
 // bucket?" it lives in verdict.ts.
 //
-// classify.ts owns: classify(), networkQuality(), networkLevel(),
-// overviewVerdict(), and the three style maps (HEALTH_STYLES, LEVEL_STYLES,
-// VERDICT_STYLES). No store imports; callers pass stats + threshold explicitly.
+// classify.ts owns: classify(), networkQuality(), overviewVerdict(), and the
+// two style maps (HEALTH_STYLES, VERDICT_STYLES). No store imports; callers
+// pass stats + threshold explicitly.
 
 import type { EndpointStatistics } from '../types';
 
@@ -94,23 +94,6 @@ export function networkQuality(
   return Math.round(total / ready.length);
 }
 
-// ─── Verdict vs networkLevel — DELIBERATE ASYMMETRY ────────────────────────
-// The two classifiers below intentionally bucket the same score differently:
-//
-//   overviewVerdict (3 buckets)  answers  "how is the user's experience?"
-//   networkLevel    (4 buckets)  answers  "what alerting action is warranted?"
-//
-// They CAN disagree at boundaries — e.g. score 80 yields verdict='healthy'
-// (the dial reads "Healthy") while networkLevel='warning' (the topbar pill
-// reads "WARNING"). That is by design: the dial is an at-a-glance human
-// summary that compresses warning + early degraded into one bucket; the pill
-// is a live alerting indicator that needs the extra granularity to
-// distinguish "watch this" from "acknowledge this".
-//
-// Do not unify the two without an explicit product call. If you add a third
-// classifier (e.g. routing, paging), document its bucketing rationale here
-// alongside these two.
-//
 export type OverviewVerdict = 'unknown' | 'healthy' | 'degraded' | 'unhealthy';
 
 export interface VerdictStyle {
@@ -121,11 +104,7 @@ export interface VerdictStyle {
 }
 
 /**
- * Coarse 3-bucket label for the Overview dial and diagnosis strip. The topbar
- * status pill uses `networkLevel()` for 4-bucket severity; this is intentionally
- * coarser because the user-facing verdict should compress to "everything's fine
- * / something's off / things are bad" without the warning/degraded split the
- * pill uses for alerting.
+ * Coarse 3-bucket label for the Overview dial and diagnosis strip.
  *
  *   null    → unknown   (Awaiting samples)
  *   ≥ 80    → healthy
@@ -146,38 +125,3 @@ export const VERDICT_STYLES: Record<OverviewVerdict, VerdictStyle> = {
   unhealthy: { color: 'var(--accent-pink)',  glow: 'var(--accent-pink-glow)',  label: 'Unhealthy',        kicker: 'CRITICAL' },
 };
 
-export type NetworkLevel = 'unknown' | 'healthy' | 'warning' | 'degraded' | 'critical';
-
-/**
- * Map a 0–100 networkQuality score to a named pill state for the topbar.
- * Buckets are spaced so mixes of classify() outcomes land in distinct pills
- * even though the underlying aggregate emits {100, 60, 20} for uniform fleets.
- *
- *   null   → unknown
- *   ≥ 90   → healthy
- *   ≥ 60   → warning
- *   ≥ 30   → degraded
- *   <  30  → critical
- */
-export function networkLevel(score: number | null): NetworkLevel {
-  if (score === null) return 'unknown';
-  if (score >= 90) return 'healthy';
-  if (score >= 60) return 'warning';
-  if (score >= 30) return 'degraded';
-  return 'critical';
-}
-
-export interface LevelStyle {
-  readonly color: string;
-  readonly glow:  string;
-  readonly label: string;
-}
-
-// CSS-var-backed palette so every level chip agrees with bridgeTokensToCss.
-export const LEVEL_STYLES: Record<NetworkLevel, LevelStyle> = {
-  unknown:  { color: 'var(--t4)',                glow: 'transparent',              label: 'No data'  },
-  healthy:  { color: 'var(--accent-green)',      glow: 'var(--green-glow)',        label: 'Healthy'  },
-  warning:  { color: 'var(--accent-amber)',      glow: 'var(--accent-amber-glow)', label: 'Warning'  },
-  degraded: { color: 'var(--accent-amber-tone)', glow: 'var(--accent-amber-glow)', label: 'Degraded' },
-  critical: { color: 'var(--accent-pink)',       glow: 'var(--accent-pink-glow)',  label: 'Critical' },
-};

--- a/tests/unit/classify.test.ts
+++ b/tests/unit/classify.test.ts
@@ -2,10 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   classify,
   networkQuality,
-  networkLevel,
   overviewVerdict,
   HEALTH_STYLES,
-  LEVEL_STYLES,
   VERDICT_STYLES,
 } from '../../src/lib/utils/classify';
 import type { EndpointStatistics } from '../../src/lib/types';
@@ -108,45 +106,6 @@ describe('HEALTH_STYLES', () => {
     for (const bucket of ['healthy', 'degraded', 'unhealthy', 'unknown'] as const) {
       expect(HEALTH_STYLES[bucket].color).toMatch(/^var\(--/);
     }
-  });
-});
-
-describe('networkLevel()', () => {
-  it('returns "unknown" for null score', () => {
-    expect(networkLevel(null)).toBe('unknown');
-  });
-  it('returns "healthy" at 90 and above', () => {
-    expect(networkLevel(100)).toBe('healthy');
-    expect(networkLevel(90)).toBe('healthy');
-  });
-  it('returns "warning" between 60 and 89', () => {
-    expect(networkLevel(89)).toBe('warning');
-    expect(networkLevel(60)).toBe('warning');
-  });
-  it('returns "degraded" between 30 and 59', () => {
-    expect(networkLevel(59)).toBe('degraded');
-    expect(networkLevel(30)).toBe('degraded');
-  });
-  it('returns "critical" below 30', () => {
-    expect(networkLevel(29)).toBe('critical');
-    expect(networkLevel(0)).toBe('critical');
-  });
-});
-
-describe('LEVEL_STYLES', () => {
-  it('defines a style entry for every level', () => {
-    for (const level of ['unknown', 'healthy', 'warning', 'degraded', 'critical'] as const) {
-      expect(LEVEL_STYLES[level].color).toBeTruthy();
-      expect(LEVEL_STYLES[level].label).toBeTruthy();
-    }
-  });
-  it('references CSS custom properties bridged from tokens', () => {
-    for (const level of ['healthy', 'warning', 'degraded', 'critical'] as const) {
-      expect(LEVEL_STYLES[level].color).toMatch(/^var\(--/);
-    }
-  });
-  it('keeps the "unknown" label distinguishable for screen readers', () => {
-    expect(LEVEL_STYLES.unknown.label).toBe('No data');
   });
 });
 


### PR DESCRIPTION
## Summary
- Drops the legacy network-quality \`status-pill\` and the separate \`run-state\` label, combining them into a single prototype-style \`run-status\` strip (dot + label + tick) — see \`v2/shell.jsx\` lines 49–53.
- The chronograph dial in Overview already carries the network-quality verdict; the pill duplicated that signal in a less expressive form, so the pill plus its plumbing (\`networkLevel\`, \`LEVEL_STYLES\`, \`NetworkLevel\` type) are deleted.
- Slice #3 of v2-parity umbrella (#56). Diff: \`+44 / −160\`, 580 → 572 tests, bundle 60.33 KB gzip (no measurable delta).

## Files
- \`src/lib/components/Topbar.svelte\` — refactor (replace pill + run-state with run-status)
- \`src/lib/utils/classify.ts\` — drop \`networkLevel\`, \`NetworkLevel\`, \`LevelStyle\`, \`LEVEL_STYLES\` and the now-irrelevant DELIBERATE ASYMMETRY comment
- \`tests/unit/classify.test.ts\` — drop describe blocks for the deleted exports (8 tests)
- \`src/lib/stores/derived.ts\` — refresh doc comment on \`networkQualityStore\` (only the dial subscribes now)

## Test plan
- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npm test\` — 572 / 572 passing
- [x] \`npm run build\` — 196 KB raw / 60.33 KB gzip
- [ ] Visual: topbar shows \`[brand] | [● Measuring T+0042]\` while running; \`[● Halted T+0000]\` (gray dot, no pulse) when idle. Action cluster on the right unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the network quality status indicator from the topbar to streamline the user interface.
  * Simplified the run status presentation into a consolidated, cleaner display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->