### PR TITLE
feat(parity-4): align overview top padding + right-col gap to v2 prototype

### DIFF
--- a/src/lib/components/OverviewView.svelte
+++ b/src/lib/components/OverviewView.svelte
@@ -315,7 +315,7 @@
     display: flex;
     flex-direction: column;
     gap: 24px;
-    padding: 32px 28px 40px;
+    padding: 18px 28px 40px;
     min-height: 0;
     overflow-y: auto;
   }
@@ -331,10 +331,16 @@
     gap: 24px;
     align-items: start;
   }
-  .overview-left, .overview-right {
+  .overview-left {
     display: flex;
     flex-direction: column;
     gap: 18px;
+    min-width: 0;
+  }
+  .overview-right {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
     min-width: 0;
   }
   @media (max-width: 1023px) {


### PR DESCRIPTION
## Summary
- \`.overview\` top padding: 32px → 18px so the chronograph dial sits flush below the ViewSwitcher tabs (matches \`overviewV2Styles.wrap.padding\` in \`v2/view-overview-v2.jsx:12\`).
- \`.overview-right\` gap: 18px → 16px to match \`overviewV2Styles.rightCol.gap\` (the column holding RacingStrip + EventFeed).
- Left column gap stays 18px — that domain (dial + CausalVerdictStrip) has Chronoscope-specific structure that isn't a direct prototype port.
- Slice #4 of v2-parity umbrella (#56). Diff: \`+8 / −2\`.

## Test plan
- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npm test\` — 572 / 572 passing
- [ ] Visual: Overview opens with the dial visibly closer to the ViewSwitcher tabs; the racing strip and event feed sit a hair tighter together.