### PR TITLE
fix(deps): bump postcss to 8.5.10 (CVE-2026-41305)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2966,9 +2966,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- Closes Dependabot alert #1 (GHSA-qx2v-qp2m-jg93, CVSS 6.1 medium).
- postcss 8.5.9 → 8.5.10 via transitive resolution through `vite`, `eslint-plugin-svelte`, and `svelte-eslint-parser` (all already allow `^8.5.x`).
- Only `package-lock.json` changes — 3 lines.

## Exposure assessment

The CVE (XSS via unescaped `</style>` in CSS stringify) requires PostCSS to process attacker-controlled CSS and embed its output into a `<style>` tag at runtime. Chronoscope only runs PostCSS at build time via Vite against in-repo CSS, so real-world exposure is zero. This bump is hygiene — it closes the alert without adding risk.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 552 / 552 passing
- [x] `npm run build` — 191.70 kB / 59.95 kB gzip (unchanged)