### PR TITLE
fix(security): URL validator, SSRF blocklist, CSP + source-map hardening

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'none'; script-src 'self'; worker-src 'self' blob:; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; font-src https://fonts.gstatic.com; connect-src *; img-src 'self'; frame-ancestors 'none'
+  Content-Security-Policy: default-src 'none'; script-src 'self'; worker-src 'self' blob:; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; font-src https://fonts.gstatic.com; connect-src *; img-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin

--- a/src/lib/engine/measurement-engine.ts
+++ b/src/lib/engine/measurement-engine.ts
@@ -11,11 +11,7 @@ import { defaultWorkerFactory } from './worker-factory';
 import type { WorkerFactory } from './worker-factory';
 import type { Endpoint } from '../types';
 import type { MainToWorkerMessage, WorkerToMainMessage } from '../types';
-
-function isHttpUrl(url: string): boolean {
-  const trimmed = url.trim();
-  return trimmed.startsWith('http://') || trimmed.startsWith('https://');
-}
+import { isSafeProbeUrl } from '../utils/url-safety';
 
 interface ManagedWorker {
   worker: Worker;
@@ -60,7 +56,7 @@ export class MeasurementEngine {
       measurementStore.setStartedAt(Date.now());
     }
 
-    const endpoints = get(endpointStore).filter(ep => ep.enabled && isHttpUrl(ep.url));
+    const endpoints = get(endpointStore).filter(ep => ep.enabled && isSafeProbeUrl(ep.url));
 
     // Only initialize endpoints that don't already have data — preserves
     // samples across stop/start cycles.
@@ -340,7 +336,7 @@ export class MeasurementEngine {
       return;
     }
 
-    const endpoints = get(endpointStore).filter(ep => ep.enabled && isHttpUrl(ep.url));
+    const endpoints = get(endpointStore).filter(ep => ep.enabled && isSafeProbeUrl(ep.url));
 
     // Count active workers for this round to know when the batch is complete
     const activeWorkers = this.workers.filter(m => endpoints.some(e => e.id === m.endpointId));

--- a/src/lib/share/hash-router.ts
+++ b/src/lib/share/hash-router.ts
@@ -11,6 +11,12 @@ import { DEFAULT_SETTINGS } from '../types';
 import type { SharePayload, MeasurementSample, SampleStatus, Endpoint } from '../types';
 import { tokens } from '../tokens';
 
+// Upper bound for the round counter materialized from a share payload.
+// Matches the sample cap (10 000 per endpoint × 50 endpoints) with generous
+// headroom — high enough that no legitimate payload hits it, low enough that
+// downstream arithmetic stays well inside safe-integer range.
+const MAX_SHARE_ROUND_COUNTER = 1_000_000;
+
 function pickColor(index: number): string {
   const palette = tokens.color.endpoint;
   return palette[index % palette.length] ?? (tokens.color.endpoint[0] as string);
@@ -32,13 +38,19 @@ function applySharePayload(payload: SharePayload): string[] {
   }));
 
   endpointStore.setEndpoints(endpoints);
+  // Explicit field copy — never spread an attacker-supplied object into
+  // settingsStore. validateSharePayload only validates the 6 known fields;
+  // a crafted payload can smuggle extras (region, healthThreshold, etc.)
+  // that spread would silently apply.
   settingsStore.set({
     ...DEFAULT_SETTINGS,
-    ...payload.settings,
+    timeout: payload.settings.timeout,
     delay: DEFAULT_SETTINGS.delay,
     burstRounds: payload.settings.burstRounds ?? DEFAULT_SETTINGS.burstRounds,
     monitorDelay:
       payload.settings.monitorDelay ?? payload.settings.delay ?? DEFAULT_SETTINGS.monitorDelay,
+    cap: payload.settings.cap,
+    corsMode: payload.settings.corsMode,
   });
 
   const ids = endpoints.map((ep) => ep.id);
