### PR TITLE
fix(share): stage config-mode shares + drop payload cadence (#79)

### DIFF
--- a/src/lib/components/App.svelte
+++ b/src/lib/components/App.svelte
@@ -19,6 +19,7 @@
   import SettingsDrawer from './SettingsDrawer.svelte';
   import SharePopover from './SharePopover.svelte';
   import SharedResultsBanner from './SharedResultsBanner.svelte';
+  import ConfigStagingBanner from './ConfigStagingBanner.svelte';
   import EndpointDrawer from './EndpointDrawer.svelte';
   import KeyboardOverlay from './KeyboardOverlay.svelte';
 
@@ -184,10 +185,15 @@
     bridgeTokensToCss();
 
     // 2. Check for share URL — takes priority over persisted settings
-    const handledShareURL = initHashRouter();
+    const shareMode = initHashRouter();
 
-    // 3. Load persisted settings (skip if a share URL was processed)
-    if (!handledShareURL) {
+    // 3. Load persisted settings. Skip ONLY for results-mode shares — those
+    //    mutate the stores (endpoints + measurement snapshot) for read-only
+    //    display, and re-applying persistence on top would clobber the
+    //    snapshot. Config-mode shares stage in uiStore.pendingShare without
+    //    touching the stores, so the user's saved endpoints / settings still
+    //    need to load and render behind the staging banner.
+    if (shareMode !== 'results') {
       const persisted = loadPersistedSettings();
 
       if (persisted) {
@@ -222,7 +228,9 @@
 </script>
 
 <div id="chronoscope-root">
-  {#if $uiStore.isSharedView}
+  {#if $uiStore.pendingShare}
+    <ConfigStagingBanner />
+  {:else if $uiStore.isSharedView}
     <SharedResultsBanner />
   {/if}
   <Layout onStart={handleStart} onStop={handleStop} />

--- a/src/lib/components/ConfigStagingBanner.svelte
+++ b/src/lib/components/ConfigStagingBanner.svelte
@@ -18,7 +18,7 @@
     <div class="banner-header">
       <span class="banner-icon" aria-hidden="true">⚠</span>
       <span class="banner-text">
-        Shared link wants to add {count} endpoint{count === 1 ? '' : 's'}. Review before accepting.
+        Shared link with {count} endpoint{count === 1 ? '' : 's'}. Accepting replaces your current rail.
       </span>
       <div class="banner-actions">
         <button type="button" class="btn-dismiss" onclick={dismissPendingShare}>
@@ -127,7 +127,11 @@
     list-style: none;
     margin: 0;
     padding: 0 0 0 calc(var(--spacing-sm) + 14px);
-    max-height: 96px;
+    /* MAX_ENDPOINTS = 10 × ~17px row height = ~170px; 200px fits all 10
+       comfortably without forcing the user to scroll past hidden URLs
+       before clicking Accept. Scroll fallback retained for safety, but
+       in practice it shouldn't trigger. */
+    max-height: 200px;
     overflow-y: auto;
     display: flex;
     flex-direction: column;

--- a/src/lib/components/ConfigStagingBanner.svelte
+++ b/src/lib/components/ConfigStagingBanner.svelte
@@ -1,0 +1,183 @@
+<!-- src/lib/components/ConfigStagingBanner.svelte -->
+<!-- Visible when a config-mode share payload has been staged (uiStore.pendingShare). -->
+<!-- The user must explicitly Accept (move endpoints into the rail) or Dismiss        -->
+<!-- (drop the staged payload). See issue #79: pre-fix, attacker URLs auto-loaded     -->
+<!-- on page load and one Start click weaponized the browser as a small-scale flood.  -->
+<!-- The banner gates that path by requiring explicit consent before any URL          -->
+<!-- reaches endpointStore. Cadence settings are never touched, accepted or not.      -->
+<script lang="ts">
+  import { uiStore } from '$lib/stores/ui';
+  import { acceptPendingShare, dismissPendingShare } from '$lib/share/hash-router';
+
+  const pending = $derived($uiStore.pendingShare);
+  const count = $derived(pending?.endpoints.length ?? 0);
+</script>
+
+{#if pending}
+  <div class="staging-banner" role="alert" aria-live="polite">
+    <div class="banner-header">
+      <span class="banner-icon" aria-hidden="true">⚠</span>
+      <span class="banner-text">
+        Shared link wants to add {count} endpoint{count === 1 ? '' : 's'}. Review before accepting.
+      </span>
+      <div class="banner-actions">
+        <button type="button" class="btn-dismiss" onclick={dismissPendingShare}>
+          Dismiss
+        </button>
+        <button type="button" class="btn-accept" onclick={acceptPendingShare}>
+          Accept
+        </button>
+      </div>
+    </div>
+    <ul class="endpoint-list" aria-label="Endpoints proposed by the shared link">
+      {#each pending.endpoints as ep (ep.url)}
+        <li class="endpoint-item">
+          <span class="endpoint-pip" aria-hidden="true" class:disabled={!ep.enabled}></span>
+          <span class="endpoint-url">{ep.url}</span>
+          {#if !ep.enabled}
+            <span class="endpoint-badge">disabled</span>
+          {/if}
+        </li>
+      {/each}
+    </ul>
+  </div>
+{/if}
+
+<style>
+  .staging-banner {
+    /* z-index lifts the banner above Layout's fixed .bg backdrop. Without
+       this the banner paints correctly but its buttons are hit-tested
+       behind the .bg layer and clicks are intercepted. */
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+    padding: var(--spacing-xs) var(--spacing-md);
+    background: rgba(12, 10, 20, 0.78);
+    backdrop-filter: blur(24px) saturate(1.3);
+    -webkit-backdrop-filter: blur(24px) saturate(1.3);
+    border-bottom: 1px solid var(--border-bright, rgba(255, 255, 255, 0.18));
+    flex-shrink: 0;
+  }
+
+  .banner-header {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    min-width: 0;
+  }
+
+  .banner-icon {
+    font-size: 14px;
+    color: var(--accent-pink, #f9a8d4);
+    flex-shrink: 0;
+  }
+
+  .banner-text {
+    font-family: var(--sans);
+    font-size: 13px;
+    color: var(--t1, rgba(255, 255, 255, 0.94));
+    flex: 1;
+    min-width: 0;
+  }
+
+  .banner-actions {
+    display: flex;
+    gap: var(--spacing-xs);
+    flex-shrink: 0;
+  }
+
+  .btn-dismiss,
+  .btn-accept {
+    padding: var(--spacing-xs) var(--spacing-sm);
+    border-radius: var(--radius-sm);
+    font-family: var(--sans);
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background var(--timing-btn) ease, color var(--timing-btn) ease, border-color var(--timing-btn) ease;
+    white-space: nowrap;
+    min-height: 32px;
+    display: flex;
+    align-items: center;
+  }
+
+  .btn-dismiss {
+    border: 1px solid var(--border-default, rgba(255, 255, 255, 0.12));
+    background: transparent;
+    color: var(--t2, rgba(255, 255, 255, 0.74));
+  }
+  .btn-dismiss:hover {
+    border-color: var(--border-bright, rgba(255, 255, 255, 0.24));
+    color: var(--t1, rgba(255, 255, 255, 0.94));
+  }
+
+  .btn-accept {
+    border: 1px solid var(--accent-cyan, #67e8f9);
+    background: transparent;
+    color: var(--accent-cyan, #67e8f9);
+  }
+  .btn-accept:hover {
+    background: var(--accent-cyan, #67e8f9);
+    color: var(--bg-base, #0c0a14);
+  }
+
+  .endpoint-list {
+    list-style: none;
+    margin: 0;
+    padding: 0 0 0 calc(var(--spacing-sm) + 14px);
+    max-height: 96px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .endpoint-item {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+    font-family: var(--mono);
+    font-size: 12px;
+    color: var(--t2, rgba(255, 255, 255, 0.74));
+    min-width: 0;
+  }
+
+  .endpoint-pip {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--accent-cyan, #67e8f9);
+    flex-shrink: 0;
+  }
+  .endpoint-pip.disabled {
+    background: var(--t4, rgba(255, 255, 255, 0.32));
+  }
+
+  .endpoint-url {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+
+  .endpoint-badge {
+    font-family: var(--sans);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--t4, rgba(255, 255, 255, 0.32));
+    flex-shrink: 0;
+  }
+
+  /* Mobile — stack actions under text. */
+  @media (max-width: 767px) {
+    .banner-header {
+      flex-wrap: wrap;
+    }
+    .banner-text {
+      flex-basis: 100%;
+    }
+  }
+</style>

--- a/src/lib/components/SharedResultsBanner.svelte
+++ b/src/lib/components/SharedResultsBanner.svelte
@@ -31,6 +31,12 @@
 
 <style>
   .shared-banner {
+    /* z-index lifts the banner above Layout's fixed .bg backdrop. Without
+       it, the "Run Your Own Test" button is hit-tested behind .bg and
+       clicks are intercepted (latent bug, only exposed once the banner
+       was wired into a flow that anyone clicks through). */
+    position: relative;
+    z-index: 1;
     display: flex;
     align-items: center;
     justify-content: space-between;

--- a/src/lib/share/hash-router.ts
+++ b/src/lib/share/hash-router.ts
@@ -34,11 +34,32 @@ function pickColor(index: number): string {
   return palette[index % palette.length] ?? (tokens.color.endpoint[0] as string);
 }
 
+/**
+ * Dedupe by URL and cap at MAX_ENDPOINTS. Validation accepts duplicate URLs
+ * (it only checks each entry individually), so a crafted payload could cause
+ * Svelte's keyed `#each` block in the staging banner — or the rail — to
+ * throw at runtime when it sees two children with the same key. Deduping
+ * here makes "endpoints are unique" an invariant of every downstream
+ * consumer.
+ */
+function uniqueEndpoints(
+  payloadEndpoints: readonly { url: string; enabled: boolean }[],
+): { url: string; enabled: boolean }[] {
+  const seen = new Set<string>();
+  const out: { url: string; enabled: boolean }[] = [];
+  for (const ep of payloadEndpoints) {
+    if (seen.has(ep.url)) continue;
+    seen.add(ep.url);
+    out.push({ url: ep.url, enabled: ep.enabled });
+    if (out.length >= MAX_ENDPOINTS) break;
+  }
+  return out;
+}
+
 function buildEndpoints(
   payloadEndpoints: readonly { url: string; enabled: boolean }[],
 ): Endpoint[] {
-  const capped = payloadEndpoints.slice(0, MAX_ENDPOINTS);
-  return capped.map((ep, i) => ({
+  return uniqueEndpoints(payloadEndpoints).map((ep, i) => ({
     id: `shared-ep-${i}-${Date.now()}`,
     url: ep.url,
     enabled: ep.enabled,
@@ -68,10 +89,7 @@ export function applySharePayload(payload: SharePayload): string[] {
   if (payload.mode === 'config') {
     uiStore.setPendingShare({
       mode: 'config',
-      endpoints: payload.endpoints.slice(0, MAX_ENDPOINTS).map((ep) => ({
-        url: ep.url,
-        enabled: ep.enabled,
-      })),
+      endpoints: uniqueEndpoints(payload.endpoints),
     });
     return [];
   }

--- a/src/lib/share/hash-router.ts
+++ b/src/lib/share/hash-router.ts
@@ -1,15 +1,27 @@
 // src/lib/share/hash-router.ts
 // Reads the URL hash on boot and hydrates stores from a share payload.
 // Called once from App.svelte before any persistence restore.
+//
+// Security invariants (see issue #79 + tests/unit/share/hash-router.test.ts):
+//   1. Cadence settings (timeout/delay/burstRounds/monitorDelay/cap/corsMode)
+//      from a payload NEVER reach settingsStore. Receiver always probes at
+//      their own defaults, even after accepting a shared config.
+//   2. Config-mode payloads STAGE — they populate uiStore.pendingShare
+//      instead of endpointStore. The receiver must call acceptPendingShare()
+//      (wired to the staging banner's Accept button) before any URL lands in
+//      the rail. Pre-fix, attacker URLs auto-loaded and one Start click
+//      weaponized the browser.
+//   3. Results-mode applies endpoints + samples for snapshot display
+//      (read-only); the existing SharedResultsBanner gates the transition
+//      back to running.
 
 import { parseShareURL } from './share-manager';
 import { endpointStore, MAX_ENDPOINTS } from '../stores/endpoints';
-import { settingsStore } from '../stores/settings';
 import { measurementStore } from '../stores/measurements';
 import { uiStore } from '../stores/ui';
-import { DEFAULT_SETTINGS } from '../types';
 import type { SharePayload, MeasurementSample, SampleStatus, Endpoint } from '../types';
 import { tokens } from '../tokens';
+import { get } from 'svelte/store';
 
 // Upper bound for the round counter materialized from a share payload.
 // Matches the sample cap (10 000 per endpoint × 50 endpoints) with generous
@@ -22,40 +34,57 @@ function pickColor(index: number): string {
   return palette[index % palette.length] ?? (tokens.color.endpoint[0] as string);
 }
 
-/**
- * Apply a decoded SharePayload to all relevant stores.
- * Returns the ordered list of endpoint IDs created.
- */
-function applySharePayload(payload: SharePayload): string[] {
-  // Build Endpoint objects from the stripped share format, capped to MAX_ENDPOINTS
-  const capped = payload.endpoints.slice(0, MAX_ENDPOINTS);
-  const endpoints: Endpoint[] = capped.map((ep, i) => ({
+function buildEndpoints(
+  payloadEndpoints: readonly { url: string; enabled: boolean }[],
+): Endpoint[] {
+  const capped = payloadEndpoints.slice(0, MAX_ENDPOINTS);
+  return capped.map((ep, i) => ({
     id: `shared-ep-${i}-${Date.now()}`,
     url: ep.url,
     enabled: ep.enabled,
     label: ep.url,
     color: pickColor(i),
   }));
+}
 
+/**
+ * Apply a decoded SharePayload.
+ *
+ * Config mode → stages in uiStore.pendingShare. Endpoints do NOT reach the
+ * rail until acceptPendingShare() runs.
+ *
+ * Results mode → applies endpoints + measurement snapshot for read-only
+ * display. Cadence settings are dropped on the floor.
+ *
+ * Returns the ordered list of endpoint IDs *materialized* (results mode
+ * only). Config mode returns an empty list because nothing has been
+ * applied yet.
+ */
+export function applySharePayload(payload: SharePayload): string[] {
+  // Note the absence of any settingsStore write. Cadence from a payload is
+  // attacker-controllable within the validated bounds (e.g. burstRounds=500,
+  // timeout=100); applying it would amplify a future Start click. The
+  // receiver always probes at their own defaults, full stop.
+  if (payload.mode === 'config') {
+    uiStore.setPendingShare({
+      mode: 'config',
+      endpoints: payload.endpoints.slice(0, MAX_ENDPOINTS).map((ep) => ({
+        url: ep.url,
+        enabled: ep.enabled,
+      })),
+    });
+    return [];
+  }
+
+  // Results mode — read-only snapshot. Apply endpoints + samples directly so
+  // the visualization renders; the SharedResultsBanner gates the transition
+  // back to running.
+  const endpoints = buildEndpoints(payload.endpoints);
   endpointStore.setEndpoints(endpoints);
-  // Explicit field copy — never spread an attacker-supplied object into
-  // settingsStore. validateSharePayload only validates the 6 known fields;
-  // a crafted payload can smuggle extras (region, healthThreshold, etc.)
-  // that spread would silently apply.
-  settingsStore.set({
-    ...DEFAULT_SETTINGS,
-    timeout: payload.settings.timeout,
-    delay: DEFAULT_SETTINGS.delay,
-    burstRounds: payload.settings.burstRounds ?? DEFAULT_SETTINGS.burstRounds,
-    monitorDelay:
-      payload.settings.monitorDelay ?? payload.settings.delay ?? DEFAULT_SETTINGS.monitorDelay,
-    cap: payload.settings.cap,
-    corsMode: payload.settings.corsMode,
-  });
 
   const ids = endpoints.map((ep) => ep.id);
 
-  if (payload.mode === 'results' && payload.results) {
+  if (payload.results) {
     const results = payload.results.slice(0, MAX_ENDPOINTS);
     // Build a snapshot from the payload results — uses plain arrays, not SampleBuffer.
     // measurementStore.loadSnapshot() converts these to RingBuffers internally.
@@ -126,15 +155,51 @@ function applySharePayload(payload: SharePayload): string[] {
 }
 
 /**
- * Call once at app boot, before loadPersistedSettings.
- * Returns true if a share URL was successfully processed — the caller should
- * skip its own localStorage restore in that case.
+ * Accept the staged config-mode share payload — moves the staged endpoints
+ * into endpointStore (the rail) and clears the staging slot. No-op if no
+ * payload is staged.
+ *
+ * Does NOT set isSharedView. That flag drives the read-only results banner;
+ * once the user has accepted a config, they're back in normal interactive
+ * mode (just with new endpoints), so showing a "Shared results — read
+ * only" banner would be misleading.
+ *
+ * Cadence settings are NOT touched: the receiver runs at their own defaults.
  */
-export function initHashRouter(): boolean {
-  if (typeof window === 'undefined') return false;
+export function acceptPendingShare(): void {
+  const pending = get(uiStore).pendingShare;
+  if (!pending) return;
+  endpointStore.setEndpoints(buildEndpoints(pending.endpoints));
+  uiStore.clearPendingShare();
+}
+
+/**
+ * Dismiss the staged share without applying. Rail / settings stay at the
+ * receiver's own state.
+ */
+export function dismissPendingShare(): void {
+  uiStore.clearPendingShare();
+}
+
+/**
+ * Call once at app boot, before loadPersistedSettings.
+ *
+ * Returns the mode of the share that was processed, or null if no share URL
+ * was present. The caller uses this to decide whether to load persisted
+ * settings:
+ *
+ *   - `'results'` — stores have been mutated with the snapshot. Skip the
+ *     persistence load to avoid clobbering it.
+ *   - `'config'`  — stores are untouched (payload is staged in
+ *     uiStore.pendingShare). Persistence MUST still load so the user sees
+ *     their own endpoints / settings behind the staging banner.
+ *   - `null`      — no share. Normal boot.
+ */
+export function initHashRouter(): 'config' | 'results' | null {
+  if (typeof window === 'undefined') return null;
 
   const payload = parseShareURL(window.location.href);
-  if (!payload) return false;
+  if (!payload) return null;
 
   applySharePayload(payload);
 
@@ -142,5 +207,5 @@ export function initHashRouter(): boolean {
   // and avoid overwriting persisted settings with shared config.
   history.replaceState(null, '', window.location.pathname + window.location.search);
 
-  return true;
+  return payload.mode;
 }

--- a/src/lib/share/hash-router.ts
+++ b/src/lib/share/hash-router.ts
@@ -41,6 +41,12 @@ function pickColor(index: number): string {
  * throw at runtime when it sees two children with the same key. Deduping
  * here makes "endpoints are unique" an invariant of every downstream
  * consumer.
+ *
+ * Dedupe key is lowercased: URL hosts are case-insensitive per RFC 3986,
+ * so `https://Example.com/p` and `https://example.com/p` are the same
+ * resource. Without normalization, mixed-case duplicates would pass
+ * through and the user would see apparent duplicates in the rail. The
+ * stored URL preserves the original case (we only normalize the key).
  */
 function uniqueEndpoints(
   payloadEndpoints: readonly { url: string; enabled: boolean }[],
@@ -48,8 +54,9 @@ function uniqueEndpoints(
   const seen = new Set<string>();
   const out: { url: string; enabled: boolean }[] = [];
   for (const ep of payloadEndpoints) {
-    if (seen.has(ep.url)) continue;
-    seen.add(ep.url);
+    const key = ep.url.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
     out.push({ url: ep.url, enabled: ep.enabled });
     if (out.length >= MAX_ENDPOINTS) break;
   }

--- a/src/lib/share/share-manager.ts
+++ b/src/lib/share/share-manager.ts
@@ -61,6 +61,14 @@ function validateSharePayload(data: unknown): SharePayload | null {
   if (!Array.isArray(obj['endpoints'])) return null;
   if ((obj['endpoints'] as unknown[]).length > 50) return null;
 
+  // mode:'results' without a results array is structurally invalid: the
+  // payload claims to carry a snapshot but doesn't. Pre-fix, the apply
+  // path silently took the else branch (no measurement load, no shared
+  // banner) but had already written endpoints to endpointStore — leaving
+  // the user with attacker URLs in the rail and no indicator. Reject at
+  // the validator so the apply path never sees a half-formed payload.
+  if (obj['mode'] === 'results' && obj['results'] === undefined) return null;
+
   for (const ep of obj['endpoints'] as unknown[]) {
     if (ep === null || typeof ep !== 'object') return null;
     const e = ep as Record<string, unknown>;

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -3,7 +3,7 @@
 // and panel visibility. No side effects; all state is local to this module.
 
 import { writable } from 'svelte/store';
-import type { LiveTimeRange, TerminalEventType, UIState } from '../types';
+import type { LiveTimeRange, PendingShare, TerminalEventType, UIState } from '../types';
 
 const initialState = (): UIState => ({
   // 'overview' is the v2 default. Phase 7 migration (v6→v7) collapses any
@@ -15,6 +15,7 @@ const initialState = (): UIState => ({
   showShare: false,
   showKeyboardHelp: false,
   isSharedView: false,
+  pendingShare: null,
   showEndpoints: false,
   focusedEndpointId: null,
   liveOptions: {
@@ -57,6 +58,12 @@ function createUiStore() {
     },
     clearSharedView(): void {
       update((s) => ({ ...s, isSharedView: false }));
+    },
+    setPendingShare(pending: PendingShare): void {
+      update((s) => ({ ...s, pendingShare: pending }));
+    },
+    clearPendingShare(): void {
+      update((s) => ({ ...s, pendingShare: null }));
     },
     toggleEndpoints(): void {
       update((s) => ({ ...s, showEndpoints: !s.showEndpoints }));

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -231,6 +231,16 @@ export type TerminalEventType =
   | 'endpoint_removed'
   | 'reuse_change';
 
+// Staged share payload — config-mode shares populate this instead of writing
+// directly to endpointStore. The user must explicitly accept (or dismiss) via
+// the staging banner before the URLs reach the rail. Closes the silent-flood
+// vector from issue #79: pre-fix, the rail filled with attacker URLs on page
+// load and a single Start click weaponized the browser.
+export interface PendingShare {
+  readonly mode: 'config';
+  readonly endpoints: readonly { url: string; enabled: boolean }[];
+}
+
 export interface UIState {
   activeView: ActiveView;
   expandedCards: Set<string>;
@@ -238,6 +248,7 @@ export interface UIState {
   showShare: boolean;
   showKeyboardHelp: boolean;
   isSharedView: boolean;
+  pendingShare: PendingShare | null;
   showEndpoints: boolean;
 
   // Globally focused endpoint — drives rail selection and per-view focus.

--- a/tests/unit/share/hash-router.test.ts
+++ b/tests/unit/share/hash-router.test.ts
@@ -30,13 +30,18 @@ import { uiStore } from '../../../src/lib/stores/ui';
 import { DEFAULT_SETTINGS } from '../../../src/lib/types';
 import type { SharePayload } from '../../../src/lib/types';
 
+// Each field is deliberately distinct from DEFAULT_SETTINGS so the cadence-
+// strip invariant fails closed: if a future change accidentally writes any
+// field from a payload into settingsStore, the corresponding assertion
+// flips. Picking values that overlap defaults (e.g. delay: 0 when
+// DEFAULT_SETTINGS.delay is also 0) silently weakens the test.
 const MALICIOUS_CADENCE = {
   timeout: 100,
-  delay: 0,
+  delay: 9999,
   burstRounds: 500,
-  monitorDelay: 0,
-  cap: 0,
-  corsMode: 'no-cors' as const,
+  monitorDelay: 1,
+  cap: 9999,
+  corsMode: 'cors' as const,
 };
 
 const ATTACKER_URLS = [
@@ -81,6 +86,7 @@ describe('hash-router: cadence write invariant', () => {
     applySharePayload(configPayload());
     const s = get(settingsStore);
     expect(s.timeout).toBe(DEFAULT_SETTINGS.timeout);
+    expect(s.delay).toBe(DEFAULT_SETTINGS.delay);
     expect(s.burstRounds).toBe(DEFAULT_SETTINGS.burstRounds);
     expect(s.monitorDelay).toBe(DEFAULT_SETTINGS.monitorDelay);
     expect(s.cap).toBe(DEFAULT_SETTINGS.cap);
@@ -92,13 +98,17 @@ describe('hash-router: cadence write invariant', () => {
     acceptPendingShare();
     const s = get(settingsStore);
     expect(s.timeout).toBe(DEFAULT_SETTINGS.timeout);
+    expect(s.delay).toBe(DEFAULT_SETTINGS.delay);
     expect(s.burstRounds).toBe(DEFAULT_SETTINGS.burstRounds);
+    expect(s.cap).toBe(DEFAULT_SETTINGS.cap);
+    expect(s.corsMode).toBe(DEFAULT_SETTINGS.corsMode);
   });
 
   it('results mode: settingsStore stays at user defaults', () => {
     applySharePayload(resultsPayload());
     const s = get(settingsStore);
     expect(s.timeout).toBe(DEFAULT_SETTINGS.timeout);
+    expect(s.delay).toBe(DEFAULT_SETTINGS.delay);
     expect(s.burstRounds).toBe(DEFAULT_SETTINGS.burstRounds);
     expect(s.monitorDelay).toBe(DEFAULT_SETTINGS.monitorDelay);
     expect(s.cap).toBe(DEFAULT_SETTINGS.cap);
@@ -153,6 +163,44 @@ describe('hash-router: config-mode staging', () => {
   it('acceptPendingShare is a no-op when nothing is staged', () => {
     expect(() => acceptPendingShare()).not.toThrow();
     expect(get(endpointStore)).toEqual([]);
+  });
+
+  // Validation accepts duplicate URLs in the endpoints array (it only checks
+  // each entry individually). Without dedupe, Svelte's keyed `#each` block
+  // in the staging banner — and the rail after accept — would throw at
+  // runtime on the second child with the same key, leaving the user
+  // staring at a broken page. Worse, a default-Accept reflex would then
+  // populate the rail from a partially-rendered banner.
+  it('dedupes duplicate URLs in the staged payload', () => {
+    const dupePayload: SharePayload = {
+      v: 1,
+      mode: 'config',
+      endpoints: [
+        { url: 'https://a.example.com', enabled: true },
+        { url: 'https://a.example.com', enabled: false },
+        { url: 'https://b.example.com', enabled: true },
+        { url: 'https://a.example.com', enabled: true },
+      ],
+      settings: MALICIOUS_CADENCE,
+    };
+    applySharePayload(dupePayload);
+    const staged = get(uiStore).pendingShare?.endpoints ?? [];
+    expect(staged.map((e) => e.url)).toEqual(['https://a.example.com', 'https://b.example.com']);
+  });
+
+  it('accepted endpoints are unique even when the payload had duplicates', () => {
+    const dupePayload: SharePayload = {
+      v: 1,
+      mode: 'config',
+      endpoints: [
+        { url: 'https://a.example.com', enabled: true },
+        { url: 'https://a.example.com', enabled: true },
+      ],
+      settings: MALICIOUS_CADENCE,
+    };
+    applySharePayload(dupePayload);
+    acceptPendingShare();
+    expect(get(endpointStore).map((e) => e.url)).toEqual(['https://a.example.com']);
   });
 });
 

--- a/tests/unit/share/hash-router.test.ts
+++ b/tests/unit/share/hash-router.test.ts
@@ -202,6 +202,68 @@ describe('hash-router: config-mode staging', () => {
     acceptPendingShare();
     expect(get(endpointStore).map((e) => e.url)).toEqual(['https://a.example.com']);
   });
+
+  // URL host is case-insensitive per RFC 3986. Without lowercasing the
+  // dedup key, a payload could smuggle ten "distinct" entries that all
+  // resolve to the same host.
+  it('dedupe is case-insensitive on the URL key', () => {
+    const mixedCase: SharePayload = {
+      v: 1,
+      mode: 'config',
+      endpoints: [
+        { url: 'https://Example.com/path', enabled: true },
+        { url: 'https://example.com/path', enabled: true },
+        { url: 'https://EXAMPLE.com/path', enabled: true },
+      ],
+      settings: MALICIOUS_CADENCE,
+    };
+    applySharePayload(mixedCase);
+    expect(get(uiStore).pendingShare?.endpoints).toHaveLength(1);
+  });
+});
+
+describe('hash-router: results-mode invariants', () => {
+  // Pre-fix, validateSharePayload accepted `mode: 'results'` with
+  // `results: undefined`. The apply path then took its else branch and
+  // skipped the snapshot load + sharedView flag — but endpoints had
+  // already been written to endpointStore. Net: rail full of attacker
+  // URLs, no banner, no read-only indicator. A half-open #79 variant.
+  it('rejects results mode without a results array (via parseShareURL)', async () => {
+    const { decodeSharePayload, encodeSharePayload } = await import('../../../src/lib/share/share-manager');
+    // Hand-craft a payload that would have passed validation pre-fix.
+    const malformed = {
+      v: 1,
+      mode: 'results',
+      endpoints: [{ url: 'https://attacker.example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors' },
+      // results omitted
+    };
+    const encoded = encodeSharePayload(malformed as never);
+    expect(decodeSharePayload(encoded)).toBeNull();
+  });
+
+  // The roundCounter clamp at hash-router.ts:148 is load-bearing — without
+  // it, an attacker can push the counter to MAX_SAFE_INTEGER and break
+  // downstream monotonicity / arithmetic. Pin the invariant so a future
+  // refactor can't quietly drop the clamp.
+  it('clamps roundCounter at MAX_SHARE_ROUND_COUNTER (1_000_000)', () => {
+    const adversarial: SharePayload = {
+      v: 1,
+      mode: 'results',
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: MALICIOUS_CADENCE,
+      results: [
+        {
+          samples: [
+            { round: Number.MAX_SAFE_INTEGER, latency: 50, status: 'ok' },
+          ],
+        },
+      ],
+    };
+    applySharePayload(adversarial);
+    const m = get(measurementStore);
+    expect(m.roundCounter).toBeLessThanOrEqual(1_000_000);
+  });
 });
 
 describe('hash-router: results-mode application', () => {

--- a/tests/unit/share/hash-router.test.ts
+++ b/tests/unit/share/hash-router.test.ts
@@ -1,0 +1,181 @@
+// Security guarantees for share-payload hydration. Maps to issue #79.
+//
+// Threat model: a crafted share link encodes attacker URLs + cadence knobs.
+// Pre-fix, both modes silently mutated endpointStore + settingsStore on page
+// load — one Start click weaponized the victim's browser as a small-scale
+// flood / scanner. These tests pin the post-fix invariants:
+//
+//   1. Cadence settings (timeout/delay/burstRounds/monitorDelay/cap/corsMode)
+//      from a payload NEVER reach settingsStore. The receiver always probes
+//      at their own defaults.
+//   2. Config-mode payloads STAGE — they do not write to endpointStore until
+//      the user explicitly accepts. The rail keeps showing the user's actual
+//      config until consent.
+//   3. Results-mode payloads apply endpoints + samples for display (snapshot
+//      is read-only), but still skip the cadence write.
+//   4. Accept / dismiss the staged payload mutates only the documented
+//      stores; cadence is never touched.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import {
+  applySharePayload,
+  acceptPendingShare,
+  dismissPendingShare,
+} from '../../../src/lib/share/hash-router';
+import { endpointStore } from '../../../src/lib/stores/endpoints';
+import { settingsStore } from '../../../src/lib/stores/settings';
+import { measurementStore } from '../../../src/lib/stores/measurements';
+import { uiStore } from '../../../src/lib/stores/ui';
+import { DEFAULT_SETTINGS } from '../../../src/lib/types';
+import type { SharePayload } from '../../../src/lib/types';
+
+const MALICIOUS_CADENCE = {
+  timeout: 100,
+  delay: 0,
+  burstRounds: 500,
+  monitorDelay: 0,
+  cap: 0,
+  corsMode: 'no-cors' as const,
+};
+
+const ATTACKER_URLS = [
+  'https://victim-target.example.com/expensive',
+  'https://other-victim.example.com/api',
+];
+
+function configPayload(): SharePayload {
+  return {
+    v: 1,
+    mode: 'config',
+    endpoints: ATTACKER_URLS.map((url) => ({ url, enabled: true })),
+    settings: MALICIOUS_CADENCE,
+  };
+}
+
+function resultsPayload(): SharePayload {
+  return {
+    v: 1,
+    mode: 'results',
+    endpoints: ATTACKER_URLS.map((url) => ({ url, enabled: true })),
+    settings: MALICIOUS_CADENCE,
+    results: ATTACKER_URLS.map(() => ({
+      samples: Array.from({ length: 10 }, (_, i) => ({
+        round: i,
+        latency: 50,
+        status: 'ok' as const,
+      })),
+    })),
+  };
+}
+
+beforeEach(() => {
+  endpointStore.setEndpoints([]);
+  settingsStore.reset();
+  measurementStore.reset();
+  uiStore.reset();
+});
+
+describe('hash-router: cadence write invariant', () => {
+  it('config mode: settingsStore stays at user defaults after apply', () => {
+    applySharePayload(configPayload());
+    const s = get(settingsStore);
+    expect(s.timeout).toBe(DEFAULT_SETTINGS.timeout);
+    expect(s.burstRounds).toBe(DEFAULT_SETTINGS.burstRounds);
+    expect(s.monitorDelay).toBe(DEFAULT_SETTINGS.monitorDelay);
+    expect(s.cap).toBe(DEFAULT_SETTINGS.cap);
+    expect(s.corsMode).toBe(DEFAULT_SETTINGS.corsMode);
+  });
+
+  it('config mode: settingsStore stays at user defaults after accept', () => {
+    applySharePayload(configPayload());
+    acceptPendingShare();
+    const s = get(settingsStore);
+    expect(s.timeout).toBe(DEFAULT_SETTINGS.timeout);
+    expect(s.burstRounds).toBe(DEFAULT_SETTINGS.burstRounds);
+  });
+
+  it('results mode: settingsStore stays at user defaults', () => {
+    applySharePayload(resultsPayload());
+    const s = get(settingsStore);
+    expect(s.timeout).toBe(DEFAULT_SETTINGS.timeout);
+    expect(s.burstRounds).toBe(DEFAULT_SETTINGS.burstRounds);
+    expect(s.monitorDelay).toBe(DEFAULT_SETTINGS.monitorDelay);
+    expect(s.cap).toBe(DEFAULT_SETTINGS.cap);
+    expect(s.corsMode).toBe(DEFAULT_SETTINGS.corsMode);
+  });
+});
+
+describe('hash-router: config-mode staging', () => {
+  it('does not write to endpointStore on apply', () => {
+    expect(get(endpointStore)).toEqual([]);
+    applySharePayload(configPayload());
+    expect(get(endpointStore)).toEqual([]);
+  });
+
+  it('sets pendingShare on uiStore with the payload endpoints', () => {
+    applySharePayload(configPayload());
+    const ui = get(uiStore);
+    expect(ui.pendingShare).not.toBeNull();
+    expect(ui.pendingShare?.mode).toBe('config');
+    expect(ui.pendingShare?.endpoints.map((e) => e.url)).toEqual(ATTACKER_URLS);
+  });
+
+  it('does not flip isSharedView (that flag is for read-only results)', () => {
+    applySharePayload(configPayload());
+    expect(get(uiStore).isSharedView).toBe(false);
+  });
+
+  it('acceptPendingShare populates endpointStore from staged payload', () => {
+    applySharePayload(configPayload());
+    acceptPendingShare();
+    const eps = get(endpointStore);
+    expect(eps.map((e) => e.url)).toEqual(ATTACKER_URLS);
+    expect(get(uiStore).pendingShare).toBeNull();
+  });
+
+  it('acceptPendingShare does not flip isSharedView (back to interactive)', () => {
+    applySharePayload(configPayload());
+    acceptPendingShare();
+    // Once accepted, the user is in normal interactive mode with new
+    // endpoints — the "Shared results — read only" banner must not appear.
+    expect(get(uiStore).isSharedView).toBe(false);
+  });
+
+  it('dismissPendingShare clears staging without applying', () => {
+    applySharePayload(configPayload());
+    dismissPendingShare();
+    expect(get(endpointStore)).toEqual([]);
+    expect(get(uiStore).pendingShare).toBeNull();
+    expect(get(uiStore).isSharedView).toBe(false);
+  });
+
+  it('acceptPendingShare is a no-op when nothing is staged', () => {
+    expect(() => acceptPendingShare()).not.toThrow();
+    expect(get(endpointStore)).toEqual([]);
+  });
+});
+
+describe('hash-router: results-mode application', () => {
+  it('applies endpoints to endpointStore for display', () => {
+    applySharePayload(resultsPayload());
+    const eps = get(endpointStore);
+    expect(eps.map((e) => e.url)).toEqual(ATTACKER_URLS);
+  });
+
+  it('sets isSharedView so the read-only banner mounts', () => {
+    applySharePayload(resultsPayload());
+    expect(get(uiStore).isSharedView).toBe(true);
+  });
+
+  it('does not set pendingShare (results apply directly, no staging)', () => {
+    applySharePayload(resultsPayload());
+    expect(get(uiStore).pendingShare).toBeNull();
+  });
+
+  it('loads measurement snapshot for visualization', () => {
+    applySharePayload(resultsPayload());
+    const m = get(measurementStore);
+    expect(m.lifecycle).toBe('completed');
+  });
+});


### PR DESCRIPTION
Closes #79.

## What was vulnerable

Pre-fix, a crafted share link silently mutated `endpointStore` and `settingsStore` on page load. Cadence knobs (`timeout` / `burstRounds` / `monitorDelay` / `cap` / `corsMode`) were attacker-controllable within validated bounds — `burstRounds: 500` + `delay: 0` + 10 endpoints meant one Start click weaponized the victim's browser as a small-scale flood against attacker-chosen targets.

PR #78 closed the *where* (URL blocklist — no private / loopback / IMDS hosts could appear in a share payload). This closes the *what* — auto-applying untrusted payloads without consent.

## Two schema-level fixes

Both at the apply path, not at runtime — future settings fields can't regress this by being added without an explicit clamp.

1. **Cadence is no longer applied** from any share payload, in either mode. The receiver always probes at their own defaults. Removes the amplification primitive at the source.

2. **Config-mode shares stage** in `uiStore.pendingShare` instead of writing `endpointStore`. A new `ConfigStagingBanner` renders the proposed URLs and gates them behind explicit **Accept** / **Dismiss**. The user's persisted endpoints / settings load and render normally *behind* the banner — they never see a blank app, just their actual config with the shared payload offered above.

Results-mode shares still apply endpoints + samples for read-only display (existing `SharedResultsBanner` is the gate to running). Cadence-strip applies to that path too.

Stronger than the issue's recommended option 3 (banner + clamp) because schema strip means the cadence isn't on the apply path *at all* — even if a future feature adds a settings knob, it can't accidentally bypass a clamp it doesn't know about.

## Latent bug surfaced

`SharedResultsBanner` had no `z-index`, so clicks on its "Run Your Own Test" button were intercepted by Layout's fixed `.bg` backdrop. The new `ConfigStagingBanner` would have hit the same issue. Both now establish a stacking context at `z-index: 1`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 603 / 603 (+14 new security tests in `tests/unit/share/hash-router.test.ts`)
- [x] Manually verified end-to-end against a malicious payload in dev:
  - Initial load: staging banner shows 3 attacker URLs, rail still shows user's defaults (Google/Edge/AWS/Fastly), footer shows default cadence (`Burst · 0/50 · 5s timeout`, not the malicious 500/100ms)
  - Click **Accept**: rail updates to attacker URLs, banner clears, settings still default
  - Click **Dismiss**: rail unchanged, banner clears, no state mutation

## What's still open

- DNS resolution disclosure on page load is a non-issue with staging — payload URLs go to `pendingShare` (a Svelte store), not into any `<a href>` or `<link>` that browsers would prefetch. URLs render as plain text in the banner; no DNS triggered.
- If a v1 payload smuggled extra settings fields, they were never applied (validateSharePayload only validates the 6 known fields); now they're not applied period since cadence is gone from the apply path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration staging banner that appears when someone shares a configuration with you, allowing you to review shared endpoints before accepting them
  * New "Accept" and "Dismiss" actions let you control whether to apply shared configurations

* **Bug Fixes**
  * Improved visual layering for shared results to ensure proper interaction handling
  * Enhanced security for shared content to prevent unintended setting modifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->