### PR TITLE
feat(endpoint-identity): brand/nickname/hostname identity model + edit affordance

### DIFF
--- a/src/lib/components/ConfigStagingBanner.svelte
+++ b/src/lib/components/ConfigStagingBanner.svelte
@@ -8,6 +8,7 @@
 <script lang="ts">
   import { uiStore } from '$lib/stores/ui';
   import { acceptPendingShare, dismissPendingShare } from '$lib/share/hash-router';
+  import { displayLabel } from '$lib/endpoint/displayLabel';
 
   const pending = $derived($uiStore.pendingShare);
   const count = $derived(pending?.endpoints.length ?? 0);
@@ -33,7 +34,10 @@
       {#each pending.endpoints as ep (ep.url)}
         <li class="endpoint-item">
           <span class="endpoint-pip" aria-hidden="true" class:disabled={!ep.enabled}></span>
-          <span class="endpoint-url">{ep.url}</span>
+          <span class="endpoint-identity">
+            <span class="endpoint-label">{displayLabel({ url: ep.url })}</span>
+            <span class="endpoint-url">{ep.url}</span>
+          </span>
           {#if !ep.enabled}
             <span class="endpoint-badge">disabled</span>
           {/if}
@@ -159,7 +163,28 @@
     background: var(--t4, rgba(255, 255, 255, 0.32));
   }
 
+  .endpoint-identity {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    min-width: 0;
+    flex: 1;
+  }
+
+  .endpoint-label {
+    font-family: var(--sans, sans-serif);
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--t1, rgba(255, 255, 255, 0.94));
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   .endpoint-url {
+    font-family: var(--mono);
+    font-size: 11px;
+    color: var(--t3, rgba(255, 255, 255, 0.54));
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/src/lib/components/EndpointRow.svelte
+++ b/src/lib/components/EndpointRow.svelte
@@ -4,6 +4,7 @@
 <script lang="ts">
   import { tokens } from '$lib/tokens';
   import { latencyToColor } from '$lib/renderers/color-map';
+  import { isValidNickname } from '$lib/endpoint/displayLabel';
   import type { Endpoint, SampleStatus } from '$lib/types';
 
   // ── Props ────────────────────────────────────────────────────────────────────
@@ -54,12 +55,48 @@
       : tokens.color.text.secondary
   );
 
-  // ── Handlers ─────────────────────────────────────────────────────────────────
+  // ── Edit mode state ───────────────────────────────────────────────────────────
 
-  function handleUrlChange(e: Event): void {
-    const input = e.currentTarget as HTMLInputElement;
-    onUpdate?.(endpoint.id, { url: input.value });
+  let isEditing = $state(false);
+  let editUrl = $state('');
+  let editNickname = $state('');
+  let nicknameInvalid = $state(false);
+
+  function handleEditStart(): void {
+    editUrl = endpoint.url;
+    editNickname = endpoint.nickname ?? '';
+    nicknameInvalid = false;
+    isEditing = true;
   }
+
+  function handleEditSave(): void {
+    const trimmedNick = editNickname.trim();
+    if (trimmedNick !== '' && !isValidNickname(trimmedNick)) {
+      nicknameInvalid = true;
+      return;
+    }
+    nicknameInvalid = false;
+    const nickToSave: string | undefined = trimmedNick === '' ? undefined : trimmedNick;
+    onUpdate?.(endpoint.id, { url: editUrl, nickname: nickToSave });
+    isEditing = false;
+  }
+
+  function handleEditCancel(): void {
+    nicknameInvalid = false;
+    isEditing = false;
+  }
+
+  function handleNicknameKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Enter') { e.preventDefault(); handleEditSave(); }
+    if (e.key === 'Escape') { e.preventDefault(); handleEditCancel(); }
+  }
+
+  function handleUrlKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Enter') { e.preventDefault(); handleEditSave(); }
+    if (e.key === 'Escape') { e.preventDefault(); handleEditCancel(); }
+  }
+
+  // ── Handlers ─────────────────────────────────────────────────────────────────
 
   function handleToggle(): void {
     onUpdate?.(endpoint.id, { enabled: !endpoint.enabled });
@@ -87,6 +124,7 @@
   style:--spacing-sm="{tokens.spacing.sm}px"
   style:--spacing-md="{tokens.spacing.md}px"
   style:--mono={tokens.typography.mono.fontFamily}
+  style:--sans={tokens.typography.sans.fontFamily}
   style:--timing-btn="{tokens.timing.btnHover}ms"
   style:opacity={endpoint.enabled ? 1 : 0.5}
 >
@@ -97,19 +135,47 @@
     aria-hidden="true"
   ></span>
 
-  <!-- URL input -->
-  <input
-    type="url"
-    class="url-input"
-    value={endpoint.url}
-    readonly={isRunning}
-    placeholder="https://example.com"
-    aria-label="Endpoint URL"
-    onchange={handleUrlChange}
-  />
+  <!-- URL input (read-only in read mode; editable in edit mode) -->
+  {#if isEditing}
+    <input
+      type="url"
+      class="url-input"
+      bind:value={editUrl}
+      placeholder="https://example.com"
+      aria-label="Endpoint URL"
+      onkeydown={handleUrlKeydown}
+    />
+  {:else}
+    <input
+      type="url"
+      class="url-input"
+      value={endpoint.url}
+      readonly={true}
+      placeholder="https://example.com"
+      aria-label="Endpoint URL"
+    />
+  {/if}
+
+  <!-- Nickname input (edit mode only) -->
+  {#if isEditing}
+    <div class="edit-fields">
+      <input
+        type="text"
+        class="nickname-input"
+        bind:value={editNickname}
+        placeholder="Optional nickname"
+        aria-label="Endpoint nickname"
+        aria-invalid={nicknameInvalid ? 'true' : 'false'}
+        onkeydown={handleNicknameKeydown}
+      />
+      {#if nicknameInvalid}
+        <span class="nickname-error" role="alert">Max 80 characters</span>
+      {/if}
+    </div>
+  {/if}
 
   <!-- Latency text -->
-  {#if latencyText}
+  {#if latencyText && !isEditing}
     <span
       class="latency-text"
       style:color={latencyColor}
@@ -117,6 +183,40 @@
     >
       {latencyText}
     </span>
+  {/if}
+
+  <!-- Pencil / edit button (hidden while running) -->
+  {#if !isRunning}
+    <button
+      type="button"
+      class="edit-btn"
+      class:active={isEditing}
+      aria-label="{isEditing ? 'Cancel editing' : 'Edit'} {endpoint.label}"
+      onclick={isEditing ? handleEditCancel : handleEditStart}
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 14 14"
+        fill="none"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path
+          d="M9.5 1.5L12.5 4.5L4.5 12.5H1.5V9.5L9.5 1.5Z"
+          stroke="currentColor"
+          stroke-width="1.25"
+          stroke-linejoin="round"
+          fill="none"
+        />
+        <path
+          d="M7.5 3.5L10.5 6.5"
+          stroke="currentColor"
+          stroke-width="1.25"
+          stroke-linecap="round"
+        />
+      </svg>
+    </button>
   {/if}
 
   <!-- Enable/disable toggle -->
@@ -140,7 +240,7 @@
     <button
       type="button"
       class="remove-btn"
-      aria-label="Remove endpoint {endpoint.url}"
+      aria-label="Remove endpoint {endpoint.label}"
       disabled={isRunning}
       onclick={handleRemove}
     >
@@ -224,6 +324,50 @@
     cursor: default;
   }
 
+  /* ── Edit fields (nickname row) ──────────────────────────────────────────── */
+  .edit-fields {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    flex-shrink: 0;
+    min-width: 0;
+  }
+
+  /* ── Nickname input ──────────────────────────────────────────────────────── */
+  .nickname-input {
+    min-width: 0;
+    width: 140px;
+    background: rgba(0,0,0,.2);
+    border: 1px solid var(--glass-border);
+    border-radius: var(--btn-radius);
+    color: var(--t1);
+    font-size: 13px;
+    font-family: var(--sans);
+    padding: var(--spacing-xs) var(--spacing-sm);
+    outline: none;
+    box-shadow: inset 0 1px 4px rgba(0,0,0,.3);
+    transition: border-color var(--timing-btn) ease, box-shadow var(--timing-btn) ease;
+  }
+
+  .nickname-input:focus {
+    border-color: var(--accent-cyan);
+    box-shadow: inset 0 1px 4px rgba(0,0,0,.3), 0 0 12px rgba(103,232,249,.15);
+  }
+
+  .nickname-input[aria-invalid='true'] {
+    border-color: var(--accent-pink);
+    box-shadow: inset 0 1px 4px rgba(0,0,0,.3), 0 0 8px rgba(249,168,212,.2);
+  }
+
+  /* ── Nickname error ──────────────────────────────────────────────────────── */
+  .nickname-error {
+    font-size: 10px;
+    font-family: var(--mono);
+    color: var(--accent-pink);
+    white-space: nowrap;
+    line-height: 1.2;
+  }
+
   /* ── Latency text ────────────────────────────────────────────────────────── */
   .latency-text {
     flex-shrink: 0;
@@ -232,6 +376,51 @@
     min-width: 52px;
     text-align: right;
     white-space: nowrap;
+  }
+
+  /* ── Edit button ─────────────────────────────────────────────────────────── */
+  .edit-btn {
+    flex-shrink: 0;
+    width: 44px;  /* WCAG 2.5.5 minimum touch target */
+    height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid transparent;
+    border-radius: var(--btn-radius);
+    background: transparent;
+    color: var(--t3);
+    cursor: pointer;
+    transition: opacity var(--timing-btn) ease, color var(--timing-btn) ease,
+      background var(--timing-btn) ease, border-color var(--timing-btn) ease;
+    /* Hidden by default; revealed on row hover or focus */
+    opacity: 0;
+    visibility: hidden;
+  }
+
+  .endpoint-row:hover .edit-btn,
+  .edit-btn.active,
+  .edit-btn:focus-visible {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  .edit-btn:hover:not(:disabled) {
+    background: var(--glass-bg);
+    border-color: rgba(103,232,249,.15);
+    color: var(--accent-cyan);
+  }
+
+  .edit-btn.active {
+    color: var(--accent-cyan);
+  }
+
+  /* Touch devices: always show edit button */
+  @media (hover: none) {
+    .edit-btn {
+      opacity: 1;
+      visibility: visible;
+    }
   }
 
   /* ── Toggle ──────────────────────────────────────────────────────────────── */

--- a/src/lib/components/EndpointRow.svelte
+++ b/src/lib/components/EndpointRow.svelte
@@ -167,9 +167,10 @@
         aria-label="Endpoint nickname"
         aria-invalid={nicknameInvalid ? 'true' : 'false'}
         onkeydown={handleNicknameKeydown}
+        oninput={() => { if (nicknameInvalid) nicknameInvalid = false; }}
       />
       {#if nicknameInvalid}
-        <span class="nickname-error" role="alert">Max 80 characters</span>
+        <span class="nickname-error" role="alert">Invalid nickname (max 80 chars, no control/zero-width/bidi)</span>
       {/if}
     </div>
   {/if}

--- a/src/lib/endpoint/displayLabel.ts
+++ b/src/lib/endpoint/displayLabel.ts
@@ -1,0 +1,95 @@
+// src/lib/endpoint/displayLabel.ts
+// Pure helpers for deriving a human-readable display label from an endpoint.
+// No side-effects, no module-level mutable state. Safe to tree-shake.
+
+import { brandFor } from '../regional-defaults';
+
+// -- Types -------------------------------------------------------------------
+
+export type LabelInput = { url: string; nickname?: string };
+
+// -- Regex constants (\uXXXX escapes required for ESLint + editor safety) -----
+
+/** C0 controls (U+0000-U+001F) and C1 controls (U+007F-U+009F). */
+const RE_CONTROL = /[\u0000-\u001F\u007F-\u009F]/u;
+
+/**
+ * Bidi-override characters.
+ * U+202A-U+202E (LRE, RLE, PDF, LRO, RLO) and
+ * U+2066-U+2069 (LRI, RLI, FSI, PDI).
+ */
+const RE_BIDI = /[\u202A-\u202E\u2066-\u2069]/u;
+
+/**
+ * Zero-width and invisible formatting characters.
+ * U+200B-U+200D (ZWSP, ZWNJ, ZWJ), U+FEFF (BOM),
+ * U+2060-U+206F (word joiner, invisible operators, deprecated formatting).
+ */
+const RE_ZERO_WIDTH = /[\u200B-\u200D\uFEFF\u2060-\u206F]/u;
+
+/**
+ * Unicode line/paragraph separators.
+ * U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR).
+ */
+const RE_LINE_SEP = /[\u2028\u2029]/u;
+
+// -- displayLabel ------------------------------------------------------------
+
+/**
+ * Returns the best human-readable label for an endpoint using a 3-tier
+ * priority: nickname -> brandFor(url) -> displayHostname(url).
+ *
+ * Whitespace-only or absent nicknames fall through to the next tier so that
+ * callers which bypass isValidNickname (test fixtures, in-memory pre-save
+ * state) still produce sensible output.
+ */
+export function displayLabel(input: LabelInput): string {
+  const trimmed = input.nickname?.trim();
+  return (trimmed ? trimmed : null) ?? brandFor(input.url)?.label ?? displayHostname(input.url);
+}
+
+// -- displayHostname ---------------------------------------------------------
+
+/**
+ * Extracts the hostname (plus non-default port) from a URL string.
+ * WHATWG URL strips default ports (:443 for https, :80 for http) automatically.
+ * IPv6 bracket notation is preserved.
+ *
+ * Returns the literal string '(invalid URL)' on parse failure -- never throws.
+ * The fail-closed sentinel prevents raw URLs from leaking through AC5 textContent
+ * sweep if a malformed entry somehow passes upstream validation.
+ */
+export function displayHostname(url: string): string {
+  try {
+    const parsed = new URL(url);
+    // URL.port is empty string when the port is the scheme default.
+    return parsed.port ? `${parsed.hostname}:${parsed.port}` : parsed.hostname;
+  } catch {
+    return '(invalid URL)';
+  }
+}
+
+// -- isValidNickname ---------------------------------------------------------
+
+/**
+ * Type-guard validating a persisted / user-typed nickname.
+ *
+ * Accepts: non-empty string, <= 80 chars after trimming, free of control,
+ * bidi-override, zero-width, and line/paragraph-separator characters.
+ *
+ * Rejects without throwing for all other inputs, including non-string types,
+ * >80-char strings (DoS guard), and empty/whitespace-only values.
+ *
+ * On rejection at the load boundary, callers set nickname = undefined and
+ * keep the endpoint -- never drop the row.
+ */
+export function isValidNickname(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed.length > 80) return false;
+  if (RE_CONTROL.test(value)) return false;
+  if (RE_BIDI.test(value)) return false;
+  if (RE_ZERO_WIDTH.test(value)) return false;
+  if (RE_LINE_SEP.test(value)) return false;
+  return true;
+}

--- a/src/lib/endpoint/displayLabel.ts
+++ b/src/lib/endpoint/displayLabel.ts
@@ -55,6 +55,10 @@ export function displayLabel(input: LabelInput): string {
  * WHATWG URL strips default ports (:443 for https, :80 for http) automatically.
  * IPv6 bracket notation is preserved.
  *
+ * A leading "www." is stripped for the hostname-tier (tier-3) display so that
+ * `https://www.acme.com` renders as `acme.com`. IPv6 bracketed hosts never
+ * start with `www.`, so the slice is safe.
+ *
  * Returns the literal string '(invalid URL)' on parse failure -- never throws.
  * The fail-closed sentinel prevents raw URLs from leaking through AC5 textContent
  * sweep if a malformed entry somehow passes upstream validation.
@@ -62,8 +66,11 @@ export function displayLabel(input: LabelInput): string {
 export function displayHostname(url: string): string {
   try {
     const parsed = new URL(url);
+    const host = parsed.hostname.startsWith('www.')
+      ? parsed.hostname.slice(4)
+      : parsed.hostname;
     // URL.port is empty string when the port is the scheme default.
-    return parsed.port ? `${parsed.hostname}:${parsed.port}` : parsed.hostname;
+    return parsed.port ? `${host}:${parsed.port}` : host;
   } catch {
     return '(invalid URL)';
   }

--- a/src/lib/share/hash-router.ts
+++ b/src/lib/share/hash-router.ts
@@ -22,6 +22,7 @@ import { uiStore } from '../stores/ui';
 import type { SharePayload, MeasurementSample, SampleStatus, Endpoint } from '../types';
 import { tokens } from '../tokens';
 import { get } from 'svelte/store';
+import { displayLabel } from '../endpoint/displayLabel';
 
 // Upper bound for the round counter materialized from a share payload.
 // Matches the sample cap (10 000 per endpoint × 50 endpoints) with generous
@@ -70,7 +71,7 @@ function buildEndpoints(
     id: `shared-ep-${i}-${Date.now()}`,
     url: ep.url,
     enabled: ep.enabled,
-    label: ep.url,
+    label: displayLabel({ url: ep.url }),
     color: pickColor(i),
   }));
 }

--- a/src/lib/share/share-manager.ts
+++ b/src/lib/share/share-manager.ts
@@ -74,6 +74,10 @@ function validateSharePayload(data: unknown): SharePayload | null {
     const e = ep as Record<string, unknown>;
     if (!isSafeSharedUrl(e['url'])) return null;
     if (typeof e['enabled'] !== 'boolean') return null;
+    // Reject unknown per-entry keys. Allowlist: url, enabled. Hybrid Bet (share-side): nicknames stay local; schema-level rejection at boundary.
+    for (const key of Object.keys(e)) {
+      if (key !== 'url' && key !== 'enabled') return null;
+    }
   }
 
   const settings = obj['settings'];
@@ -85,6 +89,12 @@ function validateSharePayload(data: unknown): SharePayload | null {
   if (s['burstRounds'] !== undefined && (!isNonNegativeFiniteNumber(s['burstRounds']) || (s['burstRounds'] as number) > 500)) return null;
   if (s['monitorDelay'] !== undefined && (!isNonNegativeFiniteNumber(s['monitorDelay']) || (s['monitorDelay'] as number) > 60000)) return null;
   if (s['corsMode'] !== 'no-cors' && s['corsMode'] !== 'cors') return null;
+
+  // Reject unknown top-level keys. Allowlist: v, mode, endpoints, settings, results. Symmetric with per-entry — closes future round-trip footgun.
+  const ALLOWED_TOP_LEVEL = new Set(['v', 'mode', 'endpoints', 'settings', 'results']);
+  for (const key of Object.keys(obj)) {
+    if (!ALLOWED_TOP_LEVEL.has(key)) return null;
+  }
 
   if (obj['results'] !== undefined) {
     if (!Array.isArray(obj['results'])) return null;

--- a/src/lib/stores/endpoints.ts
+++ b/src/lib/stores/endpoints.ts
@@ -6,6 +6,7 @@ import { tokens } from '../tokens';
 import { REGIONAL_DEFAULTS } from '../regional-defaults';
 import type { Region } from '../regional-defaults';
 import type { Endpoint } from '../types';
+import { displayLabel } from '../endpoint/displayLabel';
 
 let _idCounter = 0;
 
@@ -40,7 +41,7 @@ function createEndpointStore() {
   return {
     subscribe,
 
-    addEndpoint(url: string, label?: string): string {
+    addEndpoint(url: string, label?: string, nickname?: string): string {
       let newId = '';
       update(endpoints => {
         if (endpoints.length >= MAX_ENDPOINTS) return endpoints; // no-op at cap
@@ -51,8 +52,9 @@ function createEndpointStore() {
           id,
           url,
           enabled: true,
-          label: label ?? url,
+          label: label ?? displayLabel({ url, nickname }),
           color,
+          ...(nickname !== undefined ? { nickname } : {}),
         };
         return [...endpoints, newEndpoint];
       });
@@ -65,7 +67,18 @@ function createEndpointStore() {
 
     updateEndpoint(id: string, patch: Partial<Omit<Endpoint, 'id'>>): void {
       update(endpoints =>
-        endpoints.map(ep => (ep.id === id ? { ...ep, ...patch } : ep))
+        endpoints.map(ep => {
+          if (ep.id !== id) return ep;
+          const merged = { ...ep, ...patch };
+          // Recompute label whenever url or nickname changes so the displayed
+          // name stays in sync. A caller-supplied label in the patch takes
+          // precedence (explicit wins), but if no label is patched we derive
+          // one from the merged url + nickname.
+          if (('url' in patch || 'nickname' in patch) && !('label' in patch)) {
+            merged.label = displayLabel({ url: merged.url, nickname: merged.nickname });
+          }
+          return merged;
+        })
       );
     },
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -20,6 +20,7 @@ export interface Endpoint {
   enabled: boolean;
   label: string;
   color: string;
+  nickname?: string;
 }
 
 // ── Worker message contracts ───────────────────────────────────────────────
@@ -295,13 +296,15 @@ export interface SharePayload {
 }
 
 // ── Persistence schema ─────────────────────────────────────────────────────
-// v10 is the sole supported version. Payloads at any earlier version are
-// rejected on load (both storage keys cleared) so the app seeds fresh
+// version is a permanent 10 | 11 union. v10 payloads remain valid because
+// normalizeV10 legitimately returns { version: 10 } as an intermediate value
+// before the migration chain stamps version 11. Payloads at any version < 10
+// are rejected on load (both storage keys cleared) so the app seeds fresh
 // region-aware defaults — see persistence.ts. Sets serialize as arrays on
 // disk; `ui.terminalFilters` round-trips accordingly.
 export interface PersistedSettings {
-  version: 10;
-  endpoints: { url: string; enabled: boolean }[];
+  version: 10 | 11;
+  endpoints: { url: string; enabled: boolean; nickname?: string }[];
   settings: Settings;
   ui: {
     expandedCards: string[];

--- a/src/lib/utils/apply-persisted-settings.ts
+++ b/src/lib/utils/apply-persisted-settings.ts
@@ -11,18 +11,18 @@ import { endpointStore } from '../stores/endpoints';
 import { settingsStore } from '../stores/settings';
 import { uiStore } from '../stores/ui';
 import type { PersistedSettings } from '../types';
-import { brandFor } from '../regional-defaults';
+import { displayLabel } from '../endpoint/displayLabel';
 
 // Helpers are declared as const arrows (not `function` declarations) to stay
 // clear of DeepSource's "function declaration in global scope" rule, and each
 // helper holds a single concern so cyclomatic complexity stays below threshold.
 
 // Hydrate one persisted endpoint into the runtime store.
-const hydrateEndpoint = (ep: { url: string; enabled: boolean }): void => {
+const hydrateEndpoint = (ep: { url: string; enabled: boolean; nickname?: string }): void => {
   const url = ep.url.trim();
   if (!url) return;
-  const label = brandFor(url)?.label ?? url;
-  const id = endpointStore.addEndpoint(url, label);
+  const label = displayLabel({ url, nickname: ep.nickname });
+  const id = endpointStore.addEndpoint(url, label, ep.nickname);
   endpointStore.updateEndpoint(id, { enabled: ep.enabled });
 };
 

--- a/src/lib/utils/apply-persisted-settings.ts
+++ b/src/lib/utils/apply-persisted-settings.ts
@@ -17,12 +17,16 @@ import { displayLabel } from '../endpoint/displayLabel';
 // clear of DeepSource's "function declaration in global scope" rule, and each
 // helper holds a single concern so cyclomatic complexity stays below threshold.
 
-// Hydrate one persisted endpoint into the runtime store.
+// Hydrate one persisted endpoint into the runtime store. Nickname is trimmed
+// once at the boundary so storage and display agree (displayLabel re-trims at
+// render time, so an untrimmed value would display correctly but persist
+// padded — round-trip divergence).
 const hydrateEndpoint = (ep: { url: string; enabled: boolean; nickname?: string }): void => {
   const url = ep.url.trim();
   if (!url) return;
-  const label = displayLabel({ url, nickname: ep.nickname });
-  const id = endpointStore.addEndpoint(url, label, ep.nickname);
+  const nickname = ep.nickname?.trim() || undefined;
+  const label = displayLabel({ url, nickname });
+  const id = endpointStore.addEndpoint(url, label, nickname);
   endpointStore.updateEndpoint(id, { enabled: ep.enabled });
 };
 

--- a/src/lib/utils/persistence.ts
+++ b/src/lib/utils/persistence.ts
@@ -1,5 +1,6 @@
 // src/lib/utils/persistence.ts
-// Versioned localStorage persistence. v10 is the sole supported version.
+// Versioned localStorage persistence. v11 is the current version.
+// v10 payloads are migrated to v11 on load (nickname field added, set to undefined).
 // Payloads with any other version (including all prior v1–v9 builds) are
 // rejected: both storage keys are cleared and the caller receives null,
 // which triggers the first-install / region-aware defaults path in App.svelte.
@@ -7,6 +8,7 @@
 import { DEFAULT_SETTINGS } from '../types';
 import { isValidRegion } from '../regional-defaults';
 import { isSafeProbeUrl } from './url-safety';
+import { isValidNickname } from '../endpoint/displayLabel';
 import type {
   ActiveView,
   LiveTimeRange,
@@ -18,9 +20,9 @@ import type { Region } from '../regional-defaults';
 
 const STORAGE_KEY = 'chronoscope_settings'; // skipcq: JS-0860 — localStorage key, not a credential
 const LEGACY_STORAGE_KEY = 'chronoscope_v2_settings'; // skipcq: JS-0860 — localStorage key, not a credential
-export const CURRENT_VERSION = 10;
+export const CURRENT_VERSION = 11;
 
-// Views valid at v10. Used by readActiveView to validate the persisted value.
+// Views valid at v10/v11. Used by readActiveView to validate the persisted value.
 const V10_VIEWS: ReadonlySet<string> = new Set<ActiveView>([
   'overview', 'live', 'diagnose', 'strata', 'terminal',
 ]);
@@ -84,15 +86,27 @@ export function migrateSettings(data: unknown): PersistedSettings | null {
   const record = data as Record<string, unknown>;
   const version = typeof record['version'] === 'number' ? record['version'] : 0;
 
-  if (version === CURRENT_VERSION) return normalizeV10(record);
+  if (version === 10) {
+    // Migrate v10 → v11: run v10 normalizer then stamp version 11 and clear nicknames.
+    const v10result = normalizeV10(record);
+    if (v10result === null) return null;
+    return {
+      ...v10result,
+      version: 11,
+      endpoints: v10result.endpoints.map((ep) => ({ ...ep, nickname: undefined })),
+    };
+  }
 
-  // Unknown or pre-v10 version — return null (triggers first-install path).
+  if (version === CURRENT_VERSION) return normalizeV11(record);
+
+  // Unknown, pre-v10, or future version — return null (triggers first-install path).
   return null;
 }
 
 // ── v10 normalizer ────────────────────────────────────────────────────────────
 // Reads and validates a v10 payload. Any field that fails validation falls back
 // to a safe default. Returns null only if an unexpected exception is thrown.
+// Used only as the first step in v10 → v11 migration.
 function normalizeV10(record: Record<string, unknown>): PersistedSettings | null {
   try {
     const rawUi = asRecord(record['ui']) ?? {};
@@ -100,6 +114,30 @@ function normalizeV10(record: Record<string, unknown>): PersistedSettings | null
     return {
       version: 10,
       endpoints: readEndpointsField(record),
+      settings: readSettingsField(record),
+      ui: {
+        expandedCards:     readExpandedCards(rawUi),
+        activeView,
+        focusedEndpointId: readFocusedEndpointId(rawUi),
+        liveOptions:       readLiveOptions(rawUi),
+        terminalFilters:   readTerminalFilters(rawUi),
+      },
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ── v11 normalizer ────────────────────────────────────────────────────────────
+// Reads and validates a v11 payload. Identical to v10 but uses readEndpointsFieldV11
+// (which validates and conditionally preserves the nickname field).
+function normalizeV11(record: Record<string, unknown>): PersistedSettings | null {
+  try {
+    const rawUi = asRecord(record['ui']) ?? {};
+    const activeView = readActiveView(rawUi, V10_VIEWS);
+    return {
+      version: 11,
+      endpoints: readEndpointsFieldV11(record),
       settings: readSettingsField(record),
       ui: {
         expandedCards:     readExpandedCards(rawUi),
@@ -132,6 +170,27 @@ function readEndpointsField(record: Record<string, unknown>): { url: string; ena
       url: e['url'] as string,
       enabled: typeof e['enabled'] === 'boolean' ? e['enabled'] : true,
     }));
+}
+
+function readEndpointsFieldV11(
+  record: Record<string, unknown>,
+): { url: string; enabled: boolean; nickname?: string }[] {
+  const raw = Array.isArray(record['endpoints']) ? record['endpoints'] : [];
+  // Same URL safety gate as v10. Additionally validates and conditionally
+  // preserves the nickname field — invalid nicknames are stripped (set to
+  // undefined) but the endpoint row is always kept.
+  return raw
+    .filter((e): e is Record<string, unknown> => asRecord(e) !== null)
+    .filter((e) => isSafeProbeUrl(e['url']))
+    .map((e) => {
+      const rawNick = e['nickname'];
+      const nickname = isValidNickname(rawNick) ? rawNick : undefined;
+      return {
+        url: e['url'] as string,
+        enabled: typeof e['enabled'] === 'boolean' ? e['enabled'] : true,
+        ...(nickname !== undefined ? { nickname } : {}),
+      };
+    });
 }
 
 function readSettingsField(record: Record<string, unknown>): Settings {

--- a/tests/unit/components/EndpointPanel.test.ts
+++ b/tests/unit/components/EndpointPanel.test.ts
@@ -19,7 +19,7 @@ beforeEach(() => {
 });
 
 describe('EndpointPanel — G6 add endpoint call signature', () => {
-  it('should create new endpoint with label === url when Add endpoint is clicked', async () => {
+  it('should create new endpoint with a non-empty label when Add endpoint is clicked', async () => {
     const { getByText } = render(EndpointPanel);
     const addButton = getByText('+ Add endpoint');
 
@@ -30,9 +30,9 @@ describe('EndpointPanel — G6 add endpoint call signature', () => {
     expect(eps).toHaveLength(1);
     const newEp = eps.find(e => e.url === 'https://');
     expect(newEp).toBeTruthy();
-    // label must equal url so rail dedup collapses to single line (G6 fix:
-    // second arg removed from addEndpoint call, so label ?? url falls through
-    // to url — not empty string).
-    expect(newEp?.label).toBe('https://');
+    // displayLabel returns '(invalid URL)' for malformed placeholder URLs —
+    // the fail-closed sentinel prevents raw URLs from leaking through as labels.
+    expect(newEp?.label).toBe('(invalid URL)');
+    expect(newEp?.label).not.toBe('');
   });
 });

--- a/tests/unit/components/EndpointRail.test.ts
+++ b/tests/unit/components/EndpointRail.test.ts
@@ -80,6 +80,51 @@ describe('EndpointRail — G6 URL subtitle dedup truth table', () => {
   });
 });
 
+describe('EndpointRail — hostname-derived labels (post-construction behavior)', () => {
+  // These tests exercise the normal path after EndpointPanel constructs an
+  // endpoint: ep.label is set to displayLabel(ep) at save time, which produces
+  // the hostname (or brand) rather than the raw URL. The defensive ternary in
+  // EndpointRail still guards the blank/equal cases for stale fixtures.
+
+  it('primary line shows ep.label when label is hostname-derived', () => {
+    const { container } = renderRailWith([
+      { id: 'ep1', url: 'https://api.example.com/v1/health', label: 'api.example.com', enabled: true, color: '#fff' },
+    ]);
+    const labelSpan = container.querySelector('.rail-row-label');
+    expect(labelSpan?.textContent).toBe('api.example.com');
+    expect(labelSpan?.textContent).not.toContain('https://');
+  });
+
+  it('URL subtitle rendered when hostname-derived label differs from url', () => {
+    const { container } = renderRailWith([
+      { id: 'ep1', url: 'https://api.example.com/v1/health', label: 'api.example.com', enabled: true, color: '#fff' },
+    ]);
+    const urlSpan = container.querySelector('.rail-row-url');
+    expect(urlSpan).not.toBeNull();
+    expect(urlSpan?.textContent).toBe('https://api.example.com/v1/health');
+  });
+
+  it('aria-label contains hostname-derived label as primary identifier', () => {
+    const { container } = renderRailWith([
+      { id: 'ep1', url: 'https://api.example.com/v1/health', label: 'api.example.com', enabled: true, color: '#fff' },
+    ]);
+    const row = container.querySelector('.rail-row');
+    const aria = row?.getAttribute('aria-label') ?? '';
+    expect(aria).toContain('api.example.com');
+    expect(aria).toContain('https://api.example.com/v1/health');
+  });
+
+  it('brand-labeled endpoint shows brand in primary, URL in subtitle', () => {
+    const { container } = renderRailWith([
+      { id: 'ep1', url: 'https://www.google.com', label: 'Google', enabled: true, color: '#fff' },
+    ]);
+    const labelSpan = container.querySelector('.rail-row-label');
+    const urlSpan = container.querySelector('.rail-row-url');
+    expect(labelSpan?.textContent).toBe('Google');
+    expect(urlSpan?.textContent).toBe('https://www.google.com');
+  });
+});
+
 describe('EndpointRail — G6 aria-label dedup (SR double-voice prevention)', () => {
   // aria-label used to be `"{label}, {url}, status: ..."` which reads the URL
   // twice for user-added rows where label === url. Dedup the aria-label in

--- a/tests/unit/components/endpoint-row-edit-affordance.test.ts
+++ b/tests/unit/components/endpoint-row-edit-affordance.test.ts
@@ -113,7 +113,10 @@ describe('EndpointRow — edit affordance (AC2)', () => {
     expect(label).not.toContain('https://');
   });
 
-  it('edit button has WCAG 2.5.5 class', () => {
+  // jsdom can't measure computed dimensions; this test only verifies the class
+  // is applied. The actual 44×44 WCAG 2.5.5 target size is enforced by the
+  // .edit-btn CSS rule and observable via the Playwright sweep, not here.
+  it('edit button is rendered with edit-btn class', () => {
     const { container } = renderRow();
     const editBtn = container.querySelector('.edit-btn');
     expect(editBtn).not.toBeNull();

--- a/tests/unit/components/endpoint-row-edit-affordance.test.ts
+++ b/tests/unit/components/endpoint-row-edit-affordance.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+import type { Endpoint } from '../../../src/lib/types';
+import EndpointRow from '../../../src/lib/components/EndpointRow.svelte';
+
+function makeEndpoint(overrides: Partial<Endpoint> = {}): Endpoint {
+  return {
+    id: 'ep-1',
+    url: 'https://api.example.com',
+    enabled: true,
+    color: '#67e8f9',
+    label: 'Prod API',
+    nickname: 'Prod API',
+    ...overrides,
+  };
+}
+
+function renderRow(overrides: Partial<Endpoint> = {}, props: Record<string, unknown> = {}) {
+  const endpoint = makeEndpoint(overrides);
+  return render(EndpointRow, {
+    props: {
+      endpoint,
+      isRunning: false,
+      isLast: false,
+      ...props,
+    },
+  });
+}
+
+describe('EndpointRow — edit affordance (AC2)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders a pencil/edit button in read mode', () => {
+    const { container } = renderRow();
+    const editBtn = container.querySelector('.edit-btn');
+    expect(editBtn).not.toBeNull();
+  });
+
+  it('clicking pencil reveals URL input and nickname input', async () => {
+    const { container } = renderRow();
+    const editBtn = container.querySelector('.edit-btn') as HTMLButtonElement;
+    await fireEvent.click(editBtn);
+
+    expect(container.querySelector('.url-input')).not.toBeNull();
+    const nickInput = container.querySelector('.nickname-input') as HTMLInputElement | null;
+    expect(nickInput).not.toBeNull();
+    expect(nickInput?.placeholder).toMatch(/nickname/i);
+  });
+
+  it('URL input shows endpoint URL while editing', async () => {
+    const { container } = renderRow({ url: 'https://api.example.com' });
+    const editBtn = container.querySelector('.edit-btn') as HTMLButtonElement;
+    await fireEvent.click(editBtn);
+
+    const urlInput = container.querySelector('.url-input') as HTMLInputElement | null;
+    expect(urlInput).not.toBeNull();
+    expect(urlInput?.value).toBe('https://api.example.com');
+  });
+
+  it('pressing Enter in nickname input calls onUpdate with nickname', async () => {
+    const onUpdate = vi.fn();
+    const { container } = renderRow({}, { onUpdate });
+    const editBtn = container.querySelector('.edit-btn') as HTMLButtonElement;
+    await fireEvent.click(editBtn);
+
+    const nickInput = container.querySelector('.nickname-input') as HTMLInputElement;
+    await fireEvent.input(nickInput, { target: { value: 'Prod API' } });
+    await fireEvent.keyDown(nickInput, { key: 'Enter' });
+
+    expect(onUpdate).toHaveBeenCalledOnce();
+    const [, patch] = onUpdate.mock.calls[0] as [string, { nickname: string }];
+    expect(patch.nickname).toBe('Prod API');
+  });
+
+  it('pressing Escape cancels edit without calling onUpdate', async () => {
+    const onUpdate = vi.fn();
+    const { container } = renderRow({}, { onUpdate });
+    const editBtn = container.querySelector('.edit-btn') as HTMLButtonElement;
+    await fireEvent.click(editBtn);
+
+    const nickInput = container.querySelector('.nickname-input') as HTMLInputElement;
+    await fireEvent.keyDown(nickInput, { key: 'Escape' });
+
+    expect(onUpdate).not.toHaveBeenCalled();
+    // Pencil button should be visible again (not in editing mode)
+    expect(container.querySelector('.edit-btn')).not.toBeNull();
+    expect(container.querySelector('.nickname-input')).toBeNull();
+  });
+
+  it('invalid nickname (too long) sets aria-invalid', async () => {
+    const onUpdate = vi.fn();
+    const { container } = renderRow({}, { onUpdate });
+    const editBtn = container.querySelector('.edit-btn') as HTMLButtonElement;
+    await fireEvent.click(editBtn);
+
+    const nickInput = container.querySelector('.nickname-input') as HTMLInputElement;
+    const longNick = 'a'.repeat(81);
+    await fireEvent.input(nickInput, { target: { value: longNick } });
+    await fireEvent.keyDown(nickInput, { key: 'Enter' });
+
+    expect(nickInput.getAttribute('aria-invalid')).toBe('true');
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it('remove button aria-label uses ep.label not ep.url', () => {
+    const { container } = renderRow({ label: 'Prod API', url: 'https://api.example.com' });
+    const removeBtn = container.querySelector('.remove-btn');
+    expect(removeBtn).not.toBeNull();
+    const label = removeBtn?.getAttribute('aria-label') ?? '';
+    expect(label).toContain('Prod API');
+    expect(label).not.toContain('https://');
+  });
+
+  it('edit button has WCAG 2.5.5 class', () => {
+    const { container } = renderRow();
+    const editBtn = container.querySelector('.edit-btn');
+    expect(editBtn).not.toBeNull();
+    expect(editBtn?.classList.contains('edit-btn')).toBe(true);
+  });
+});

--- a/tests/unit/endpoint/displayLabel.test.ts
+++ b/tests/unit/endpoint/displayLabel.test.ts
@@ -1,0 +1,100 @@
+// tests/unit/endpoint/displayLabel.test.ts
+import { describe, it, expect } from 'vitest';
+import { displayLabel, displayHostname } from '../../../src/lib/endpoint/displayLabel';
+
+describe('displayLabel', () => {
+  // AC1: nickname wins over brandFor and hostname
+  it('returns nickname when set and non-empty (AC1 tier-1)', () => {
+    expect(displayLabel({ url: 'https://www.google.com', nickname: 'My Google' })).toBe('My Google');
+  });
+
+  // AC1: whitespace-only nickname falls through to brandFor
+  it('falls through to brandFor when nickname is whitespace-only (AC1 tier-1 edge)', () => {
+    expect(displayLabel({ url: 'https://www.google.com', nickname: '   ' })).toBe('Google');
+  });
+
+  // AC1: brandFor wins over hostname
+  it('returns brandFor label when no nickname and URL matches brand map (AC1 tier-2)', () => {
+    expect(displayLabel({ url: 'https://www.google.com' })).toBe('Google');
+  });
+
+  // AC1: hostname fallback
+  it('returns hostname when no nickname and no brandFor match (AC1 tier-3)', () => {
+    expect(displayLabel({ url: 'https://api.example.com/v1/health' })).toBe('api.example.com');
+  });
+
+  // AC1: primary line never contains https://
+  it('result never contains https:// as a substring in hostname tier (AC1 no-raw-url)', () => {
+    const result = displayLabel({ url: 'https://api.example.com/v1/health' });
+    expect(result).not.toContain('https://');
+  });
+
+  // AC1: primary line never contains http://
+  it('result never contains http:// as a substring (AC1 no-raw-url)', () => {
+    const result = displayLabel({ url: 'http://internal.corp/' });
+    expect(result).not.toContain('http://');
+  });
+
+  // AC1: www is stripped from hostname (displayHostname handles this via URL.hostname)
+  it('strips www from hostname tier (AC1 no-www)', () => {
+    expect(displayLabel({ url: 'https://www.fastly.com/robots.txt' })).toBe('Fastly');
+  });
+
+  // Edge: undefined nickname treated same as absent
+  it('treats undefined nickname as absent', () => {
+    expect(displayLabel({ url: 'https://api.example.com', nickname: undefined })).toBe('api.example.com');
+  });
+
+  // Edge: empty-string nickname falls through
+  it('treats empty-string nickname as absent', () => {
+    expect(displayLabel({ url: 'https://api.example.com', nickname: '' })).toBe('api.example.com');
+  });
+});
+
+describe('displayHostname', () => {
+  // Standard HTTPS (default port stripped by URL constructor)
+  it('returns hostname for standard HTTPS URL', () => {
+    expect(displayHostname('https://api.example.com/v1/health')).toBe('api.example.com');
+  });
+
+  // Non-default port preserved
+  it('preserves non-default port (AC1 IP/port edge)', () => {
+    expect(displayHostname('https://api.example.com:8443/path')).toBe('api.example.com:8443');
+  });
+
+  // Default port 443 stripped
+  it('strips default :443 from HTTPS URL', () => {
+    expect(displayHostname('https://api.example.com:443/path')).toBe('api.example.com');
+  });
+
+  // Default port 80 stripped
+  it('strips default :80 from HTTP URL', () => {
+    expect(displayHostname('http://api.example.com:80/path')).toBe('api.example.com');
+  });
+
+  // IPv6 brackets preserved
+  it('preserves IPv6 brackets with port (AC1 IPv6 edge)', () => {
+    expect(displayHostname('http://[::1]:8080/')).toBe('[::1]:8080');
+  });
+
+  // IPv6 default port stripped
+  it('IPv6 without port returns bracketed hostname', () => {
+    expect(displayHostname('http://[::1]/')).toBe('[::1]');
+  });
+
+  // localhost
+  it('returns localhost for localhost URLs', () => {
+    expect(displayHostname('https://localhost/path')).toBe('localhost');
+  });
+
+  // Invalid URL — returns '(invalid URL)', never throws
+  it('returns "(invalid URL)" on parse failure, never throws (AC5 fail-closed)', () => {
+    expect(() => displayHostname('not a url at all')).not.toThrow();
+    expect(displayHostname('not a url at all')).toBe('(invalid URL)');
+  });
+
+  // userinfo not exposed
+  it('does not include userinfo (username/password) in output', () => {
+    expect(displayHostname('https://user:pass@api.example.com/')).toBe('api.example.com');
+  });
+});

--- a/tests/unit/endpoint/displayLabel.test.ts
+++ b/tests/unit/endpoint/displayLabel.test.ts
@@ -35,9 +35,14 @@ describe('displayLabel', () => {
     expect(result).not.toContain('http://');
   });
 
-  // AC1: www is stripped from hostname (displayHostname handles this via URL.hostname)
-  it('strips www from hostname tier (AC1 no-www)', () => {
+  // AC1: branded www URL resolves through brandFor (tier-2), not the hostname tier
+  it('branded www URL resolves to brand label, not hostname (AC1 tier-2)', () => {
     expect(displayLabel({ url: 'https://www.fastly.com/robots.txt' })).toBe('Fastly');
+  });
+
+  // AC1: www is stripped from hostname tier for non-brand-mapped URLs
+  it('strips leading www from hostname tier for non-brand URL (AC1 no-www)', () => {
+    expect(displayLabel({ url: 'https://www.acme-not-in-brand-map.com' })).toBe('acme-not-in-brand-map.com');
   });
 
   // Edge: undefined nickname treated same as absent
@@ -85,6 +90,21 @@ describe('displayHostname', () => {
   // localhost
   it('returns localhost for localhost URLs', () => {
     expect(displayHostname('https://localhost/path')).toBe('localhost');
+  });
+
+  // AC1: leading www is stripped
+  it('strips leading www from hostname', () => {
+    expect(displayHostname('https://www.acme.com/')).toBe('acme.com');
+  });
+
+  // AC1: leading www stripped, non-default port preserved
+  it('strips www and preserves non-default port', () => {
+    expect(displayHostname('https://www.acme.com:8443/')).toBe('acme.com:8443');
+  });
+
+  // AC1: www mid-hostname is NOT stripped (only leading)
+  it('does not strip www that is not at start of hostname', () => {
+    expect(displayHostname('https://api.www.example.com/')).toBe('api.www.example.com');
   });
 
   // Invalid URL — returns '(invalid URL)', never throws

--- a/tests/unit/endpoint/isValidNickname.test.ts
+++ b/tests/unit/endpoint/isValidNickname.test.ts
@@ -1,0 +1,115 @@
+// tests/unit/endpoint/isValidNickname.test.ts
+import { describe, it, expect } from 'vitest';
+import { isValidNickname } from '../../../src/lib/endpoint/displayLabel';
+
+describe('isValidNickname', () => {
+  // AC3: valid nicknames pass
+  it('accepts a plain ASCII nickname', () => {
+    expect(isValidNickname('My API')).toBe(true);
+  });
+
+  it('accepts a Unicode nickname without forbidden chars', () => {
+    expect(isValidNickname('Prod API 日本語')).toBe(true);
+  });
+
+  it('accepts a nickname exactly 80 chars', () => {
+    expect(isValidNickname('a'.repeat(80))).toBe(true);
+  });
+
+  // AC3: type rejections
+  it('rejects non-string types (number)', () => {
+    expect(isValidNickname(42)).toBe(false);
+  });
+
+  it('rejects non-string types (null)', () => {
+    expect(isValidNickname(null)).toBe(false);
+  });
+
+  it('rejects non-string types (object)', () => {
+    expect(isValidNickname({})).toBe(false);
+  });
+
+  // AC3: length rejection
+  it('rejects nickname over 80 chars after trim', () => {
+    expect(isValidNickname('a'.repeat(81))).toBe(false);
+  });
+
+  // AC3: 10 MB rejection (DoS guard from spec §4)
+  it('rejects 10 MB nickname (DoS guard)', () => {
+    expect(isValidNickname('a'.repeat(10 * 1024 * 1024))).toBe(false);
+  });
+
+  // AC3: empty / whitespace → false (callers store undefined)
+  it('rejects empty string', () => {
+    expect(isValidNickname('')).toBe(false);
+  });
+
+  it('rejects whitespace-only string', () => {
+    expect(isValidNickname('   ')).toBe(false);
+  });
+
+  // AC3: C0 control characters
+  it('rejects U+0000 (NUL, C0 control)', () => {
+    expect(isValidNickname('ab\u0000cd')).toBe(false);
+  });
+
+  it('rejects U+001F (C0 control, last in range)', () => {
+    expect(isValidNickname('ab\u001Fcd')).toBe(false);
+  });
+
+  // AC3: C1 control characters
+  it('rejects U+007F (DEL, C1 start)', () => {
+    expect(isValidNickname('ab\u007Fcd')).toBe(false);
+  });
+
+  it('rejects U+009F (C1 control, last in range)', () => {
+    expect(isValidNickname('ab\u009Fcd')).toBe(false);
+  });
+
+  // AC3: bidi override characters
+  it('rejects U+202E (bidi right-to-left override)', () => {
+    expect(isValidNickname('ab\u202Ecd')).toBe(false);
+  });
+
+  it('rejects U+202A (bidi left-to-right embedding, range start)', () => {
+    expect(isValidNickname('ab\u202Acd')).toBe(false);
+  });
+
+  it('rejects U+2069 (bidi pop directional isolate, range end)', () => {
+    expect(isValidNickname('ab\u2069cd')).toBe(false);
+  });
+
+  // AC3: zero-width characters
+  it('rejects U+200B (zero-width space)', () => {
+    expect(isValidNickname('ab\u200Bcd')).toBe(false);
+  });
+
+  it('rejects U+200C (ZWNJ)', () => {
+    expect(isValidNickname('ab\u200Ccd')).toBe(false);
+  });
+
+  it('rejects U+200D (ZWJ)', () => {
+    expect(isValidNickname('ab\u200Dcd')).toBe(false);
+  });
+
+  it('rejects U+FEFF (BOM)', () => {
+    expect(isValidNickname('\uFEFFab')).toBe(false);
+  });
+
+  it('rejects U+2060 (word joiner, invisible-operators range start)', () => {
+    expect(isValidNickname('ab\u2060cd')).toBe(false);
+  });
+
+  it('rejects U+206F (deprecated formatting, invisible range end)', () => {
+    expect(isValidNickname('ab\u206Fcd')).toBe(false);
+  });
+
+  // AC3: line/paragraph separators
+  it('rejects U+2028 (LINE SEPARATOR)', () => {
+    expect(isValidNickname('ab\u2028cd')).toBe(false);
+  });
+
+  it('rejects U+2029 (PARAGRAPH SEPARATOR)', () => {
+    expect(isValidNickname('ab\u2029cd')).toBe(false);
+  });
+});

--- a/tests/unit/persistence.test.ts
+++ b/tests/unit/persistence.test.ts
@@ -56,7 +56,12 @@ describe('persistence', () => {
     };
     saveSettings(v10);
     const loaded = loadPersistedSettings();
-    expect(loaded).toEqual(v10);
+    // v10 payloads are migrated to v11 at load; endpoints gain nickname: undefined
+    expect(loaded).toEqual({
+      ...v10,
+      version: 11,
+      endpoints: v10.endpoints.map((ep) => ({ ...ep, nickname: undefined })),
+    });
   });
 
   it('v10 payload with stray retired activeView coerces to overview', () => {
@@ -128,7 +133,7 @@ describe('persistence', () => {
     localStorageMock.setItem(LEGACY_KEY, JSON.stringify(v10));
     const result = loadPersistedSettings();
     expect(result).not.toBeNull();
-    expect(result?.version).toBe(10);
+    expect(result?.version).toBe(11);
     expect(localStorageMock.getItem(LEGACY_KEY)).toBeNull();
     expect(localStorageMock.getItem(PRIMARY_KEY)).not.toBeNull();
   });
@@ -150,7 +155,7 @@ describe('persistence', () => {
     try {
       const result = loadPersistedSettings();
       expect(result).not.toBeNull();
-      expect(result?.version).toBe(10);
+      expect(result?.version).toBe(11);
       expect(result?.endpoints[0]?.url).toBe('https://example.com');
     } finally {
       localStorageMock.setItem = originalSet;
@@ -180,7 +185,7 @@ describe('persistence', () => {
     };
     const result = migrateSettings(v10);
     expect(result).not.toBeNull();
-    expect(result?.version).toBe(10);
+    expect(result?.version).toBe(11);
     expect(result?.endpoints[0]?.url).toBe('https://example.com');
   });
 
@@ -223,6 +228,152 @@ describe('persistence', () => {
   it('migrateSettings: non-object input → returns null', () => {
     expect(migrateSettings(42)).toBeNull();
     expect(migrateSettings('string')).toBeNull();
+  });
+
+  // ── v10 → v11 migration ───────────────────────────────────────────────────
+
+  it('v10 → v11 migration: all v10 fields preserved, nickname undefined', () => {
+    const v10 = {
+      version: 10,
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      ui: { expandedCards: ['ep-1'], activeView: 'diagnose', focusedEndpointId: 'ep-1', liveOptions: { split: true, timeRange: '15m' }, terminalFilters: ['timeout'] },
+    };
+    const result = migrateSettings(v10);
+    expect(result).not.toBeNull();
+    expect(result?.version).toBe(11);
+    expect(result?.endpoints[0]?.url).toBe('https://example.com');
+    expect(result?.endpoints[0]?.enabled).toBe(true);
+    expect(result?.endpoints[0]?.nickname).toBeUndefined();
+    expect(result?.ui.activeView).toBe('diagnose');
+    expect(result?.ui.expandedCards).toEqual(['ep-1']);
+  });
+
+  // ── v11 round-trip and nickname validation ────────────────────────────────
+
+  it('v11 with valid nickname: round-trips intact', () => {
+    const v11 = {
+      version: 11,
+      endpoints: [{ url: 'https://example.com', enabled: true, nickname: 'My Server' }],
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      ui: { expandedCards: [], activeView: 'overview', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
+    };
+    localStorageMock.setItem(PRIMARY_KEY, JSON.stringify(v11));
+    const result = loadPersistedSettings();
+    expect(result).not.toBeNull();
+    expect(result?.version).toBe(11);
+    expect(result?.endpoints[0]?.nickname).toBe('My Server');
+  });
+
+  it('v11 with nickname >80 chars: nickname stripped, endpoint kept', () => {
+    const longNick = 'a'.repeat(81);
+    const v11 = {
+      version: 11,
+      endpoints: [{ url: 'https://example.com', enabled: true, nickname: longNick }],
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      ui: { expandedCards: [], activeView: 'overview', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
+    };
+    localStorageMock.setItem(PRIMARY_KEY, JSON.stringify(v11));
+    const result = loadPersistedSettings();
+    expect(result).not.toBeNull();
+    expect(result?.endpoints[0]?.url).toBe('https://example.com');
+    expect(result?.endpoints[0]?.nickname).toBeUndefined();
+  });
+
+  it('v11 with bidi character (U+202E) in nickname: nickname stripped, endpoint kept', () => {
+    const v11 = {
+      version: 11,
+      endpoints: [{ url: 'https://example.com', enabled: true, nickname: 'bad\u202Enick' }],
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      ui: { expandedCards: [], activeView: 'overview', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
+    };
+    localStorageMock.setItem(PRIMARY_KEY, JSON.stringify(v11));
+    const result = loadPersistedSettings();
+    expect(result).not.toBeNull();
+    expect(result?.endpoints[0]?.url).toBe('https://example.com');
+    expect(result?.endpoints[0]?.nickname).toBeUndefined();
+  });
+
+  it('v11 with control character (U+0000) in nickname: nickname stripped, endpoint kept', () => {
+    const v11 = {
+      version: 11,
+      endpoints: [{ url: 'https://example.com', enabled: true, nickname: 'bad\u0000nick' }],
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      ui: { expandedCards: [], activeView: 'overview', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
+    };
+    localStorageMock.setItem(PRIMARY_KEY, JSON.stringify(v11));
+    const result = loadPersistedSettings();
+    expect(result).not.toBeNull();
+    expect(result?.endpoints[0]?.url).toBe('https://example.com');
+    expect(result?.endpoints[0]?.nickname).toBeUndefined();
+  });
+
+  it('v11 with zero-width char (U+200B) in nickname: nickname stripped, endpoint kept', () => {
+    const v11 = {
+      version: 11,
+      endpoints: [{ url: 'https://example.com', enabled: true, nickname: 'zero\u200Bwidth' }],
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      ui: { expandedCards: [], activeView: 'overview', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
+    };
+    localStorageMock.setItem(PRIMARY_KEY, JSON.stringify(v11));
+    const result = loadPersistedSettings();
+    expect(result).not.toBeNull();
+    expect(result?.endpoints[0]?.url).toBe('https://example.com');
+    expect(result?.endpoints[0]?.nickname).toBeUndefined();
+  });
+
+  it('v11 with line-separator (U+2028) in nickname: nickname stripped, endpoint kept', () => {
+    const v11 = {
+      version: 11,
+      endpoints: [{ url: 'https://example.com', enabled: true, nickname: 'line\u2028sep' }],
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      ui: { expandedCards: [], activeView: 'overview', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
+    };
+    localStorageMock.setItem(PRIMARY_KEY, JSON.stringify(v11));
+    const result = loadPersistedSettings();
+    expect(result).not.toBeNull();
+    expect(result?.endpoints[0]?.url).toBe('https://example.com');
+    expect(result?.endpoints[0]?.nickname).toBeUndefined();
+  });
+
+  it('v11 with non-string nickname: nickname stripped, endpoint kept', () => {
+    const v11 = {
+      version: 11,
+      endpoints: [{ url: 'https://example.com', enabled: true, nickname: 42 }],
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      ui: { expandedCards: [], activeView: 'overview', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
+    };
+    localStorageMock.setItem(PRIMARY_KEY, JSON.stringify(v11));
+    const result = loadPersistedSettings();
+    expect(result).not.toBeNull();
+    expect(result?.endpoints[0]?.url).toBe('https://example.com');
+    expect(result?.endpoints[0]?.nickname).toBeUndefined();
+  });
+
+  it('v11 with whitespace-only nickname: nickname stripped, endpoint kept', () => {
+    const v11 = {
+      version: 11,
+      endpoints: [{ url: 'https://example.com', enabled: true, nickname: '   ' }],
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      ui: { expandedCards: [], activeView: 'overview', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
+    };
+    localStorageMock.setItem(PRIMARY_KEY, JSON.stringify(v11));
+    const result = loadPersistedSettings();
+    expect(result).not.toBeNull();
+    expect(result?.endpoints[0]?.url).toBe('https://example.com');
+    expect(result?.endpoints[0]?.nickname).toBeUndefined();
+  });
+
+  it('v9 payload still returns null after v11 bump', () => {
+    const v9 = {
+      version: 9,
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      ui: { expandedCards: [], activeView: 'overview', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
+    };
+    localStorageMock.setItem(PRIMARY_KEY, JSON.stringify(v9));
+    const result = loadPersistedSettings();
+    expect(result).toBeNull();
   });
 
   // ── clearPersistedSettings ────────────────────────────────────────────────

--- a/tests/unit/share/share-payload-rejects-unknown-keys.test.ts
+++ b/tests/unit/share/share-payload-rejects-unknown-keys.test.ts
@@ -1,0 +1,130 @@
+// Tests for unknown-key rejection in validateSharePayload.
+//
+// Threat model: a crafted share link can inject unexpected keys (e.g. nickname
+// harvesting, prototype-pollution surface, future round-trip footgun) at both
+// the top level and per-entry level. The validator must reject any payload
+// that contains keys outside the declared allowlists:
+//   - Top-level:  { v, mode, endpoints, settings, results }
+//   - Per-entry:  { url, enabled }
+//
+// Uses the encodeSharePayload / decodeSharePayload round-trip so the full
+// compression + validation path is exercised.
+
+import { describe, it, expect } from 'vitest';
+import {
+  encodeSharePayload,
+  decodeSharePayload,
+} from '../../../src/lib/share/share-manager';
+import type { SharePayload } from '../../../src/lib/types';
+
+// ── Per-entry rejection ────────────────────────────────────────────────────
+
+describe('validateSharePayload: per-entry unknown key rejection', () => {
+  it('rejects when a nickname is injected into an endpoint entry', () => {
+    const payload = {
+      v: 1,
+      mode: 'config',
+      endpoints: [
+        { url: 'https://example.com', enabled: true, nickname: 'My Server' },
+      ],
+      settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors' as const },
+    };
+    const encoded = encodeSharePayload(payload as never);
+    expect(decodeSharePayload(encoded)).toBeNull();
+  });
+
+  it('rejects when an arbitrary unknown key is present in an endpoint entry', () => {
+    const payload = {
+      v: 1,
+      mode: 'config',
+      endpoints: [
+        { url: 'https://example.com', enabled: true, extra: 'injected' },
+      ],
+      settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors' as const },
+    };
+    const encoded = encodeSharePayload(payload as never);
+    expect(decodeSharePayload(encoded)).toBeNull();
+  });
+
+  it('accepts an endpoint entry with only { url, enabled }', () => {
+    const payload: SharePayload = {
+      v: 1,
+      mode: 'config',
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors' },
+    };
+    const encoded = encodeSharePayload(payload);
+    expect(decodeSharePayload(encoded)).not.toBeNull();
+  });
+});
+
+// ── Top-level rejection ────────────────────────────────────────────────────
+
+describe('validateSharePayload: top-level unknown key rejection', () => {
+  it('rejects when a top-level "nicknames" key is present', () => {
+    const payload = {
+      v: 1,
+      mode: 'config',
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors' as const },
+      nicknames: { 'https://example.com': 'My Server' },
+    };
+    const encoded = encodeSharePayload(payload as never);
+    expect(decodeSharePayload(encoded)).toBeNull();
+  });
+
+  it('rejects when an arbitrary unknown top-level key is present', () => {
+    const payload = {
+      v: 1,
+      mode: 'config',
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors' as const },
+      injected: 'arbitrary',
+    };
+    const encoded = encodeSharePayload(payload as never);
+    expect(decodeSharePayload(encoded)).toBeNull();
+  });
+
+  it('accepts { v, mode, endpoints, settings } (config mode baseline)', () => {
+    const payload: SharePayload = {
+      v: 1,
+      mode: 'config',
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors' },
+    };
+    const encoded = encodeSharePayload(payload);
+    expect(decodeSharePayload(encoded)).not.toBeNull();
+  });
+
+  it('accepts { v, mode, endpoints, settings, results } (results mode baseline)', () => {
+    const payload: SharePayload = {
+      v: 1,
+      mode: 'results',
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors' },
+      results: [
+        {
+          samples: [{ round: 0, latency: 42, status: 'ok' }],
+        },
+      ],
+    };
+    const encoded = encodeSharePayload(payload);
+    expect(decodeSharePayload(encoded)).not.toBeNull();
+  });
+});
+
+// ── PR #81 invariant preserved ─────────────────────────────────────────────
+
+describe('validateSharePayload: PR #81 invariant preserved', () => {
+  it('rejects results mode without a results array (existing invariant)', () => {
+    const payload = {
+      v: 1,
+      mode: 'results',
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors' as const },
+      // results intentionally omitted
+    };
+    const encoded = encodeSharePayload(payload as never);
+    expect(decodeSharePayload(encoded)).toBeNull();
+  });
+});

--- a/tests/unit/stores/endpoints-label.test.ts
+++ b/tests/unit/stores/endpoints-label.test.ts
@@ -1,0 +1,64 @@
+// tests/unit/stores/endpoints-label.test.ts
+// TDD: verify addEndpoint and updateEndpoint produce displayLabel-derived labels.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import { endpointStore, buildDefaultEndpoints } from '../../../src/lib/stores/endpoints';
+
+beforeEach(() => {
+  endpointStore.setEndpoints([]);
+});
+
+describe('addEndpoint label derivation', () => {
+  it('label for user-added URL is hostname, not raw URL', () => {
+    const id = endpointStore.addEndpoint('https://api.example.com/v1');
+    const ep = get(endpointStore).find(e => e.id === id);
+    expect(ep!.label).toBe('api.example.com');
+    expect(ep!.label).not.toContain('https://');
+  });
+
+  it('label for Google URL is the brand label', () => {
+    const id = endpointStore.addEndpoint('https://www.google.com');
+    const ep = get(endpointStore).find(e => e.id === id);
+    expect(ep!.label).toBe('Google');
+  });
+
+  it('explicit label param still overrides (for hydrateEndpoint backward compat)', () => {
+    const id = endpointStore.addEndpoint('https://api.example.com', 'My label');
+    const ep = get(endpointStore).find(e => e.id === id);
+    expect(ep!.label).toBe('My label');
+  });
+
+  it('buildDefaultEndpoints: all labels are non-URL strings', () => {
+    const eps = buildDefaultEndpoints();
+    for (const ep of eps) {
+      expect(ep.label).not.toContain('https://');
+      expect(ep.label).not.toContain('http://');
+    }
+  });
+});
+
+describe('updateEndpoint label recompute', () => {
+  it('changing url recomputes label via displayLabel', () => {
+    const id = endpointStore.addEndpoint('https://api.example.com');
+    endpointStore.updateEndpoint(id, { url: 'https://www.google.com' });
+    const ep = get(endpointStore).find(e => e.id === id);
+    expect(ep!.label).toBe('Google');
+  });
+
+  it('setting nickname recomputes label to nickname value', () => {
+    const id = endpointStore.addEndpoint('https://api.example.com');
+    endpointStore.updateEndpoint(id, { nickname: 'My API' });
+    const ep = get(endpointStore).find(e => e.id === id);
+    expect(ep!.label).toBe('My API');
+  });
+
+  it('clearing nickname falls back to brandFor or hostname', () => {
+    // Add with explicit label matching Google brand; then set nickname, then clear it
+    const id = endpointStore.addEndpoint('https://www.google.com');
+    endpointStore.updateEndpoint(id, { nickname: 'My nickname' });
+    endpointStore.updateEndpoint(id, { nickname: undefined });
+    const ep = get(endpointStore).find(e => e.id === id);
+    expect(ep!.label).toBe('Google');
+  });
+});

--- a/tests/unit/types.test.ts
+++ b/tests/unit/types.test.ts
@@ -126,6 +126,31 @@ describe('types', () => {
   });
 });
 
+describe('types — Endpoint.nickname', () => {
+  it('Endpoint type accepts optional nickname field', () => {
+    const ep: Endpoint = {
+      id: 'ep-1',
+      url: 'https://example.com',
+      enabled: true,
+      label: 'example.com',
+      color: '#fff',
+      nickname: 'My API',
+    };
+    expect(ep.nickname).toBe('My API');
+  });
+
+  it('Endpoint type allows nickname to be undefined', () => {
+    const ep: Endpoint = {
+      id: 'ep-1',
+      url: 'https://example.com',
+      enabled: true,
+      label: 'example.com',
+      color: '#fff',
+    };
+    expect(ep.nickname).toBeUndefined();
+  });
+});
+
 describe('types — timingFallback additions', () => {
   it('WorkerToMainMessage result variant accepts timingFallback: boolean', () => {
     const msg: WorkerToMainMessage = {

--- a/tests/unit/utils/apply-persisted-settings.test.ts
+++ b/tests/unit/utils/apply-persisted-settings.test.ts
@@ -56,7 +56,8 @@ describe('applyPersistedSettings — G6 label hydration via brandFor', () => {
 
     const eps = get(endpointStore);
     expect(eps).toHaveLength(1);
-    expect(eps[0]?.label).toBe('https://unknown-domain.example.com');
+    // displayLabel now returns the hostname for unknown domains (not the raw URL)
+    expect(eps[0]?.label).toBe('unknown-domain.example.com');
   });
 
   it('should trim surrounding whitespace from url AND still derive brand label', () => {

--- a/tests/visual/overview-no-raw-url.spec.ts
+++ b/tests/visual/overview-no-raw-url.spec.ts
@@ -1,0 +1,183 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// AC5 — fail-closed sweep: no raw URL string appears as the textContent of
+// a primary-identifier element on Overview, Live, or Diagnose views.
+//
+// "Primary identifier" means the name/label slot for an endpoint — the element
+// the user scans to identify which endpoint is being described.  Subtitle
+// elements that intentionally display URLs (`.rail-row-url`, `.diagnose-title-url`)
+// are excluded.
+//
+// Class mapping (verified against component source 2026-04-25):
+//   EndpointRail   →  .rail-row-label       (primary)  /  .rail-row-url      (subtitle — excluded)
+//   DiagnoseView   →  .diagnose-title-name  (primary)  /  .diagnose-title-url (subtitle — excluded)
+//   EventFeed      →  .feed-name            (primary)  — no URL subtitle element
+//
+// The sentinel test injects a synthetic .rail-row-label with a raw URL into
+// the live DOM and asserts the sweep catches it, proving fail-closed behaviour.
+
+const VIEWPORTS = [
+  { name: 'desktop', width: 1366, height: 768 },
+  { name: 'mobile',  width: 375,  height: 812 },
+] as const;
+
+// Selectors for primary identifier elements.  Subtitle / secondary elements
+// that intentionally carry URLs are NOT listed here.
+const PRIMARY_SELECTORS = [
+  '.rail-row-label',
+  '.diagnose-title-name',
+  '.feed-name',
+] as const;
+
+// Patterns that unambiguously identify a raw URL string.
+const URL_PATTERNS = [
+  /^https?:\/\//i,
+  /^\/\//,
+  /^www\./i,
+];
+
+function looksLikeUrl(text: string): boolean {
+  return URL_PATTERNS.some((re) => re.test(text.trim()));
+}
+
+interface RawUrlLeak {
+  readonly selector: string;
+  readonly text: string;
+}
+
+/**
+ * Walk every visible primary-identifier element in the page and return any
+ * whose textContent looks like a raw URL.
+ */
+const findRawUrlLeaks = async (page: Page): Promise<readonly RawUrlLeak[]> => {
+  return await page.evaluate(
+    ({ selectors, urlPatternStrings }: { selectors: readonly string[]; urlPatternStrings: readonly string[] }) => {
+      const patterns = urlPatternStrings.map((s) => new RegExp(s, 'i'));
+
+      function looksLikeUrl(text: string): boolean {
+        return patterns.some((re) => re.test(text.trim()));
+      }
+
+      const leaks: RawUrlLeak[] = [];
+      for (const selector of selectors) {
+        const elements = Array.from(document.querySelectorAll<HTMLElement>(selector));
+        for (const el of elements) {
+          // Visibility filter: must have non-zero dimensions and not be display:none.
+          const rect = el.getBoundingClientRect();
+          const cs = getComputedStyle(el);
+          const visible =
+            rect.width > 0 &&
+            rect.height > 0 &&
+            cs.display !== 'none' &&
+            cs.visibility !== 'hidden';
+          if (!visible) continue;
+
+          const text = (el.textContent ?? '').trim();
+          if (looksLikeUrl(text)) {
+            leaks.push({ selector, text });
+          }
+        }
+      }
+      return leaks;
+    },
+    {
+      selectors: PRIMARY_SELECTORS as readonly string[],
+      // Serialise RegExp sources so they cross the evaluate boundary.
+      urlPatternStrings: URL_PATTERNS.map((re) => re.source),
+    },
+  );
+};
+
+// ── Real-view sweeps ──────────────────────────────────────────────────────────
+
+test.describe('AC5 — no raw URL in primary identifiers', () => {
+  for (const vp of VIEWPORTS) {
+    test.describe(`@ ${vp.name} (${vp.width}×${vp.height})`, () => {
+      test('Overview view', async ({ page }) => {
+        await page.setViewportSize({ width: vp.width, height: vp.height });
+        await page.goto('/');
+        await page.waitForSelector('#chronoscope-root');
+        await page.waitForTimeout(400);
+
+        const leaks = await findRawUrlLeaks(page);
+        expect(
+          leaks,
+          `Raw URL(s) found in primary identifier elements on Overview: ${JSON.stringify(leaks)}`,
+        ).toEqual([]);
+      });
+
+      test('Live view', async ({ page }) => {
+        await page.setViewportSize({ width: vp.width, height: vp.height });
+        await page.goto('/');
+        await page.waitForSelector('#chronoscope-root');
+        await page.waitForTimeout(400);
+
+        // Navigate to the Live view via the nav tab.
+        const liveTab = page.getByRole('tab', { name: /live/i });
+        const liveTabExists = await liveTab.count();
+        if (liveTabExists > 0) {
+          await liveTab.click();
+          await page.waitForTimeout(300);
+        }
+
+        const leaks = await findRawUrlLeaks(page);
+        expect(
+          leaks,
+          `Raw URL(s) found in primary identifier elements on Live: ${JSON.stringify(leaks)}`,
+        ).toEqual([]);
+      });
+
+      test('Diagnose view', async ({ page }) => {
+        await page.setViewportSize({ width: vp.width, height: vp.height });
+        await page.goto('/');
+        await page.waitForSelector('#chronoscope-root');
+        await page.waitForTimeout(400);
+
+        // Navigate to Diagnose via the nav tab.
+        const diagnoseTab = page.getByRole('tab', { name: /diagnose/i });
+        const diagnoseTabExists = await diagnoseTab.count();
+        if (diagnoseTabExists > 0) {
+          await diagnoseTab.click();
+          await page.waitForTimeout(300);
+        }
+
+        const leaks = await findRawUrlLeaks(page);
+        expect(
+          leaks,
+          `Raw URL(s) found in primary identifier elements on Diagnose: ${JSON.stringify(leaks)}`,
+        ).toEqual([]);
+      });
+    });
+  }
+});
+
+// ── Sentinel test — fail-closed verification ──────────────────────────────────
+//
+// Injects a synthetic .rail-row-label element containing a raw URL into the
+// live DOM, then asserts the sweep detects it.  If the sweep returns empty here,
+// the detection logic is broken and would silently miss real regressions.
+
+test.describe('AC5 sentinel — sweep is fail-closed', () => {
+  test('detects injected raw URL in .rail-row-label', async ({ page }) => {
+    await page.setViewportSize({ width: 1366, height: 768 });
+    await page.goto('/');
+    await page.waitForSelector('#chronoscope-root');
+    await page.waitForTimeout(400);
+
+    // Inject a visible span with the primary-identifier class and a raw URL.
+    await page.evaluate(() => {
+      const sentinel = document.createElement('span');
+      sentinel.className = 'rail-row-label';
+      sentinel.textContent = 'https://sentinel.example.com/test';
+      sentinel.style.cssText = 'display:inline-block;width:200px;height:20px;position:fixed;top:10px;left:10px;z-index:9999;visibility:visible';
+      document.body.appendChild(sentinel);
+    });
+
+    const leaks = await findRawUrlLeaks(page);
+    expect(
+      leaks.length,
+      'Sentinel: sweep must detect the injected raw URL — if this fails the sweep logic is broken',
+    ).toBeGreaterThan(0);
+    expect(leaks[0]?.text).toMatch(/^https:\/\/sentinel\.example\.com/);
+  });
+});

--- a/tests/visual/overview-no-raw-url.spec.ts
+++ b/tests/visual/overview-no-raw-url.spec.ts
@@ -15,6 +15,8 @@ import { test, expect, type Page } from '@playwright/test';
 //
 // The sentinel test injects a synthetic .rail-row-label with a raw URL into
 // the live DOM and asserts the sweep catches it, proving fail-closed behaviour.
+//
+// Coverage gap: ConfigStagingBanner is reachable only via a staged share URL and is excluded from this Playwright sweep — its `.endpoint-url` subtitle is the only URL surface it renders, and that's a permitted exception per AC5.
 
 const VIEWPORTS = [
   { name: 'desktop', width: 1366, height: 768 },
@@ -30,15 +32,12 @@ const PRIMARY_SELECTORS = [
 ] as const;
 
 // Patterns that unambiguously identify a raw URL string.
+// Serialised as RegExp sources so they can cross the page.evaluate() boundary.
 const URL_PATTERNS = [
   /^https?:\/\//i,
   /^\/\//,
   /^www\./i,
 ];
-
-function looksLikeUrl(text: string): boolean {
-  return URL_PATTERNS.some((re) => re.test(text.trim()));
-}
 
 interface RawUrlLeak {
   readonly selector: string;
@@ -69,7 +68,8 @@ const findRawUrlLeaks = async (page: Page): Promise<readonly RawUrlLeak[]> => {
             rect.width > 0 &&
             rect.height > 0 &&
             cs.display !== 'none' &&
-            cs.visibility !== 'hidden';
+            cs.visibility !== 'hidden' &&
+            cs.opacity !== '0';
           if (!visible) continue;
 
           const text = (el.textContent ?? '').trim();
@@ -112,13 +112,12 @@ test.describe('AC5 — no raw URL in primary identifiers', () => {
         await page.waitForSelector('#chronoscope-root');
         await page.waitForTimeout(400);
 
-        // Navigate to the Live view via the nav tab.
-        const liveTab = page.getByRole('tab', { name: /live/i });
-        const liveTabExists = await liveTab.count();
-        if (liveTabExists > 0) {
-          await liveTab.click();
-          await page.waitForTimeout(300);
-        }
+        // Navigate to the Live view via the ViewSwitcher button.
+        // Anchored regex avoids matching aria-labels like "Diagnose endpoint X…"
+        // on CausalVerdictStrip drill buttons.
+        await page.getByRole('button', { name: /^Live/ }).click();
+        // Assert the Live view section is mounted before sweeping.
+        await page.waitForSelector('section[aria-label="Live latency trace"]');
 
         const leaks = await findRawUrlLeaks(page);
         expect(
@@ -133,13 +132,12 @@ test.describe('AC5 — no raw URL in primary identifiers', () => {
         await page.waitForSelector('#chronoscope-root');
         await page.waitForTimeout(400);
 
-        // Navigate to Diagnose via the nav tab.
-        const diagnoseTab = page.getByRole('tab', { name: /diagnose/i });
-        const diagnoseTabExists = await diagnoseTab.count();
-        if (diagnoseTabExists > 0) {
-          await diagnoseTab.click();
-          await page.waitForTimeout(300);
-        }
+        // Navigate to the Diagnose view via the ViewSwitcher button.
+        // Anchored regex avoids matching aria-labels like "Diagnose endpoint X…"
+        // on CausalVerdictStrip drill buttons.
+        await page.getByRole('button', { name: /^Diagnose/ }).click();
+        // Assert the Diagnose view section is mounted before sweeping.
+        await page.waitForSelector('section[aria-label="Diagnose"]');
 
         const leaks = await findRawUrlLeaks(page);
         expect(
@@ -178,6 +176,6 @@ test.describe('AC5 sentinel — sweep is fail-closed', () => {
       leaks.length,
       'Sentinel: sweep must detect the injected raw URL — if this fails the sweep logic is broken',
     ).toBeGreaterThan(0);
-    expect(leaks[0]?.text).toMatch(/^https:\/\/sentinel\.example\.com/);
+    expect(leaks.some(l => l.text.includes('sentinel.example.com'))).toBe(true);
   });
 });

--- a/tests/visual/overview-no-raw-url.spec.ts
+++ b/tests/visual/overview-no-raw-url.spec.ts
@@ -97,7 +97,8 @@ test.describe('AC5 — no raw URL in primary identifiers', () => {
         await page.setViewportSize({ width: vp.width, height: vp.height });
         await page.goto('/');
         await page.waitForSelector('#chronoscope-root');
-        await page.waitForTimeout(400);
+        // Deterministic wait: sweep runs only after primary-identifier content mounts.
+        await page.waitForSelector('.rail-row-label, .feed-name', { state: 'attached' });
 
         const leaks = await findRawUrlLeaks(page);
         expect(
@@ -110,7 +111,8 @@ test.describe('AC5 — no raw URL in primary identifiers', () => {
         await page.setViewportSize({ width: vp.width, height: vp.height });
         await page.goto('/');
         await page.waitForSelector('#chronoscope-root');
-        await page.waitForTimeout(400);
+        // Deterministic wait: sweep runs only after primary-identifier content mounts.
+        await page.waitForSelector('.rail-row-label, .feed-name', { state: 'attached' });
 
         // Navigate to the Live view via the ViewSwitcher button.
         // Anchored regex avoids matching aria-labels like "Diagnose endpoint X…"
@@ -130,7 +132,8 @@ test.describe('AC5 — no raw URL in primary identifiers', () => {
         await page.setViewportSize({ width: vp.width, height: vp.height });
         await page.goto('/');
         await page.waitForSelector('#chronoscope-root');
-        await page.waitForTimeout(400);
+        // Deterministic wait: sweep runs only after primary-identifier content mounts.
+        await page.waitForSelector('.rail-row-label, .feed-name', { state: 'attached' });
 
         // Navigate to the Diagnose view via the ViewSwitcher button.
         // Anchored regex avoids matching aria-labels like "Diagnose endpoint X…"
@@ -176,6 +179,8 @@ test.describe('AC5 sentinel — sweep is fail-closed', () => {
       leaks.length,
       'Sentinel: sweep must detect the injected raw URL — if this fails the sweep logic is broken',
     ).toBeGreaterThan(0);
-    expect(leaks.some(l => l.text.includes('sentinel.example.com'))).toBe(true);
+    // Exact-equality match (not substring) — sentinel content is fully test-controlled.
+    // Avoids CodeQL "incomplete URL substring sanitization" false positive without suppression.
+    expect(leaks.some(l => l.text === 'https://sentinel.example.com/test')).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

The endpoint rail and drawer truncated URLs to ~12 characters of usable text (`https://www.g`…), making endpoints visually indistinguishable. Friend testing on 2026-04-13 surfaced the failure. URL was the wrong primary identifier in a 264-px list.

## What ships

**3-tier identity hierarchy** (`displayLabel`: nickname → brandFor → hostname). No more truncated URLs as primary identity; URL becomes optional secondary metadata.

- **AC1** — Identity hierarchy at every render site (rail, drawer, ConfigStagingBanner, DiagnoseView). Uses curated brand labels for the 6 default endpoints; bare hostname for user-added URLs (with `https://` and `www.` stripped).
- **AC2** — Inline edit affordance: hover-pencil button (44×44, WCAG 2.5.5) reveals URL + nickname inputs. Enter saves both, Esc cancels. Touch-revealed on `(hover: none)`. Invalid nickname surfaces `aria-invalid="true"` + `role="alert"` inline error.
- **AC3** — v10 → v11 persistence migration (additive; permanent `version: 10 | 11` union). Nickname validated at load via `isValidNickname` (control / bidi-override / zero-width / line-paragraph-separator rejection). Bad nicknames stripped, endpoint preserved.
- **AC4** — `validateSharePayload` schema-level unknown-key rejection (top-level allowlist `{v, mode, endpoints, settings, results}` + per-entry allowlist `{url, enabled}`). Hybrid Bet (share-side) codified: nicknames stay local, share boundary rejects them schema-level. PR #81 invariants preserved.
- **AC5** — Playwright fail-closed sweep on Overview / Live / Diagnose primary identifiers (`.rail-row-label`, `.diagnose-title-name`, `.feed-name`). textContent-only. Sentinel injection test verifies fail-closed.

## Test deltas

- 608 → **690 Vitest tests** (+82 net; far exceeding +20 spec floor).
- New: 14 Playwright AC5 tests (chromium + mobile-chrome × 6 view-viewport combos + sentinel).
- Updated 5 existing assertions to reflect derived labels:
  - `apply-persisted-settings.test.ts:59` — unknown domain label is `unknown-domain.example.com` (not `https://unknown-domain.example.com`)
  - `EndpointPanel.test.ts:~36` — placeholder URL `https://` produces label `(invalid URL)` (not the literal `https://`)
  - `persistence.test.ts` — round-trip + 3 version assertions reflect v10 → v11 migration

## Bundle delta

198.11 kB raw / 61.86 kB gzip — under the 200/60 kB ceiling. +3.6 kB raw / +0.99 kB gzip vs main (helper module + edit affordance UI). Within practical wire-impact budget; over the +1 kB raw soft floor — acknowledged by Final Reviewer.

## Process

8 tasks across 4 phases via subagent-driven-development. Each task gated by spec compliance + stack-aware code review. Round-2 caught a silent-skip bug in the AC5 sweep (`getByRole('tab')` against `<button>` elements) and fixed before merge. Final cross-cutting review approved with 5 non-blocking advisories documented in phase artifacts.

Spec: `docs/superpowers/specs/2026-04-25-endpoint-identity-design.md`
Plan: `docs/plans/2026-04-25-endpoint-identity-plan.md`
Phase artifacts: `docs/superpowers/progress/2026-04-25-endpoint-identity-phase{A,B,C,D}.md`
Retrospective: `docs/superpowers/retrospectives/2026-04-25-endpoint-identity-retro.md`

## Test plan

- [ ] Verify rail and drawer show derived labels (Google, AWS, hostname for user-added URLs)
- [ ] Click pencil on a rail/drawer row, set a nickname, save → label updates everywhere
- [ ] Reload → nickname persists
- [ ] Try invalid nickname (paste `‮` or 81 chars) → aria-invalid + inline error, save blocked
- [ ] Generate a share link with nicknames → receiver sees derived labels (nicknames dropped at boundary)
- [ ] Try a malicious share URL with `nickname` injected per-entry → ConfigStagingBanner does not appear (validator rejects)
- [ ] Mobile drawer: pencil is always visible (no hover required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Endpoints now display human-readable labels (hostnames or custom nicknames) instead of raw URLs
  * Added ability to edit endpoint URLs and nicknames with inline validation
  * Support for optional custom nicknames to identify endpoints

* **Improvements**
  * Enhanced endpoint list display with clearer label presentation
  * Stricter share payload validation to prevent unknown fields

* **Tests**
  * Comprehensive test coverage for endpoint editing, labeling, and persistence features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->