### PR TITLE
feat(overview): fluid grid + container-query dial for wide viewports

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -7,6 +7,13 @@
 :root {
   --sans: 'Sora', system-ui, sans-serif;
   --mono: 'Martian Mono', monospace;
+
+  /* Layout ceilings — consumed by OverviewView grid and ChronographDial.
+     Fluid below the ceiling (grid via 92vw, dial via 90cqi on its column),
+     capped here so the dial doesn't become wall-sized on 4K monitors. */
+  --content-max-w: 2200px;
+  --dial-min-w: 520px;
+  --dial-max-w: 720px;
 }
 
 html, body {

--- a/src/lib/components/ChronographDial.svelte
+++ b/src/lib/components/ChronographDial.svelte
@@ -646,10 +646,13 @@
 
   .dial {
     width: 100%;
-    /* 520 px is the design size. On short viewports (laptop floor 1366×768)
-       the dial caps at 440 px so the verdict strip fits above the fold. On
-       mobile widths it caps at 320 px — above the 300 px legibility floor. */
-    max-width: min(520px, 80vw);
+    /* Floor 520 px (original design size) on laptop, grows with the column
+       via container query up to 720 px on wide displays. 90cqi = 90% of the
+       .overview-left column inline size, so the dial tracks its own column
+       and ignores the rail/viewport directly. Short viewports and mobile
+       are handled by the @media overrides below (laptop floor 1366×768,
+       mobile 767/375, short-height ≤820). */
+    max-width: clamp(var(--dial-min-w, 520px), 90cqi, var(--dial-max-w, 720px));
     height: auto;
     display: block;
     /* Breathing chrome — the five --vars transitions run in parallel.

--- a/src/lib/components/OverviewView.svelte
+++ b/src/lib/components/OverviewView.svelte
@@ -342,22 +342,27 @@
   }
 
   /* Two-column grid: dial + causal verdict on the left, racing strip + event
-     feed on the right. Collapses to one column below 1024 px. Centered with
-     max-width so wide viewports don't stretch the grid. */
+     feed on the right. Collapses to one column below 1024 px. Fluid above
+     1440 up to the --content-max-w ceiling so ultrawide monitors use their
+     real estate instead of floating the grid in a centered 1440 box. */
   .overview-grid {
     width: 100%;
-    max-width: 1440px;
+    max-width: min(92vw, var(--content-max-w));
     margin: 0 auto;
     display: grid;
     grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
     gap: 20px;
     align-items: start;
   }
+  /* container-type lets the dial size against this column's actual width via
+     `cqi`, so it grows with the column on wide viewports without having to
+     know about the rail, gutters, or viewport directly. */
   .overview-left {
     display: flex;
     flex-direction: column;
     gap: 12px;
     min-width: 0;
+    container-type: inline-size;
   }
   .overview-right {
     display: flex;

--- a/tests/visual/overview-no-scroll.spec.ts
+++ b/tests/visual/overview-no-scroll.spec.ts
@@ -5,13 +5,15 @@ import { test, expect, type Page } from '@playwright/test';
 // lifecycle (cold / first round). See
 // docs/superpowers/research/2026-04-22-overview-no-scroll-acceptance-criteria.md.
 
-const FLOORS = [
+// Viewports the no-scroll invariant must hold at: the original "floor"
+// cases (1366×768 desktop, 360/390-wide mobile) plus wide displays added
+// for the fluid grid/dial ceiling. 1920×1080 is common laptop;
+// 2560×1440 is typical 32" monitor — the case the fluid layout was
+// introduced for.
+const VIEWPORTS = [
   { name: 'desktop-floor', width: 1366, height: 768 },
   { name: 'mobile-floor',  width: 360,  height: 780 },
   { name: 'mobile-390',    width: 390,  height: 844 },
-  // Wide viewports — guard against regressions in the fluid grid/dial ceiling.
-  // 1920×1080 is common laptop; 2560×1440 is typical 32" monitor (the case
-  // the fluid layout was introduced for).
   { name: 'desktop-1920',  width: 1920, height: 1080 },
   { name: 'desktop-2560',  width: 2560, height: 1440 },
 ] as const;
@@ -68,7 +70,7 @@ const scrollState = async (page: Page): Promise<ScrollCheck> => {
 };
 
 test.describe('Overview — no scroll on first visit', () => {
-  for (const vp of FLOORS) {
+  for (const vp of VIEWPORTS) {
     test(`cold state @ ${vp.name} (${vp.width}×${vp.height})`, async ({ page }) => {
       await page.setViewportSize({ width: vp.width, height: vp.height });
       await page.goto('/');
@@ -96,7 +98,7 @@ test.describe('Overview — no scroll on first visit', () => {
       await page.setViewportSize({ width: w, height: h });
       await page.goto('/');
       await page.waitForSelector('#chronoscope-root');
-      await page.waitForTimeout(300);
+      await page.waitForTimeout(400);
       return await page.evaluate(() => {
         const dial = document.querySelector<SVGElement>('svg.dial');
         const grid = document.querySelector<HTMLElement>('.overview-grid');

--- a/tests/visual/overview-no-scroll.spec.ts
+++ b/tests/visual/overview-no-scroll.spec.ts
@@ -9,6 +9,11 @@ const FLOORS = [
   { name: 'desktop-floor', width: 1366, height: 768 },
   { name: 'mobile-floor',  width: 360,  height: 780 },
   { name: 'mobile-390',    width: 390,  height: 844 },
+  // Wide viewports — guard against regressions in the fluid grid/dial ceiling.
+  // 1920×1080 is common laptop; 2560×1440 is typical 32" monitor (the case
+  // the fluid layout was introduced for).
+  { name: 'desktop-1920',  width: 1920, height: 1080 },
+  { name: 'desktop-2560',  width: 2560, height: 1440 },
 ] as const;
 
 interface ScrollerReport {
@@ -82,6 +87,40 @@ test.describe('Overview — no scroll on first visit', () => {
       ).toEqual([]);
     });
   }
+
+  // Guards the fluid grid + container-query dial introduced for ultrawide
+  // monitors. If someone reverts the grid ceiling or the dial's cqi rule, the
+  // dial snaps back to its 520 px design size and this test fires.
+  test('dial and grid grow on wide viewports', async ({ page }) => {
+    const measure = async (w: number, h: number) => {
+      await page.setViewportSize({ width: w, height: h });
+      await page.goto('/');
+      await page.waitForSelector('#chronoscope-root');
+      await page.waitForTimeout(300);
+      return await page.evaluate(() => {
+        const dial = document.querySelector<SVGElement>('svg.dial');
+        const grid = document.querySelector<HTMLElement>('.overview-grid');
+        return {
+          dialW: dial ? dial.getBoundingClientRect().width : 0,
+          gridW: grid ? grid.getBoundingClientRect().width : 0,
+        };
+      });
+    };
+
+    const at1440 = await measure(1440, 900);
+    const at2560 = await measure(2560, 1440);
+
+    // 1440 holds the design size (floor); 2560 hits both ceilings.
+    expect(at1440.dialW, 'dial at 1440').toBeGreaterThanOrEqual(515);
+    expect(at1440.dialW, 'dial at 1440').toBeLessThanOrEqual(560);
+    expect(at2560.dialW, 'dial at 2560').toBeGreaterThanOrEqual(700);
+    expect(at2560.dialW, 'dial at 2560').toBeLessThanOrEqual(725);
+    expect(at2560.gridW, 'grid at 2560').toBeGreaterThanOrEqual(2150);
+    expect(at2560.gridW, 'grid at 2560').toBeLessThanOrEqual(2205);
+    // The grid at 2560 must be materially wider than at 1440 — the whole
+    // point of the fluid layout.
+    expect(at2560.gridW).toBeGreaterThan(at1440.gridW + 600);
+  });
 
   test('lifecycle stability @ mobile-floor (no reflow after engine starts)', async ({ page }) => {
     await page.setViewportSize({ width: 360, height: 780 });


### PR DESCRIPTION
## Summary
- Overview grid was capped at 1440 px and the dial at 520 px, so on 27–32″ monitors the content floated in a centered box with ~1000 px of dead space to the right.
- Raise the grid ceiling to 2200 px (fluid via `min(92vw, …)`) and make the dial size against its column via `90cqi` with a 520 → 720 px clamp. The dial tracks its own column through container queries instead of knowing about the rail or viewport directly.
- Structural breakpoints (1023 / 767 / 375 px, short-height ≤820 px) and mobile caps untouched — this only changes behavior above 1440 px wide on normal-height viewports.

## Behavior (grid × dial at representative widths)
| Viewport | Grid | Dial | vs. today |
|---|---|---|---|
| 1366×768 | fills | 440 (short-height rule) | unchanged |
| 1440×900 | fills | 520 (floor) | grid fills, dial unchanged |
| 1920×1080 | fills (≈1650) | ≈720 (ceiling) | grid +216, dial +200 |
| 2560×1440 | 2200 (ceiling) | 720 | grid +760, dial +200 |
| 3840×2160 | 2200 | 720 | capped — letterboxes by design |

## Design decisions
- **Container queries on the dial, viewport `min()` on the grid.** The grid is the top-level layout — it has no meaningful container besides the shell. The dial is a component that should size against its assigned column; `90cqi` keeps it decoupled from the rail width.
- **Tokens in `app.css`, not `tokens.ts`.** These are static CSS values — no TS round-trip needed. `--content-max-w`, `--dial-min-w`, `--dial-max-w`.
- **Deferred as premature for this product's scope:** density mode, Utopia-style fluid type/space scale, named viewport-tier tokens. Add when the surface area justifies it.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (589 passed)
- [x] `npx playwright test tests/visual/overview-no-scroll.spec.ts` (7 passed, including new 1920×1080 and 2560×1440 coverage + a dial/grid growth assertion that fails if the fluid rules are reverted)
- [ ] Manual check on a real 32″ monitor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced responsive layout for ultrawide displays, scaling fluidly up to 2560px width
  * Improved dial component sizing with better responsiveness across viewport widths

* **Tests**
  * Added visual regression tests for ultrawide viewport coverage to ensure layout consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->