### PR TITLE
fix(racing-strip): clarify modifier hint from ⇧ to ⇧-click

### DIFF
--- a/src/lib/components/RacingStrip.svelte
+++ b/src/lib/components/RacingStrip.svelte
@@ -87,7 +87,7 @@
       <h3 class="racing-title">Per-endpoint comparison</h3>
       <p class="racing-sub">Live latencies on shared axis</p>
     </div>
-    <p class="racing-hint">Click → Live · ⇧ → Diagnose</p>
+    <p class="racing-hint">Click → Live · ⇧-click → Diagnose</p>
   </header>
 
   <div class="racing-axis" aria-hidden="true">

--- a/tests/unit/components/RacingStrip.test.ts
+++ b/tests/unit/components/RacingStrip.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/svelte';
+import RacingStrip from '../../../src/lib/components/RacingStrip.svelte';
+
+// Minimal prop set. RacingStrip renders the hint regardless of data.
+const baseProps = {
+  endpoints: [],
+  stats: {},
+  lastLatencies: {},
+  samplesByEndpoint: {},
+  threshold: 120,
+  focusedEndpointId: null,
+};
+
+describe('RacingStrip — G5 hint copy', () => {
+  it('should render exactly "Click → Live · ⇧-click → Diagnose"', () => {
+    const { getByText } = render(RacingStrip, { props: baseProps });
+    expect(getByText('Click → Live · ⇧-click → Diagnose')).toBeTruthy();
+  });
+
+  it('should NOT contain the old ambiguous "⇧ → Diagnose" text', () => {
+    const { queryByText } = render(RacingStrip, { props: baseProps });
+    expect(queryByText('Click → Live · ⇧ → Diagnose')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Changes the per-endpoint comparison hint from `Click → Live · ⇧ → Diagnose` to `Click → Live · ⇧-click → Diagnose`. Bare `⇧` was ambiguous (scroll? keyboard?); `⇧-click` is unambiguous.
- Adds regression tests in `tests/unit/components/RacingStrip.test.ts` covering both the positive (new text present) and negative (old text absent) cases.
- This is **PR 1 of 5** in the v2-parity-remaining slice — deliberately trivial, verifies the implementation loop end-to-end before larger phases (G4 unit suffix, G2 \`NORMAL\` label, G6 endpoint loader + rail dedup, G1 dual-stroke baseline) ship.

> **Note (force-push correction):** The initial push of this branch accidentally wrote `Atlas` into the target text because the spec was drafted against stale state. The rename `Atlas → Diagnose` was already completed in PR #57 (`303d62b`). Amended commit preserves the same one-letter modifier-notation fix (`⇧` → `⇧-click`) without touching the already-correct `Diagnose`.

Spec: \`docs/superpowers/specs/2026-04-20-v2-parity-remaining.md\` §4.1 (G5)
Plan: \`docs/plans/2026-04-20-v2-parity-remaining-plan.md\` Phase 1

## Test plan

- [x] `npm run typecheck` exits 0
- [x] `npm run lint` exits 0
- [x] `npm test` — 2/2 passing on the scoped test file
- [x] Spec compliance review: pass
- [x] Stack-aware code review: pass