### PR TITLE
fix(live): drop oscilloscope/trig misnomers — it's a trace, not a scope

### DIFF
--- a/src/lib/components/LiveView.svelte
+++ b/src/lib/components/LiveView.svelte
@@ -69,10 +69,10 @@
   }
 </script>
 
-<section class="live-wrap" aria-label="Live oscilloscope">
+<section class="live-wrap" aria-label="Live latency trace">
   <header class="live-header">
     <div class="live-title-block">
-      <div class="live-kicker">Live · Oscilloscope</div>
+      <div class="live-kicker">Live · Trace</div>
       <h1 class="live-title">
         {#if soloEndpoint}
           <span class="live-title-solo">
@@ -80,7 +80,7 @@
             Tracing <span class="live-title-solo-label" style:color={soloEndpoint.color}>{soloEndpoint.label}</span>
           </span>
         {:else}
-          All endpoints · {liveOptions.split ? 'split' : 'unified'} scope
+          All endpoints · {liveOptions.split ? 'split' : 'unified'} view
         {/if}
       </h1>
     </div>
@@ -96,12 +96,12 @@
         </button>
       {/if}
 
-      <div class="live-control" role="group" aria-label="Scope mode">
+      <div class="live-control" role="group" aria-label="Layout mode">
         <span class="live-control-label">Mode</span>
         <div class="live-segment">
           <!--
             Pressed state tracks `liveOptions.split` (the user's stashed
-            preference), not the current `mode`. In solo mode the scope is
+            preference), not the current `mode`. In solo mode the trace is
             always a single full-height canvas regardless of the toggle, so
             we keep the toggle disabled + visually showing the stashed value
             so clicks are advisory — the preference will apply on unfocus.
@@ -123,8 +123,8 @@
         </div>
       </div>
 
-      <div class="live-control live-control-trig" aria-label="Trigger threshold, {threshold} milliseconds">
-        <span class="live-control-label">Trig</span>
+      <div class="live-control live-control-trig" aria-label="Health threshold, {threshold} milliseconds">
+        <span class="live-control-label">Threshold</span>
         <div class="trig-display">
           {threshold}<span>ms</span>
         </div>


### PR DESCRIPTION
## Summary

A friend pointed out that calling the Live view an "Oscilloscope" and labelling the health-threshold control as "Trig" overclaims — what the view actually displays is discrete, event-driven latency samples over time (a time-series trace), not a continuous-time analog waveform with sweep triggering. The name was aspirational aesthetic, not accurate function.

Only user-facing strings change; the dark-grid visual aesthetic and every internal name (`ScopeCanvas.svelte` filename, `.scope-stack` CSS class, `trace-repaint` token, etc.) stay as-is.

| Before | After | Where |
|---|---|---|
| `Live · Oscilloscope` | `Live · Trace` | kicker |
| `unified/split scope` | `unified/split view` | `{all endpoints · N view}` title |
| `aria-label="Live oscilloscope"` | `aria-label="Live latency trace"` | section wrapper |
| `aria-label="Scope mode"` | `aria-label="Layout mode"` | mode toggle group |
| `aria-label="Trigger threshold, …"` | `aria-label="Health threshold, …"` | threshold control |
| Control label `Trig` | Control label `Threshold` | threshold control |

## Test plan

- [ ] CI green (typecheck, lint, tests — 588/588 locally)
- [ ] CodeRabbit clean
- [ ] Visual regression: no Live-view snapshots exist in `tests/visual/*.spec.ts-snapshots/`, so no regeneration needed (verified)
- [ ] Spot-check in browser: Live view kicker reads "Live · Trace", threshold control reads "Threshold" and doesn't overflow the control strip at the default viewport

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated terminology and labels throughout the interface, including accessibility descriptions for controls.
  * Revised control naming conventions for mode selection and threshold settings.
  * Adjusted descriptive text for visualization controls to reflect current interface organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->