### PR TITLE
chore: ignore test-results and .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ docs/superpowers/
 docs/specs/
 .playwright-mcp/
 screenshots/
+test-results/
+.DS_Store


### PR DESCRIPTION
## Summary
- Add `test-results/` and `.DS_Store` to `.gitignore`. Playwright writes run artifacts to `test-results/` on every invocation, and macOS drops `.DS_Store` into any browsed directory — neither belongs in version control.

## Test plan
- [x] Working tree no longer surfaces `test-results/` or `.DS_Store` as untracked
- [ ] CI green on this branch