### PR TITLE
fix(endpoint-row): stack edit form vertically; add explicit Save/Cancel

### DIFF
--- a/src/lib/components/EndpointRow.svelte
+++ b/src/lib/components/EndpointRow.svelte
@@ -2,6 +2,7 @@
 <!-- Single endpoint row: URL input, color dot, enable toggle, remove button,  -->
 <!-- and inline latency display.                                                 -->
 <script lang="ts">
+  import { tick } from 'svelte';
   import { tokens } from '$lib/tokens';
   import { latencyToColor } from '$lib/renderers/color-map';
   import { isValidNickname } from '$lib/endpoint/displayLabel';
@@ -62,14 +63,23 @@
   let editNickname = $state('');
   let nicknameInvalid = $state(false);
 
-  function handleEditStart(): void {
+  // Element refs for focus management. Without these, activating the pencil
+  // unmounts .edit-btn in the same tick as .url-input mounts, leaving keyboard
+  // and screen-reader users on <body> (WCAG 2.4.3 violation).
+  let urlInputEl: HTMLInputElement | null = $state(null);
+  let editBtnEl: HTMLButtonElement | null = $state(null);
+
+  async function handleEditStart(): Promise<void> {
     editUrl = endpoint.url;
     editNickname = endpoint.nickname ?? '';
     nicknameInvalid = false;
     isEditing = true;
+    // Wait for the form to mount, then focus the URL input.
+    await tick();
+    urlInputEl?.focus();
   }
 
-  function handleEditSave(): void {
+  async function handleEditSave(): Promise<void> {
     const trimmedNick = editNickname.trim();
     if (trimmedNick !== '' && !isValidNickname(trimmedNick)) {
       nicknameInvalid = true;
@@ -79,11 +89,16 @@
     const nickToSave: string | undefined = trimmedNick === '' ? undefined : trimmedNick;
     onUpdate?.(endpoint.id, { url: editUrl, nickname: nickToSave });
     isEditing = false;
+    // Wait for read-mode to remount, then return focus to the pencil.
+    await tick();
+    editBtnEl?.focus();
   }
 
-  function handleEditCancel(): void {
+  async function handleEditCancel(): Promise<void> {
     nicknameInvalid = false;
     isEditing = false;
+    await tick();
+    editBtnEl?.focus();
   }
 
   function handleNicknameKeydown(e: KeyboardEvent): void {
@@ -128,6 +143,34 @@
   style:--timing-btn="{tokens.timing.btnHover}ms"
   style:opacity={endpoint.enabled ? 1 : 0.5}
 >
+  {#snippet toggleAndRemove()}
+    <label
+      class="toggle-label"
+      aria-label="{endpoint.enabled ? 'Disable' : 'Enable'} this endpoint"
+      title={isLastEnabled ? 'At least one endpoint must be enabled' : ''}
+    >
+      <input
+        type="checkbox"
+        class="toggle-input"
+        checked={endpoint.enabled}
+        disabled={isRunning || isLastEnabled}
+        onchange={handleToggle}
+      />
+      <span class="toggle-track" aria-hidden="true"></span>
+    </label>
+    {#if !isLast}
+      <button
+        type="button"
+        class="remove-btn"
+        aria-label="Remove endpoint {endpoint.label}"
+        disabled={isRunning}
+        onclick={handleRemove}
+      >
+        ✕
+      </button>
+    {/if}
+  {/snippet}
+
   {#if isEditing}
     <!-- Edit mode: row expands vertically into a stacked form. -->
     <!-- The cramped "two inputs in a flex row" pattern doesn't fit narrow viewports;
@@ -138,6 +181,7 @@
         <input
           type="url"
           class="url-input"
+          bind:this={urlInputEl}
           bind:value={editUrl}
           placeholder="https://example.com"
           aria-label="Endpoint URL"
@@ -163,31 +207,7 @@
         <button type="button" class="btn-secondary" onclick={handleEditCancel}>Cancel</button>
         <button type="button" class="btn-primary" onclick={handleEditSave}>Save</button>
         <span class="actions-spacer"></span>
-        <label
-          class="toggle-label"
-          aria-label="{endpoint.enabled ? 'Disable' : 'Enable'} this endpoint"
-          title={isLastEnabled ? 'At least one endpoint must be enabled' : ''}
-        >
-          <input
-            type="checkbox"
-            class="toggle-input"
-            checked={endpoint.enabled}
-            disabled={isRunning || isLastEnabled}
-            onchange={handleToggle}
-          />
-          <span class="toggle-track" aria-hidden="true"></span>
-        </label>
-        {#if !isLast}
-          <button
-            type="button"
-            class="remove-btn"
-            aria-label="Remove endpoint {endpoint.label}"
-            disabled={isRunning}
-            onclick={handleRemove}
-          >
-            ✕
-          </button>
-        {/if}
+        {@render toggleAndRemove()}
       </div>
     </div>
   {:else}
@@ -214,6 +234,7 @@
       <button
         type="button"
         class="edit-btn"
+        bind:this={editBtnEl}
         aria-label="Edit {endpoint.label}"
         onclick={handleEditStart}
       >
@@ -242,37 +263,17 @@
       </button>
     {/if}
 
-    <label
-      class="toggle-label"
-      aria-label="{endpoint.enabled ? 'Disable' : 'Enable'} this endpoint"
-      title={isLastEnabled ? 'At least one endpoint must be enabled' : ''}
-    >
-      <input
-        type="checkbox"
-        class="toggle-input"
-        checked={endpoint.enabled}
-        disabled={isRunning || isLastEnabled}
-        onchange={handleToggle}
-      />
-      <span class="toggle-track" aria-hidden="true"></span>
-    </label>
-
-    {#if !isLast}
-      <button
-        type="button"
-        class="remove-btn"
-        aria-label="Remove endpoint {endpoint.label}"
-        disabled={isRunning}
-        onclick={handleRemove}
-      >
-        ✕
-      </button>
-    {/if}
+    {@render toggleAndRemove()}
   {/if}
 </div>
 
 <style>
   .endpoint-row {
+    /* Single source for the color-dot diameter — used by .dot and by
+       .edit-actions's left padding so the action bar stays aligned with the
+       input column without drift if the dot ever resizes. */
+    --dot-size: 10px;
+
     display: flex;
     align-items: center;
     gap: var(--spacing-sm);
@@ -310,8 +311,8 @@
   /* ── Color dot ───────────────────────────────────────────────────────────── */
   .dot {
     flex-shrink: 0;
-    width: 10px;
-    height: 10px;
+    width: var(--dot-size);
+    height: var(--dot-size);
     border-radius: 50%;
     background: var(--dot-color);
     box-shadow: 0 0 8px var(--dot-color); /* fallback for browsers without color-mix() */
@@ -396,7 +397,7 @@
     gap: var(--spacing-sm);
     /* Sit just inside the dot's column so the action bar visually nests under
        the input column rather than the dot. */
-    padding-left: calc(10px + var(--spacing-sm));
+    padding-left: calc(var(--dot-size) + var(--spacing-sm));
   }
 
   .actions-spacer { flex: 1; }

--- a/src/lib/components/EndpointRow.svelte
+++ b/src/lib/components/EndpointRow.svelte
@@ -128,118 +128,146 @@
   style:--timing-btn="{tokens.timing.btnHover}ms"
   style:opacity={endpoint.enabled ? 1 : 0.5}
 >
-  <!-- Color dot (pulses when running + enabled) -->
-  <span
-    class="dot"
-    class:pulse={isRunning && endpoint.enabled}
-    aria-hidden="true"
-  ></span>
-
-  <!-- Identity: label as primary in read mode; URL input revealed in edit mode -->
   {#if isEditing}
-    <input
-      type="url"
-      class="url-input"
-      bind:value={editUrl}
-      placeholder="https://example.com"
-      aria-label="Endpoint URL"
-      onkeydown={handleUrlKeydown}
-    />
-  {:else}
-    <span class="row-label" title={endpoint.url}>{endpoint.label}</span>
-  {/if}
-
-  <!-- Nickname input (edit mode only) -->
-  {#if isEditing}
-    <div class="edit-fields">
-      <input
-        type="text"
-        class="nickname-input"
-        bind:value={editNickname}
-        placeholder="Optional nickname"
-        aria-label="Endpoint nickname"
-        aria-invalid={nicknameInvalid ? 'true' : 'false'}
-        onkeydown={handleNicknameKeydown}
-        oninput={() => { if (nicknameInvalid) nicknameInvalid = false; }}
-      />
+    <!-- Edit mode: row expands vertically into a stacked form. -->
+    <!-- The cramped "two inputs in a flex row" pattern doesn't fit narrow viewports;
+         stacking gives each input full width regardless of viewport size. -->
+    <div class="edit-form">
+      <div class="edit-form-line">
+        <span class="dot" aria-hidden="true"></span>
+        <input
+          type="url"
+          class="url-input"
+          bind:value={editUrl}
+          placeholder="https://example.com"
+          aria-label="Endpoint URL"
+          onkeydown={handleUrlKeydown}
+        />
+      </div>
+      <div class="edit-form-line">
+        <input
+          type="text"
+          class="nickname-input"
+          bind:value={editNickname}
+          placeholder="Optional nickname"
+          aria-label="Endpoint nickname"
+          aria-invalid={nicknameInvalid ? 'true' : 'false'}
+          onkeydown={handleNicknameKeydown}
+          oninput={() => { if (nicknameInvalid) nicknameInvalid = false; }}
+        />
+      </div>
       {#if nicknameInvalid}
         <span class="nickname-error" role="alert">Invalid nickname (max 80 chars, no control/zero-width/bidi)</span>
       {/if}
+      <div class="edit-actions">
+        <button type="button" class="btn-secondary" onclick={handleEditCancel}>Cancel</button>
+        <button type="button" class="btn-primary" onclick={handleEditSave}>Save</button>
+        <span class="actions-spacer"></span>
+        <label
+          class="toggle-label"
+          aria-label="{endpoint.enabled ? 'Disable' : 'Enable'} this endpoint"
+          title={isLastEnabled ? 'At least one endpoint must be enabled' : ''}
+        >
+          <input
+            type="checkbox"
+            class="toggle-input"
+            checked={endpoint.enabled}
+            disabled={isRunning || isLastEnabled}
+            onchange={handleToggle}
+          />
+          <span class="toggle-track" aria-hidden="true"></span>
+        </label>
+        {#if !isLast}
+          <button
+            type="button"
+            class="remove-btn"
+            aria-label="Remove endpoint {endpoint.label}"
+            disabled={isRunning}
+            onclick={handleRemove}
+          >
+            ✕
+          </button>
+        {/if}
+      </div>
     </div>
-  {/if}
-
-  <!-- Latency text -->
-  {#if latencyText && !isEditing}
+  {:else}
+    <!-- Read mode: single horizontal line (dot · label · pencil · toggle · remove). -->
     <span
-      class="latency-text"
-      style:color={latencyColor}
-      aria-label="Last measurement: {latencyText}"
-    >
-      {latencyText}
-    </span>
-  {/if}
+      class="dot"
+      class:pulse={isRunning && endpoint.enabled}
+      aria-hidden="true"
+    ></span>
 
-  <!-- Pencil / edit button (hidden while running) -->
-  {#if !isRunning}
-    <button
-      type="button"
-      class="edit-btn"
-      class:active={isEditing}
-      aria-label="{isEditing ? 'Cancel editing' : 'Edit'} {endpoint.label}"
-      onclick={isEditing ? handleEditCancel : handleEditStart}
-    >
-      <svg
-        width="14"
-        height="14"
-        viewBox="0 0 14 14"
-        fill="none"
-        aria-hidden="true"
-        focusable="false"
+    <span class="row-label" title={endpoint.url}>{endpoint.label}</span>
+
+    {#if latencyText}
+      <span
+        class="latency-text"
+        style:color={latencyColor}
+        aria-label="Last measurement: {latencyText}"
       >
-        <path
-          d="M9.5 1.5L12.5 4.5L4.5 12.5H1.5V9.5L9.5 1.5Z"
-          stroke="currentColor"
-          stroke-width="1.25"
-          stroke-linejoin="round"
+        {latencyText}
+      </span>
+    {/if}
+
+    {#if !isRunning}
+      <button
+        type="button"
+        class="edit-btn"
+        aria-label="Edit {endpoint.label}"
+        onclick={handleEditStart}
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 14 14"
           fill="none"
-        />
-        <path
-          d="M7.5 3.5L10.5 6.5"
-          stroke="currentColor"
-          stroke-width="1.25"
-          stroke-linecap="round"
-        />
-      </svg>
-    </button>
-  {/if}
+          aria-hidden="true"
+          focusable="false"
+        >
+          <path
+            d="M9.5 1.5L12.5 4.5L4.5 12.5H1.5V9.5L9.5 1.5Z"
+            stroke="currentColor"
+            stroke-width="1.25"
+            stroke-linejoin="round"
+            fill="none"
+          />
+          <path
+            d="M7.5 3.5L10.5 6.5"
+            stroke="currentColor"
+            stroke-width="1.25"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+    {/if}
 
-  <!-- Enable/disable toggle -->
-  <label
-    class="toggle-label"
-    aria-label="{endpoint.enabled ? 'Disable' : 'Enable'} this endpoint"
-    title={isLastEnabled ? 'At least one endpoint must be enabled' : ''}
-  >
-    <input
-      type="checkbox"
-      class="toggle-input"
-      checked={endpoint.enabled}
-      disabled={isRunning || isLastEnabled}
-      onchange={handleToggle}
-    />
-    <span class="toggle-track" aria-hidden="true"></span>
-  </label>
-
-  <!-- Remove button -->
-  {#if !isLast}
-    <button
-      type="button"
-      class="remove-btn"
-      aria-label="Remove endpoint {endpoint.label}"
-      disabled={isRunning}
-      onclick={handleRemove}
+    <label
+      class="toggle-label"
+      aria-label="{endpoint.enabled ? 'Disable' : 'Enable'} this endpoint"
+      title={isLastEnabled ? 'At least one endpoint must be enabled' : ''}
     >
-      ✕
-    </button>
+      <input
+        type="checkbox"
+        class="toggle-input"
+        checked={endpoint.enabled}
+        disabled={isRunning || isLastEnabled}
+        onchange={handleToggle}
+      />
+      <span class="toggle-track" aria-hidden="true"></span>
+    </label>
+
+    {#if !isLast}
+      <button
+        type="button"
+        class="remove-btn"
+        aria-label="Remove endpoint {endpoint.label}"
+        disabled={isRunning}
+        onclick={handleRemove}
+      >
+        ✕
+      </button>
+    {/if}
   {/if}
 </div>
 
@@ -251,6 +279,14 @@
     padding: var(--spacing-md);
     min-height: 44px; /* WCAG touch target */
     position: relative;
+  }
+
+  /* Edit mode: container becomes a vertical stack so .edit-form's columns
+     can flow naturally. The two-input flex-row layout was unusable at narrow
+     viewports — even Google's URL would collapse to one character. */
+  .endpoint-row:has(.edit-form) {
+    align-items: stretch;
+    flex-direction: column;
   }
 
   /* Gradient separator between rows */
@@ -330,19 +366,74 @@
     white-space: nowrap;
   }
 
-  /* ── Edit fields (nickname row) ──────────────────────────────────────────── */
-  .edit-fields {
+  /* ── Edit form (vertical stack inside .endpoint-row when isEditing) ──────── */
+  .edit-form {
     display: flex;
     flex-direction: column;
-    gap: 2px;
-    flex-shrink: 0;
-    min-width: 0;
+    gap: var(--spacing-sm);
+    width: 100%;
+  }
+
+  .edit-form-line {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+  }
+
+  /* Within the form, URL input and nickname input both expand full-width.
+     Override the read-mode .url-input flex:1 inheritance; the form-line is
+     already a flex container. */
+  .edit-form .url-input,
+  .edit-form .nickname-input {
+    flex: 1;
+    width: 100%;
+  }
+
+  /* Action bar — Cancel/Save on the left, toggle/remove on the right. */
+  .edit-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    /* Sit just inside the dot's column so the action bar visually nests under
+       the input column rather than the dot. */
+    padding-left: calc(10px + var(--spacing-sm));
+  }
+
+  .actions-spacer { flex: 1; }
+
+  .btn-primary,
+  .btn-secondary {
+    min-height: 32px;
+    padding: 0 var(--spacing-md);
+    border-radius: var(--btn-radius);
+    border: 1px solid transparent;
+    font-family: var(--sans);
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background var(--timing-btn) ease, border-color var(--timing-btn) ease;
+  }
+  .btn-primary {
+    background: color-mix(in srgb, var(--accent-cyan) 18%, transparent);
+    color: var(--accent-cyan);
+    border-color: color-mix(in srgb, var(--accent-cyan) 35%, transparent);
+  }
+  .btn-primary:hover {
+    background: color-mix(in srgb, var(--accent-cyan) 28%, transparent);
+  }
+  .btn-secondary {
+    background: transparent;
+    color: var(--t2);
+    border-color: var(--glass-border);
+  }
+  .btn-secondary:hover {
+    color: var(--t1);
+    border-color: var(--glass-highlight);
   }
 
   /* ── Nickname input ──────────────────────────────────────────────────────── */
   .nickname-input {
     min-width: 0;
-    width: 140px;
     background: rgba(0,0,0,.2);
     border: 1px solid var(--glass-border);
     border-radius: var(--btn-radius);
@@ -405,7 +496,6 @@
   }
 
   .endpoint-row:hover .edit-btn,
-  .edit-btn.active,
   .edit-btn:focus-visible {
     opacity: 1;
     visibility: visible;
@@ -414,10 +504,6 @@
   .edit-btn:hover:not(:disabled) {
     background: var(--glass-bg);
     border-color: rgba(103,232,249,.15);
-    color: var(--accent-cyan);
-  }
-
-  .edit-btn.active {
     color: var(--accent-cyan);
   }
 

--- a/tests/unit/components/endpoint-row-edit-affordance.test.ts
+++ b/tests/unit/components/endpoint-row-edit-affordance.test.ts
@@ -131,6 +131,7 @@ describe('EndpointRow — edit affordance (AC2)', () => {
 
     expect(onUpdate).toHaveBeenCalledOnce();
     const [, patch] = onUpdate.mock.calls[0] as [string, { url: string; nickname: string }];
+    expect(patch.url).toBe('https://api.example.com');
     expect(patch.nickname).toBe('Prod API');
   });
 
@@ -143,6 +144,18 @@ describe('EndpointRow — edit affordance (AC2)', () => {
     await fireEvent.click(container.querySelector('.edit-btn') as HTMLButtonElement);
     expect(container.querySelector('.edit-form')).not.toBeNull();
     expect(container.querySelector('.edit-actions')).not.toBeNull();
+  });
+
+  // WCAG 2.4.3: focus must not be lost when the pencil unmounts. Without the
+  // focus-on-mount behavior, keyboard/SR users land on <body> and have to
+  // re-traverse to reach the URL input.
+  it('moves focus into URL input after entering edit mode', async () => {
+    const { container } = renderRow();
+    await fireEvent.click(container.querySelector('.edit-btn') as HTMLButtonElement);
+    // tick() inside the handler resolves on the next microtask
+    await new Promise(r => setTimeout(r, 0));
+    const urlInput = container.querySelector('.url-input') as HTMLInputElement;
+    expect(document.activeElement).toBe(urlInput);
   });
 
   it('invalid nickname (too long) sets aria-invalid', async () => {

--- a/tests/unit/components/endpoint-row-edit-affordance.test.ts
+++ b/tests/unit/components/endpoint-row-edit-affordance.test.ts
@@ -106,6 +106,45 @@ describe('EndpointRow — edit affordance (AC2)', () => {
     expect(container.querySelector('.nickname-input')).toBeNull();
   });
 
+  // Mobile cannot easily reach Esc — explicit Cancel/Save buttons are required
+  // for the edit form to be usable on touch devices.
+  it('Cancel button exits edit mode without calling onUpdate', async () => {
+    const onUpdate = vi.fn();
+    const { container, getByText } = renderRow({}, { onUpdate });
+    await fireEvent.click(container.querySelector('.edit-btn') as HTMLButtonElement);
+
+    await fireEvent.click(getByText('Cancel'));
+
+    expect(onUpdate).not.toHaveBeenCalled();
+    expect(container.querySelector('.nickname-input')).toBeNull();
+  });
+
+  it('Save button calls onUpdate with current url and nickname', async () => {
+    const onUpdate = vi.fn();
+    const { container, getByText } = renderRow({}, { onUpdate });
+    await fireEvent.click(container.querySelector('.edit-btn') as HTMLButtonElement);
+
+    const nickInput = container.querySelector('.nickname-input') as HTMLInputElement;
+    await fireEvent.input(nickInput, { target: { value: 'Prod API' } });
+
+    await fireEvent.click(getByText('Save'));
+
+    expect(onUpdate).toHaveBeenCalledOnce();
+    const [, patch] = onUpdate.mock.calls[0] as [string, { url: string; nickname: string }];
+    expect(patch.nickname).toBe('Prod API');
+  });
+
+  // Edit form layout: inputs stack vertically rather than competing for
+  // horizontal space within a single row. Verifies the .edit-form container
+  // exists when isEditing — that's how the row knows to switch from the
+  // horizontal flex layout to the vertical stack.
+  it('edit mode renders an .edit-form vertical-stack container', async () => {
+    const { container } = renderRow();
+    await fireEvent.click(container.querySelector('.edit-btn') as HTMLButtonElement);
+    expect(container.querySelector('.edit-form')).not.toBeNull();
+    expect(container.querySelector('.edit-actions')).not.toBeNull();
+  });
+
   it('invalid nickname (too long) sets aria-invalid', async () => {
     const onUpdate = vi.fn();
     const { container } = renderRow({}, { onUpdate });


### PR DESCRIPTION
## Problem

PR #82's edit affordance crammed two `<input>`s into the read-mode flex row. On a 393 px-wide phone, the URL input collapsed to **one character wide** (showing just `h` from `https://www.google.com`) — worse than the truncation bug it was meant to fix.

![Before — Google's URL input collapsed to 'h'](https://github.com/user-attachments/assets/placeholder-before)

## Root cause

The original spec said *"reveal URL input + nickname input inline."* I interpreted "inline" as "horizontally, in the existing row flex." That works at 1366 px; it falls apart at 393 px once you account for dot + pencil + toggle + remove eating ~180 px of horizontal budget.

The right interpretation: **"inline within the row's vertical bounds"** — the row should expand vertically when editing, not squeeze more controls onto a single line.

## Fix

In edit mode, `.endpoint-row` switches from horizontal flex to a vertical stack containing `.edit-form`:

```
Read mode (one horizontal line, unchanged):
  ●  Google              ✏️  ⬤  ✕

Edit mode (row expands into 3 stacked lines):
  ●  [ https://www.google.com                        ]
     [ Optional nickname                             ]
     [ Cancel ] [ Save ]                       ⬤  ✕
```

`.edit-form-line` lays out each field in a horizontal flex; the lines themselves stack vertically. Inputs get `flex: 1; width: 100%` so they breathe at any viewport. The action bar packs Cancel/Save on the left, toggle/remove on the right.

Explicit **Save / Cancel** buttons supplement the existing Enter/Esc keyboard shortcuts. Mobile users can't easily reach Esc; Save provides a clear "I'm done" affordance.

## What changed

- `src/lib/components/EndpointRow.svelte` — restructured template into `{#if isEditing} <form> {:else} <row> {/if}` branches with their own layouts, plus CSS for `.edit-form`, `.edit-form-line`, `.edit-actions`, `.btn-primary`, `.btn-secondary`. Read mode markup is unchanged. Removed dead `.edit-btn.active` CSS (Svelte unused-selector warning).
- `tests/unit/components/endpoint-row-edit-affordance.test.ts` — +3 tests:
  - Cancel button exits without calling `onUpdate`
  - Save button calls `onUpdate` with current url + nickname
  - `.edit-form` and `.edit-actions` containers exist in edit mode

## Test plan

- [x] 699 Vitest pass (+3 new)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] Visual verify at 393×752 (iPhone 14 Pro mobile drawer): URL input full-width, nickname full-width, action bar fits
- [x] Visual verify at 1440×900 (desktop drawer-from-right): same vertical stack composition; reads cleanly at desktop widths too
- [ ] Manual touch verification (long-press, swipe-out behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Redesigned endpoint editor interface with a vertically stacked form layout in edit mode, improved button organization with dedicated action controls, and enhanced visibility of latency information and controls in read mode.

* **Tests**
  * Added comprehensive tests covering edit mode interaction, save and cancel button functionality, and form layout validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->