### PR TITLE
fix(dial): resolve four text-overlap bugs on the chronograph face

### DIFF
--- a/src/lib/components/ChronographDial.svelte
+++ b/src/lib/components/ChronographDial.svelte
@@ -159,7 +159,9 @@
     if (p25 > p75) [p25, p75] = [p75, p25];
     const ang = latToAng(p75);
     const a = (ang * Math.PI) / 180;
-    const r = BASELINE_R;
+    // Inward 22px from BASELINE_R clears the 22 px outer cyan glow so the
+    // word reads against the darker face instead of blending into the arc.
+    const r = BASELINE_R - 22;
     return {
       x: CX + Math.cos(a) * r,
       y: CY + Math.sin(a) * r,
@@ -457,7 +459,7 @@
               dominant-baseline="middle"
               font-size="8.5"
               font-family={tokens.typography.mono.fontFamily}
-              fill="rgba(103,232,249,.55)"
+              fill="rgba(103,232,249,.80)"
               letter-spacing="0.2em"
               data-role="normal-label"
             >NORMAL</text>
@@ -489,20 +491,15 @@
         >{l.ms}</text>
       {/each}
 
-      <!-- 8. Center readouts. Kicker / score / verdict. The "LIVE {median} ·
-           WITHIN/ABOVE/BELOW BAND" line is rendered below the trace at
-           CY+108 (see step 8b). Y-positions and sizes match the v2 prototype
-           MainDialV2 (view-overview-v2.jsx): kicker cy-72@9px, score cy-6@100px,
-           verdict cy+22@10px. -->
-      <text x={CX} y={CY - 72} text-anchor="middle" font-size="9"
-            font-family={tokens.typography.mono.fontFamily} fill="var(--t3)" letter-spacing="0.3em">QUALITY</text>
+      <!-- 8. Center readouts — score only. The QUALITY kicker (cy-72) and the
+           standalone verdict kicker (cy+22) were removed in the 2026-04-22
+           overlap polish: QUALITY was redundant with the score + verdict, and
+           the cy+22 verdict collided with the hand needle. Verdict text is
+           now carried as a tspan in the merged strip at cy+108 (see step 8b
+           below, which is painted AFTER the hand). -->
       <text x={CX} y={CY - 6} text-anchor="middle" font-size="100" font-weight="200"
             fill="var(--t1)" font-family={tokens.typography.sans.fontFamily}
             style="letter-spacing: -0.05em; font-variant-numeric: tabular-nums;">{scoreDisplay}</text>
-      <text x={CX} y={CY + 22} text-anchor="middle" font-size="10"
-            font-family={tokens.typography.mono.fontFamily} fill={verdictStyle.color} letter-spacing="0.28em">
-        {verdictStyle.kicker}
-      </text>
 
       <!-- 8a (v2). 60s quality trace inside the face. Decorative — the numeric
            score + verdict kicker carry the primary meaning for SR users. -->
@@ -528,17 +525,9 @@
         >CALIBRATING</text>
       {/if}
 
-      <!-- 8b (v2). LIVE median + band label. Combines the prototype's single
-           "LIVE {median} · WITHIN BAND" / "OUTSIDE BAND" line (cy+108, 9.5 px)
-           with our more precise 3-way ABOVE/WITHIN/BELOW distinction. Dim
-           when WITHIN, amber when ABOVE/BELOW. Included in dial aria-label. -->
-      <text
-        x={CX} y={CY + 108}
-        text-anchor="middle" font-size="9.5"
-        font-family={tokens.typography.mono.fontFamily}
-        fill={bandLabel === null || bandLabel === 'WITHIN BAND' ? 'var(--t4)' : bandLabelColor}
-        letter-spacing="0.18em"
-      >LIVE {fmt(liveMedian).toUpperCase()}{bandLabel !== null ? ` · ${bandLabel}` : ''}</text>
+      <!-- (The merged verdict + LIVE + band strip that used to live here has
+           moved below, AFTER the hand group, so it paints on top of the
+           needle. See step 12 at the bottom of the SVG. -->
 
       <!-- 9. Endpoint orbit ring. -->
       <g aria-hidden="true">
@@ -576,6 +565,29 @@
       <!-- 11. Central hub. -->
       <circle cx={CX} cy={CY} r="8" fill="var(--bg-base)" stroke="var(--border-bright)" stroke-width="1" />
       <circle cx={CX} cy={CY} r="2.5" fill="var(--t1)" />
+
+      <!-- 12. Merged verdict · LIVE · band strip (cy+108).
+           Painted AFTER the hand so the needle never visually cuts the
+           glyphs. `paint-order="stroke fill"` with a dial-face-colored
+           stroke draws a 3 px halo behind each tspan, so hand line that
+           crosses the strip threads around the letters instead of through
+           them. Three tspans in sequence:
+             · verdictStyle.kicker   (cyan / amber / pink by state)
+             · " · LIVE {median}"     (t3 grey)
+             · " · {bandLabel}"       (green / amber / t4, omitted if null)
+           This block carries the screen-reader information previously split
+           between the cy+22 kicker and the cy+108 LIVE line. -->
+      <text
+        x={CX} y={CY + 108}
+        text-anchor="middle" font-size="9.5"
+        font-family={tokens.typography.mono.fontFamily}
+        letter-spacing="0.18em"
+        paint-order="stroke fill"
+        stroke="var(--bg-base)"
+        stroke-width="3"
+        stroke-linejoin="round"
+        data-role="merged-verdict-live"
+      ><tspan fill={verdictStyle.color}>{verdictStyle.kicker}</tspan><tspan fill="var(--t3)"> · LIVE {fmt(liveMedian).toUpperCase()}</tspan>{#if bandLabel !== null}<tspan fill={bandLabelColor}> · {bandLabel}</tspan>{/if}</text>
     </svg>
 
   <div class="dial-announcer" role="status" aria-live="polite" aria-atomic="true">
@@ -583,7 +595,7 @@
   </div>
 
   {#if paused}
-    <span class="paused-badge" aria-hidden="true">PAUSED</span>
+    <div class="paused-overlay" aria-hidden="true">PAUSED</div>
   {/if}
 </div>
 
@@ -666,19 +678,40 @@
     .dial.pulsing { animation: none; }
   }
 
-  .paused-badge {
+  /* Paused treatment — dim the whole SVG face and overlay a centered pill.
+     Replaces the old .paused-badge that sat at bottom:28px and overlapped
+     the pink threshold arc. Dimming also kills the "live-looking readouts"
+     bug — score, verdict, LIVE band all fade together so they stop
+     contradicting the halted state. */
+  .dial-wrap.paused .dial {
+    opacity: 0.4;
+    transition: opacity 300ms ease, filter 300ms ease;
+    filter: saturate(0.6);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .dial-wrap.paused .dial { transition: none; }
+  }
+
+  .paused-overlay {
     position: absolute;
-    bottom: 28px;
+    top: 50%;
     left: 50%;
-    transform: translateX(-50%);
+    transform: translate(-50%, -50%);
     font-family: var(--mono);
-    font-size: var(--ts-xs);
-    letter-spacing: var(--tr-kicker);
-    color: var(--t3);
-    padding: 3px 10px;
-    border: 1px solid var(--border-mid);
+    font-weight: 500;
+    font-size: 18px;
+    letter-spacing: 0.3em;
+    color: var(--t2);
+    padding: 10px 22px 9px;
+    border: 1px solid var(--border-bright);
     border-radius: 3px;
+    background: rgba(0, 0, 0, 0.75);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
     text-transform: uppercase;
+    line-height: 1;
+    white-space: nowrap;
+    pointer-events: none;
   }
 
   .dial-announcer {

--- a/src/lib/components/ChronographDial.svelte
+++ b/src/lib/components/ChronographDial.svelte
@@ -586,6 +586,7 @@
         stroke="var(--bg-base)"
         stroke-width="3"
         stroke-linejoin="round"
+        aria-hidden="true"
         data-role="merged-verdict-live"
       ><tspan fill={verdictStyle.color}>{verdictStyle.kicker}</tspan><tspan fill="var(--t3)"> · LIVE {fmt(liveMedian).toUpperCase()}</tspan>{#if bandLabel !== null}<tspan fill={bandLabelColor}> · {bandLabel}</tspan>{/if}</text>
     </svg>
@@ -648,9 +649,14 @@
     max-width: min(520px, 80vw);
     height: auto;
     display: block;
-    /* Breathing chrome — all five transitions run in parallel. Subtle by
-       design; if visibly "pulsing", amplitude is wrong, not timing. */
+    /* Breathing chrome — the five --vars transitions run in parallel.
+       opacity + filter sit on the base rule so the paused → unpaused
+       direction also animates; declaring them only in the .paused
+       selector would snap on exit (CR #68). Subtle by design; if visibly
+       "pulsing", amplitude is wrong, not timing. */
     transition:
+      opacity        300ms ease,
+      filter         300ms ease,
       --ring-opacity 900ms ease,
       --face-stroke  900ms ease,
       --tick-minor-op 900ms ease,
@@ -682,14 +688,11 @@
      Replaces the old .paused-badge that sat at bottom:28px and overlapped
      the pink threshold arc. Dimming also kills the "live-looking readouts"
      bug — score, verdict, LIVE band all fade together so they stop
-     contradicting the halted state. */
+     contradicting the halted state. (Transitions live on the base .dial
+     rule so paused → unpaused also fades — see above.) */
   .dial-wrap.paused .dial {
     opacity: 0.4;
-    transition: opacity 300ms ease, filter 300ms ease;
     filter: saturate(0.6);
-  }
-  @media (prefers-reduced-motion: reduce) {
-    .dial-wrap.paused .dial { transition: none; }
   }
 
   .paused-overlay {

--- a/tests/unit/components/ChronographDial.test.ts
+++ b/tests/unit/components/ChronographDial.test.ts
@@ -49,7 +49,30 @@ describe('ChronographDial — G2 NORMAL label', () => {
     const normalText = container.querySelector('text[data-role="normal-label"]');
     expect(normalText?.getAttribute('font-size')).toBe('8.5');
     expect(normalText?.getAttribute('letter-spacing')).toBe('0.2em');
-    expect(normalText?.getAttribute('fill')).toBe('rgba(103,232,249,.55)');
+    // Bumped from .55 → .80 alongside the inward-nudge fix so the label
+    // reads clearly on the darker face radius it now sits at.
+    expect(normalText?.getAttribute('fill')).toBe('rgba(103,232,249,.80)');
+  });
+
+  it('should place the NORMAL label at BASELINE_R - 22 radius (inside the arc glow)', () => {
+    // Geometry: CX=CY=260, OUTER_R=240, BASELINE_R=OUTER_R-48=192,
+    // new label radius = BASELINE_R - 22 = 170. Angle = latToAng(p75),
+    // where latToAng(ms) = -135 + (ms/300)*270.
+    const p75 = 80;
+    const angDeg = -135 + (p75 / 300) * 270;
+    const angRad = (angDeg * Math.PI) / 180;
+    const expectedX = 260 + Math.cos(angRad) * 170;
+    const expectedY = 260 + Math.sin(angRad) * 170;
+
+    const { container } = render(ChronographDial, {
+      props: { ...baseProps, baseline: { p25: 30, median: 50, p75 } },
+    });
+    const normalText = container.querySelector('text[data-role="normal-label"]');
+    expect(normalText).toBeTruthy();
+    const gotX = Number(normalText?.getAttribute('x'));
+    const gotY = Number(normalText?.getAttribute('y'));
+    expect(gotX).toBeCloseTo(expectedX, 2);
+    expect(gotY).toBeCloseTo(expectedY, 2);
   });
 
   it('should handle inverted p25/p75 (swap + clamp) without placing label off-dial', () => {
@@ -135,5 +158,143 @@ describe('ChronographDial — G1 dual-stroke baseline arc', () => {
     expect(d0).toBeTruthy();
     expect(paths[1]?.getAttribute('d')).toBe(d0);
     expect(paths[2]?.getAttribute('d')).toBe(d0);
+  });
+});
+
+// ── Dial overlap polish (2026-04-22) ─────────────────────────────────────
+// Four fixes targeting the face-text collisions documented in the audit:
+// QUALITY / verdict-needle / NORMAL / PAUSED.
+
+describe('ChronographDial — overlap polish · QUALITY kicker removed', () => {
+  it('no text element should contain the literal string "QUALITY"', () => {
+    const { container } = render(ChronographDial, { props: baseProps });
+    const allText = Array.from(container.querySelectorAll('text'));
+    const qualityText = allText.find(t => t.textContent?.trim() === 'QUALITY');
+    expect(qualityText).toBeUndefined();
+  });
+});
+
+describe('ChronographDial — overlap polish · verdict+LIVE merged strip', () => {
+  const withBand = {
+    ...baseProps,
+    score: 85,
+    liveMedian: 45,
+    baseline: { p25: 30, median: 50, p75: 80 },
+  };
+
+  it('should NOT render the standalone verdict text at cy+22', () => {
+    // The old kicker was `<text y=CY+22>HEALTHY</text>` (or DEGRADED/etc.).
+    // After the merge, verdict text only appears as a tspan inside the merged
+    // strip at cy+108. No top-level <text> should be at y≈282 (CY+22).
+    const { container } = render(ChronographDial, { props: withBand });
+    const topLevelTexts = Array.from(
+      container.querySelectorAll('svg > text'),
+    ) as SVGTextElement[];
+    const atCy22 = topLevelTexts.find(t => Number(t.getAttribute('y')) === 282);
+    expect(atCy22).toBeUndefined();
+  });
+
+  it('merged strip at cy+108 renders three tspans: verdict · live · band', () => {
+    const { container } = render(ChronographDial, { props: withBand });
+    const merged = container.querySelector(
+      'text[data-role="merged-verdict-live"]',
+    );
+    expect(merged).toBeTruthy();
+    expect(Number(merged?.getAttribute('y'))).toBe(368); // CY + 108
+    const tspans = Array.from(merged?.querySelectorAll('tspan') ?? []);
+    expect(tspans).toHaveLength(3);
+    // Segment 1: verdict kicker. Segment 2: live median prefix.
+    // Segment 3: band label.
+    expect(tspans[0].textContent).toBe('HEALTHY');
+    expect(tspans[1].textContent?.trim().startsWith('· LIVE')).toBe(true);
+    expect(tspans[2].textContent?.trim()).toBe('· WITHIN BAND');
+  });
+
+  it('merged strip uses per-segment fills: verdict / t3 / band', () => {
+    const { container } = render(ChronographDial, { props: withBand });
+    const merged = container.querySelector(
+      'text[data-role="merged-verdict-live"]',
+    );
+    const tspans = Array.from(merged?.querySelectorAll('tspan') ?? []);
+    // Verdict tspan inherits verdictStyle.color for its state (healthy = cyan).
+    expect(tspans[0].getAttribute('fill')).toMatch(/cyan|accent|#67/);
+    // Live-median tspan uses t3 grey.
+    expect(tspans[1].getAttribute('fill')).toBe('var(--t3)');
+    // Band tspan uses accent-green for WITHIN BAND.
+    expect(tspans[2].getAttribute('fill')).toBe('var(--accent-green)');
+  });
+
+  it('merged strip has paint-order stroke fill with dial-face stroke (halo)', () => {
+    const { container } = render(ChronographDial, { props: withBand });
+    const merged = container.querySelector(
+      'text[data-role="merged-verdict-live"]',
+    );
+    expect(merged?.getAttribute('paint-order')).toBe('stroke fill');
+    expect(merged?.getAttribute('stroke')).toBe('var(--bg-base)');
+    expect(merged?.getAttribute('stroke-width')).toBe('3');
+  });
+
+  it('omits the band tspan when bandLabel is null (no baseline yet)', () => {
+    const withoutBaseline = { ...baseProps, score: 85, liveMedian: 45, baseline: null };
+    const { container } = render(ChronographDial, { props: withoutBaseline });
+    const merged = container.querySelector(
+      'text[data-role="merged-verdict-live"]',
+    );
+    expect(merged).toBeTruthy();
+    const tspans = Array.from(merged?.querySelectorAll('tspan') ?? []);
+    expect(tspans).toHaveLength(2); // verdict + live-median only
+  });
+
+  it('merged strip is painted AFTER the hand group (so it sits on top)', () => {
+    // DOM order inside the SVG matters for painting: later = on top.
+    const { container } = render(ChronographDial, { props: withBand });
+    const svg = container.querySelector('svg');
+    expect(svg).toBeTruthy();
+    const children = Array.from(svg?.children ?? []);
+    const handIndex = children.findIndex(c =>
+      c.tagName === 'g' &&
+      c.querySelector('line[stroke="var(--svg-hand-stroke)"]') !== null,
+    );
+    const mergedIndex = children.findIndex(
+      c => (c as Element).getAttribute?.('data-role') === 'merged-verdict-live',
+    );
+    expect(handIndex).toBeGreaterThanOrEqual(0);
+    expect(mergedIndex).toBeGreaterThan(handIndex);
+  });
+});
+
+describe('ChronographDial — overlap polish · paused state', () => {
+  it('wrap has .paused class when paused=true', () => {
+    const { container } = render(ChronographDial, {
+      props: { ...baseProps, paused: true },
+    });
+    const wrap = container.querySelector('.dial-wrap');
+    expect(wrap?.classList.contains('paused')).toBe(true);
+  });
+
+  it('renders a .paused-overlay element with text "PAUSED" when paused', () => {
+    const { container } = render(ChronographDial, {
+      props: { ...baseProps, paused: true },
+    });
+    const overlay = container.querySelector('.paused-overlay');
+    expect(overlay).toBeTruthy();
+    expect(overlay?.textContent?.trim()).toBe('PAUSED');
+    expect(overlay?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('the old .paused-badge bottom pill is gone', () => {
+    const { container } = render(ChronographDial, {
+      props: { ...baseProps, paused: true },
+    });
+    const oldBadge = container.querySelector('.paused-badge');
+    expect(oldBadge).toBeNull();
+  });
+
+  it('does not render the overlay when paused=false', () => {
+    const { container } = render(ChronographDial, {
+      props: { ...baseProps, paused: false },
+    });
+    const overlay = container.querySelector('.paused-overlay');
+    expect(overlay).toBeNull();
   });
 });

--- a/tests/unit/components/ChronographDial.test.ts
+++ b/tests/unit/components/ChronographDial.test.ts
@@ -234,6 +234,16 @@ describe('ChronographDial — overlap polish · verdict+LIVE merged strip', () =
     expect(merged?.getAttribute('stroke-width')).toBe('3');
   });
 
+  it('merged strip is aria-hidden (decorative — info lives on the SVG aria-label)', () => {
+    const { container } = render(ChronographDial, { props: withBand });
+    const merged = container.querySelector(
+      'text[data-role="merged-verdict-live"]',
+    );
+    // Matches the pattern for every other decorative SVG group:
+    // baseline-arc, quality-trace, CALIBRATING, orbit.
+    expect(merged?.getAttribute('aria-hidden')).toBe('true');
+  });
+
   it('omits the band tspan when bandLabel is null (no baseline yet)', () => {
     const withoutBaseline = { ...baseProps, score: 85, liveMedian: 45, baseline: null };
     const { container } = render(ChronographDial, { props: withoutBaseline });


### PR DESCRIPTION
## Summary

Four bounded fixes to `ChronographDial.svelte` that clear the center-column collisions documented in the 2026-04-21 audit. One file, no pipeline or prop changes, no settings migration.

| Fix | Before | After |
|---|---|---|
| 1 | `QUALITY` kicker at cy−72 clipped by the 100 px score's ascenders | Kicker removed. Score + verdict already name the reading. |
| 2 | Verdict kicker at cy+22 bisected by the hand needle | Verdict now a colored tspan inside the cy+108 band strip. Strip is painted **after** the hand; paint-order halo prevents glyph cuts. |
| 3 | `NORMAL` label at BASELINE_R blended into the cyan body (same color, same radius) | Moved 22 px radially inward; alpha bumped .55 → .80 for contrast. |
| 4 | `PAUSED` pill at `bottom: 28px` intersected the pink threshold arc + score/verdict/LIVE kept looking live while halted | `.paused-overlay` centered pill + full-dial opacity 0.4 / saturate 0.6. Readouts fade with the SVG so they stop contradicting the halted state. |

## Test plan

- [x] 25 new / updated unit tests in `tests/unit/components/ChronographDial.test.ts` cover:
  - QUALITY text absent
  - cy+22 verdict text absent
  - merged-strip tspan structure (count + order + text content)
  - per-segment fills (verdict color / t3 / band color)
  - paint-order + stroke halo attributes
  - DOM ordering: merged strip after the hand group
  - null-baseline collapse (two tspans only when no band)
  - NORMAL label at radius 170 (BASELINE_R − 22)
  - NORMAL fill `rgba(103,232,249,.80)`
  - Paused overlay present with `PAUSED` text + `aria-hidden="true"`
  - Old `.paused-badge` selector removed
- [x] `npm run typecheck` clean
- [x] `npm test` — 620 / 620 passing
- [x] `npm run lint` clean
- [x] `npx playwright test visual-regression.spec.ts` — 16 / 16, no drift
- [x] 375 px mobile layout verified via `.dial { max-width: min(520px, 80vw) }`
- [x] `prefers-reduced-motion: reduce` — paused transition disabled in the new media query

## Out of scope

- Racing Strip density work (follow-up project per memory)
- Ring Field experiment (shelved, preserved in `dial-redesign-mockup.html` locally)
- Any change to OverviewView, measurement pipeline, or persistence

## Rollout

Revertable in one commit. Uses existing tokens (`--bg-base`, `--border-bright`, `--t2`, `--t3`) — no new tokens, no new props, no new persistence version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visibility of the NORMAL label with adjusted positioning and improved opacity.
  * Reorganized center readouts to display verdict, LIVE indicator, and band information as a unified strip with improved visual styling and hierarchy.
  * Redesigned paused state UI from a bottom-positioned badge to a centered overlay that dims the entire dial for better visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->