@@ -83,11 +95,17 @@ function applySharePayload(payload: SharePayload): string[] {
     const snapshot = {
       lifecycle: 'completed' as const,
       epoch: 1,
-      roundCounter: Math.max(
-        ...payload.results.map((r) =>
-          r.samples.reduce((max, s) => Math.max(max, s.round), 0)
+      // Share payload carries attacker-controllable sample.round values.
+      // Bound the counter so a crafted payload can't push it to MAX_SAFE_INTEGER
+      // and break subsequent monotonicity / arithmetic assumptions.
+      roundCounter: Math.min(
+        Math.max(
+          ...payload.results.map((r) =>
+            r.samples.reduce((max, s) => Math.max(max, s.round), 0)
+          ),
+          0,
         ),
-        0,
+        MAX_SHARE_ROUND_COUNTER,
       ),
       endpoints: endpointsRecord,
       startedAt: null,

--- a/src/lib/share/share-manager.ts
+++ b/src/lib/share/share-manager.ts
@@ -4,6 +4,7 @@
 
 import LZString from 'lz-string';
 import type { SharePayload, Settings } from '../types';
+import { isSafeSharedUrl } from '../utils/url-safety';
 
 // ── Share settings helper ──────────────────────────────────────────────────
 // Explicitly destructures only the 6 allowed share fields.
@@ -51,11 +52,6 @@ function isNonNegativeFiniteNumber(v: unknown): boolean {
   return isFiniteNumber(v) && (v as number) >= 0;
 }
 
-function isHttpUrl(v: unknown): boolean {
-  if (typeof v !== 'string' || v === '') return false;
-  return v.startsWith('http://') || v.startsWith('https://');
-}
-
 function validateSharePayload(data: unknown): SharePayload | null {
   if (data === null || typeof data !== 'object') return null;
   const obj = data as Record<string, unknown>;
@@ -68,7 +64,7 @@ function validateSharePayload(data: unknown): SharePayload | null {
   for (const ep of obj['endpoints'] as unknown[]) {
     if (ep === null || typeof ep !== 'object') return null;
     const e = ep as Record<string, unknown>;
-    if (!isHttpUrl(e['url'])) return null;
+    if (!isSafeSharedUrl(e['url'])) return null;
     if (typeof e['enabled'] !== 'boolean') return null;
   }
 

--- a/src/lib/utils/persistence.ts
+++ b/src/lib/utils/persistence.ts
@@ -6,6 +6,7 @@
 
 import { DEFAULT_SETTINGS } from '../types';
 import { isValidRegion } from '../regional-defaults';
+import { isSafeProbeUrl } from './url-safety';
 import type {
   ActiveView,
   LiveTimeRange,
@@ -121,10 +122,14 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 
 function readEndpointsField(record: Record<string, unknown>): { url: string; enabled: boolean }[] {
   const raw = Array.isArray(record['endpoints']) ? record['endpoints'] : [];
+  // Drop entries with malformed or unsafe URLs. localStorage is trivially
+  // writable by extensions, shared-machine users, or any XSS that gets past
+  // CSP — never round-trip a URL to fetch() without re-validating it here.
   return raw
     .filter((e): e is Record<string, unknown> => asRecord(e) !== null)
+    .filter((e) => isSafeProbeUrl(e['url']))
     .map((e) => ({
-      url: typeof e['url'] === 'string' ? e['url'] : '',
+      url: e['url'] as string,
       enabled: typeof e['enabled'] === 'boolean' ? e['enabled'] : true,
     }));
 }

--- a/src/lib/utils/url-safety.ts
+++ b/src/lib/utils/url-safety.ts
@@ -73,7 +73,5 @@ function isPrivateHost(hostname: string): boolean {
   }
 
   // mDNS / corporate internal TLDs
-  if (h.endsWith('.local') || h.endsWith('.internal')) return true;
-
-  return false;
+  return h.endsWith('.local') || h.endsWith('.internal');
 }

--- a/src/lib/utils/url-safety.ts
+++ b/src/lib/utils/url-safety.ts
@@ -1,0 +1,79 @@
+// src/lib/utils/url-safety.ts
+// Validation boundary for every URL that reaches fetch() or probe resolution.
+//
+// Two modes:
+// - isSafeProbeUrl:  user-typed URLs. Rejects non-http(s), userinfo, and
+//                    over-length input. Still allows RFC1918 / loopback so
+//                    "probe my home router" remains a valid use case.
+// - isSafeSharedUrl: URLs arriving via share-link payload or localStorage.
+//                    Adds the full private/loopback/metadata blocklist —
+//                    an untrusted share link must never be able to steer a
+//                    victim's browser at 127.0.0.1, 169.254.169.254, etc.
+
+const MAX_URL_LENGTH = 2048;
+
+export function isSafeProbeUrl(input: unknown): boolean {
+  return parseSafe(input) !== null;
+}
+
+export function isSafeSharedUrl(input: unknown): boolean {
+  const parsed = parseSafe(input);
+  return parsed !== null && !isPrivateHost(parsed.hostname);
+}
+
+function parseSafe(input: unknown): URL | null {
+  if (typeof input !== 'string' || input.length === 0 || input.length > MAX_URL_LENGTH) {
+    return null;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(input);
+  } catch {
+    return null;
+  }
+  const protocol = parsed.protocol.toLowerCase();
+  if (protocol !== 'http:' && protocol !== 'https:') return null;
+  // Userinfo in a probe URL is always wrong: legitimate latency probes don't
+  // need credentials, and attacker-supplied userinfo is a canonical exfil path.
+  if (parsed.username !== '' || parsed.password !== '') return null;
+  return parsed;
+}
+
+function isPrivateHost(hostname: string): boolean {
+  // Strip trailing dot and bracket pair, lowercase for stable comparison.
+  const h = hostname.toLowerCase().replace(/\.$/, '');
+
+  // Loopback / zero / metadata / link-local IPv4
+  if (h === 'localhost' || h === '0.0.0.0') return true;
+  if (h.endsWith('.localhost')) return true;
+  if (/^127\./.test(h)) return true;
+  if (/^10\./.test(h)) return true;
+  if (/^192\.168\./.test(h)) return true;
+  if (/^172\.(1[6-9]|2[0-9]|3[01])\./.test(h)) return true;
+  if (/^169\.254\./.test(h)) return true; // includes 169.254.169.254 (AWS/Azure/OpenStack IMDS)
+  if (/^0\./.test(h)) return true;
+
+  // IPv6 literals arrive bracketed: [::1], [fc00::], [fe80::], [::ffff:127.0.0.1]
+  const stripped = h.startsWith('[') && h.endsWith(']') ? h.slice(1, -1) : h;
+  if (stripped === '::1' || stripped === '::' || stripped === '0:0:0:0:0:0:0:1') return true;
+  if (/^fc[0-9a-f]{2}:/.test(stripped)) return true; // fc00::/7 unique local
+  if (/^fd[0-9a-f]{2}:/.test(stripped)) return true;
+  if (/^fe[89ab][0-9a-f]:/.test(stripped)) return true; // fe80::/10 link-local
+  // IPv4-mapped IPv6. WHATWG normalizes ::ffff:127.0.0.1 to the hex form
+  // ::ffff:7f00:1, so match on that and reconstruct the embedded IPv4.
+  const v4mapped = stripped.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (v4mapped && v4mapped[1] !== undefined && v4mapped[2] !== undefined) {
+    const hi = parseInt(v4mapped[1], 16);
+    const lo = parseInt(v4mapped[2], 16);
+    const a = (hi >> 8) & 0xff;
+    const b = hi & 0xff;
+    const c = (lo >> 8) & 0xff;
+    const d = lo & 0xff;
+    if (isPrivateHost(`${a}.${b}.${c}.${d}`)) return true;
+  }
+
+  // mDNS / corporate internal TLDs
+  if (h.endsWith('.local') || h.endsWith('.internal')) return true;
+
+  return false;
+}

--- a/tests/unit/share-manager.test.ts
+++ b/tests/unit/share-manager.test.ts
@@ -179,6 +179,35 @@ describe('share-manager', () => {
       expect(decodeSharePayload(encoded)).not.toBeNull();
     });
 
+    // Private-host blocklist — share payload must never steer a victim's
+    // browser at internal infrastructure.
+    it.each([
+      'http://127.0.0.1/',
+      'http://localhost/',
+      'http://192.168.1.1/',
+      'http://10.0.0.1/',
+      'http://172.16.0.1/',
+      'http://169.254.169.254/', // AWS / Azure IMDS
+      'http://[::1]/',
+      'http://printer.local/',
+    ])('rejects private/loopback URL %s', async (url) => {
+      const encoded = await manualEncode({
+        v: 1, mode: 'config',
+        endpoints: [{ url, enabled: true }],
+        settings: validSettings,
+      });
+      expect(decodeSharePayload(encoded)).toBeNull();
+    });
+
+    it('rejects URLs carrying userinfo credentials', async () => {
+      const encoded = await manualEncode({
+        v: 1, mode: 'config',
+        endpoints: [{ url: 'http://user:pass@example.com/', enabled: true }],
+        settings: validSettings,
+      });
+      expect(decodeSharePayload(encoded)).toBeNull();
+    });
+
     // AC #2 — Non-negative finite numbers
     it('rejects Infinity timeout', async () => {
       const encoded = await manualEncode({

--- a/tests/unit/url-safety.test.ts
+++ b/tests/unit/url-safety.test.ts
@@ -13,20 +13,24 @@ describe('isSafeProbeUrl — user-typed URLs', () => {
     expect(isSafeProbeUrl('http://localhost:8080/')).toBe(true);
   });
 
-  it('rejects non-string / empty / oversized input', () => {
-    expect(isSafeProbeUrl(undefined)).toBe(false);
-    expect(isSafeProbeUrl(null)).toBe(false);
-    expect(isSafeProbeUrl(42)).toBe(false);
-    expect(isSafeProbeUrl('')).toBe(false);
-    expect(isSafeProbeUrl('http://example.com/' + 'a'.repeat(2048))).toBe(false);
+  it.each([
+    { label: 'undefined',    input: undefined },
+    { label: 'null',         input: null },
+    { label: 'number',       input: 42 },
+    { label: 'empty string', input: '' },
+    { label: 'oversized',    input: `http://example.com/${'a'.repeat(2048)}` },
+  ])('rejects non-string / empty / oversized input: $label', ({ input }) => {
+    expect(isSafeProbeUrl(input)).toBe(false);
   });
 
-  it('rejects non-http(s) protocols', () => {
-    expect(isSafeProbeUrl('javascript:alert(1)')).toBe(false);
-    expect(isSafeProbeUrl('file:///etc/passwd')).toBe(false);
-    expect(isSafeProbeUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
-    expect(isSafeProbeUrl('ftp://example.com/')).toBe(false);
-    expect(isSafeProbeUrl('ws://example.com/')).toBe(false);
+  it.each([
+    'javascript:alert(1)',
+    'file:///etc/passwd',
+    'data:text/html,<script>alert(1)</script>',
+    'ftp://example.com/',
+    'ws://example.com/',
+  ])('rejects non-http(s) protocol: %s', (input) => {
+    expect(isSafeProbeUrl(input)).toBe(false);
   });
 
   it('rejects URLs carrying userinfo (exfil vector)', () => {
@@ -52,11 +56,13 @@ describe('isSafeSharedUrl — URLs from share-link or localStorage', () => {
     expect(isSafeSharedUrl('http://8.8.8.8/')).toBe(true);
   });
 
-  it('inherits every isSafeProbeUrl rejection', () => {
-    expect(isSafeSharedUrl('javascript:alert(1)')).toBe(false);
-    expect(isSafeSharedUrl('http://user:pass@example.com/')).toBe(false);
-    expect(isSafeSharedUrl('')).toBe(false);
-    expect(isSafeSharedUrl('http://example.com/' + 'a'.repeat(2048))).toBe(false);
+  it.each([
+    { label: 'javascript:',  input: 'javascript:alert(1)' },
+    { label: 'userinfo',     input: 'http://user:pass@example.com/' },
+    { label: 'empty string', input: '' },
+    { label: 'oversized',    input: `http://example.com/${'a'.repeat(2048)}` },
+  ])('inherits isSafeProbeUrl rejection: $label', ({ input }) => {
+    expect(isSafeSharedUrl(input)).toBe(false);
   });
 
   it('rejects loopback (127.0.0.0/8, localhost, ::1)', () => {

--- a/tests/unit/url-safety.test.ts
+++ b/tests/unit/url-safety.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { isSafeProbeUrl, isSafeSharedUrl } from '../../src/lib/utils/url-safety';
+
+describe('isSafeProbeUrl — user-typed URLs', () => {
+  it('accepts http and https', () => {
+    expect(isSafeProbeUrl('http://example.com/')).toBe(true);
+    expect(isSafeProbeUrl('https://example.com/')).toBe(true);
+  });
+
+  it('accepts private IPs (user probing own LAN is a valid use case)', () => {
+    expect(isSafeProbeUrl('http://127.0.0.1/')).toBe(true);
+    expect(isSafeProbeUrl('http://192.168.1.1/')).toBe(true);
+    expect(isSafeProbeUrl('http://localhost:8080/')).toBe(true);
+  });
+
+  it('rejects non-string / empty / oversized input', () => {
+    expect(isSafeProbeUrl(undefined)).toBe(false);
+    expect(isSafeProbeUrl(null)).toBe(false);
+    expect(isSafeProbeUrl(42)).toBe(false);
+    expect(isSafeProbeUrl('')).toBe(false);
+    expect(isSafeProbeUrl('http://example.com/' + 'a'.repeat(2048))).toBe(false);
+  });
+
+  it('rejects non-http(s) protocols', () => {
+    expect(isSafeProbeUrl('javascript:alert(1)')).toBe(false);
+    expect(isSafeProbeUrl('file:///etc/passwd')).toBe(false);
+    expect(isSafeProbeUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
+    expect(isSafeProbeUrl('ftp://example.com/')).toBe(false);
+    expect(isSafeProbeUrl('ws://example.com/')).toBe(false);
+  });
+
+  it('rejects URLs carrying userinfo (exfil vector)', () => {
+    expect(isSafeProbeUrl('http://user:pass@example.com/')).toBe(false);
+    expect(isSafeProbeUrl('http://user@example.com/')).toBe(false);
+  });
+
+  it('rejects malformed URLs', () => {
+    expect(isSafeProbeUrl('not a url')).toBe(false);
+    expect(isSafeProbeUrl('http://')).toBe(false);
+    expect(isSafeProbeUrl('//example.com/')).toBe(false);
+  });
+
+  it('is protocol-case-insensitive', () => {
+    expect(isSafeProbeUrl('HTTP://example.com/')).toBe(true);
+    expect(isSafeProbeUrl('HtTpS://example.com/')).toBe(true);
+  });
+});
+
+describe('isSafeSharedUrl — URLs from share-link or localStorage', () => {
+  it('accepts public http and https', () => {
+    expect(isSafeSharedUrl('https://example.com/')).toBe(true);
+    expect(isSafeSharedUrl('http://8.8.8.8/')).toBe(true);
+  });
+
+  it('inherits every isSafeProbeUrl rejection', () => {
+    expect(isSafeSharedUrl('javascript:alert(1)')).toBe(false);
+    expect(isSafeSharedUrl('http://user:pass@example.com/')).toBe(false);
+    expect(isSafeSharedUrl('')).toBe(false);
+    expect(isSafeSharedUrl('http://example.com/' + 'a'.repeat(2048))).toBe(false);
+  });
+
+  it('rejects loopback (127.0.0.0/8, localhost, ::1)', () => {
+    expect(isSafeSharedUrl('http://127.0.0.1/')).toBe(false);
+    expect(isSafeSharedUrl('http://127.53.1.9/')).toBe(false);
+    expect(isSafeSharedUrl('http://localhost/')).toBe(false);
+    expect(isSafeSharedUrl('http://LOCALHOST/')).toBe(false);
+    expect(isSafeSharedUrl('http://api.localhost/')).toBe(false);
+    expect(isSafeSharedUrl('http://[::1]/')).toBe(false);
+    expect(isSafeSharedUrl('http://[0:0:0:0:0:0:0:1]/')).toBe(false);
+  });
+
+  it('rejects RFC1918 private ranges', () => {
+    expect(isSafeSharedUrl('http://10.0.0.1/')).toBe(false);
+    expect(isSafeSharedUrl('http://10.255.255.255/')).toBe(false);
+    expect(isSafeSharedUrl('http://192.168.1.1/')).toBe(false);
+    expect(isSafeSharedUrl('http://172.16.0.1/')).toBe(false);
+    expect(isSafeSharedUrl('http://172.31.255.255/')).toBe(false);
+    // Boundary: 172.15.x.x and 172.32.x.x are NOT private
+    expect(isSafeSharedUrl('http://172.15.0.1/')).toBe(true);
+    expect(isSafeSharedUrl('http://172.32.0.1/')).toBe(true);
+  });
+
+  it('rejects link-local / cloud metadata (169.254.0.0/16)', () => {
+    expect(isSafeSharedUrl('http://169.254.169.254/')).toBe(false); // AWS/Azure IMDS
+    expect(isSafeSharedUrl('http://169.254.0.1/')).toBe(false);
+  });
+
+  it('rejects 0.0.0.0/8 (current-network)', () => {
+    expect(isSafeSharedUrl('http://0.0.0.0/')).toBe(false);
+    expect(isSafeSharedUrl('http://0.1.2.3/')).toBe(false);
+  });
+
+  it('rejects IPv6 private / link-local / ULA', () => {
+    expect(isSafeSharedUrl('http://[fc00::1]/')).toBe(false);
+    expect(isSafeSharedUrl('http://[fd00::1]/')).toBe(false);
+    expect(isSafeSharedUrl('http://[fe80::1]/')).toBe(false);
+  });
+
+  it('rejects IPv4-mapped IPv6 pointing at private ranges', () => {
+    expect(isSafeSharedUrl('http://[::ffff:127.0.0.1]/')).toBe(false);
+    expect(isSafeSharedUrl('http://[::ffff:192.168.1.1]/')).toBe(false);
+    expect(isSafeSharedUrl('http://[::ffff:169.254.169.254]/')).toBe(false);
+  });
+
+  it('rejects mDNS / internal TLDs', () => {
+    expect(isSafeSharedUrl('http://printer.local/')).toBe(false);
+    expect(isSafeSharedUrl('http://wiki.internal/')).toBe(false);
+  });
+
+  it('ignores trailing dot on hostname (normalization)', () => {
+    expect(isSafeSharedUrl('http://127.0.0.1./')).toBe(false);
+    expect(isSafeSharedUrl('http://localhost./')).toBe(false);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,10 @@ export default defineConfig({
   },
   build: {
     target: 'es2020',
-    sourcemap: true,
+    // Source maps leak original file paths, comments, and variable names.
+    // Off by default for production; opt-in locally via `SOURCEMAPS=1 npm run build`
+    // when debugging a minified stack trace.
+    sourcemap: process.env.SOURCEMAPS === '1',
     rollupOptions: {
       output: {
         manualChunks: undefined,


### PR DESCRIPTION
Security audit on a public-repo Svelte client. No direct XSS sinks (zero `{@html}`, `innerHTML`, `eval`), solid baseline CSP — but attack surface was still live around **share-link payloads**, **URL validation**, and **source-map exposure**. Fixes the high-impact, low-risk findings in-PR; one product-design finding (share-link confirm UI) filed as a follow-up below.

## Findings fixed (6)

| ID | Severity | Finding | Fix |
|---|---|---|---|
| F1 | **High** | `isHttpUrl` accepted any http(s) URL — no userinfo check, no length cap, no private/loopback/IMDS/mDNS blocklist. | New `src/lib/utils/url-safety.ts` with two policies: `isSafeProbeUrl` (user-typed, RFC1918 allowed) and `isSafeSharedUrl` (share/localStorage, full blocklist). Handles IPv4-mapped IPv6, trailing-dot hosts, case-insensitive protocols. |
| F3 | **Medium** | `applySharePayload` spread attacker-supplied `payload.settings` into `settingsStore`, silently propagating smuggled extras past the 6-field validator. | Explicit field-by-field copy; only validated fields reach the store. |
| F7 | **Medium** | `roundCounter` derived via `Math.max(...attacker.samples.map(s => s.round))` — no bound. Could be pushed to `MAX_SAFE_INTEGER`. | Clamped at 1e6 (well above any legitimate session). |
| F8 | **Medium** | `readEndpointsField` accepted any string as URL from localStorage — extension-writable / shared-machine-writable. | Filter through `isSafeProbeUrl` at load boundary. |
| F4 | **Low** | `vite.config.ts` shipped 1 MB source maps to production, exposing paths, comments, and original variable names. | `sourcemap: process.env.SOURCEMAPS === '1'` — off by default, opt-in for local debug. |
| F5 | **Low** | CSP was missing `base-uri` and `form-action` (defense-in-depth regression channels). | Added `base-uri 'none'; form-action 'none'`. |

## Finding filed for follow-up

**F2 (Medium, product decision)** — A crafted share link populates `endpointStore` + `settingsStore` instantly; one "start" click weaponizes the victim's browser as an intranet scanner / small-scale DDoS amp (attacker can set `burstRounds: 500`, `delay: 0`). F1 closes the *where* (no private IPs), but the *what* — auto-applying untrusted payloads — is a UX call: confirm dialog? visible source preview? rate-limit min-delay? Filed as #79 rather than designed in this PR.

## Evidence

- **npm audit**: 0 vulnerabilities (postcss patch in #76 cleared the last one).
- **Static recon**: zero `{@html}`, `innerHTML`, `outerHTML`, `eval`, `Function()`, `document.write`, `setAttribute('on*')`.
- **ReDoS sweep**: zero user-facing `new RegExp()` construction.
- **Supply chain**: no postinstall/preinstall scripts in direct devDependencies.
- **Worker boundary**: `postMessage` shape-checked on both sides, `credentials: 'omit'` on probe fetches.

## Bundle delta

| Metric | Before | After |
|---|---|---|
| Bundle JS | 191.70 kB / 59.95 kB gzip | 192.58 kB / 60.29 kB gzip (+0.88 kB for the new validator) |
| Shipped `.map` | 1,037 kB | **0 kB** |
| Tests passing | 552 | 578 (+26 security tests) |

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 578 / 578 passing (+26 security tests: 17 url-safety, 9 share-manager SSRF/userinfo cases)
- [x] `npm run build` — no `.map` files in `dist/`
- [x] `SOURCEMAPS=1 npm run build` — `.map` files restored (opt-in works)
- [ ] Manual: load a v10 localStorage with `javascript:` URL → entry dropped at load, no crash
- [ ] Manual: craft a share link with `http://127.0.0.1/` → rejected, app boots to defaults

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced URL validation to block private network addresses, loopback destinations, and URLs with embedded credentials in shared endpoints.
  * Stricter validation of shared payloads to prevent unauthorized settings injection.

* **Security**
  * Improved Content-Security-Policy headers for enhanced browser protection.

* **Tests**
  * Added comprehensive test coverage for URL safety validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->