### PR TITLE
feat(diagnose): histogram + cross-endpoint correlation; verdict in plain language

### DIFF
--- a/src/lib/components/DiagnoseView.svelte
+++ b/src/lib/components/DiagnoseView.svelte
@@ -11,6 +11,7 @@
   import { statisticsStore } from '$lib/stores/statistics';
   import { uiStore } from '$lib/stores/ui';
   import { phaseHypothesis, PHASE_LABELS, type PhaseBreakdown, type Tier2Phase } from '$lib/utils/verdict';
+  import { buildHistogram, buildCorrelation } from '$lib/utils/diagnose-stats';
   import { fmt } from '$lib/utils/format';
   import { tokens } from '$lib/tokens';
   import type { MeasurementSample } from '$lib/types';
@@ -92,6 +93,58 @@
     return m.samples.toArray().slice(-8);
   });
 
+  // ── Histogram of focused endpoint's recent latency distribution ───────────
+  // Last 50 samples — long enough to be statistically meaningful, short enough
+  // to reflect "current" behavior rather than the whole session.
+  const focusedAllSamples: readonly MeasurementSample[] = $derived.by(() => {
+    if (!focusedEndpoint) return [];
+    const m = measurements.endpoints[focusedEndpoint.id];
+    if (!m) return [];
+    return m.samples.toArray().slice(-50);
+  });
+  const histogram = $derived(buildHistogram(focusedAllSamples, 10));
+
+  // p50 / p95 / spread — recompute locally so the histogram and the readout
+  // share a single source of truth (focusedStats may use a different window).
+  const distroStats = $derived.by(() => {
+    const oks: number[] = [];
+    for (const s of focusedAllSamples) if (s.status === 'ok' && typeof s.latency === 'number') oks.push(s.latency);
+    if (oks.length === 0) return null;
+    const sorted = [...oks].sort((a, b) => a - b);
+    const pickQ = (q: number): number => {
+      const idx = Math.min(sorted.length - 1, Math.max(0, Math.floor(q * sorted.length)));
+      // sorted is non-empty (checked above), and idx is clamped, so a default of 0 is unreachable.
+      return sorted[idx] ?? 0;
+    };
+    const p50 = pickQ(0.5);
+    const p95 = pickQ(0.95);
+    return { p50, p95, spread: p50 > 0 ? p95 / p50 : 0, n: oks.length };
+  });
+
+  // ── Cross-endpoint correlation grid ─────────────────────────────────────
+  // For each enabled endpoint, build a per-round comparison so the user can
+  // see whether the focused endpoint's spikes are isolated (likely the site)
+  // or shared with others (likely the network).
+  const correlation = $derived.by(() => {
+    if (!focusedEndpoint) return null;
+    const others = monitored
+      .filter(ep => ep.id !== focusedEndpoint.id)
+      .map(ep => ({
+        id: ep.id,
+        label: ep.label,
+        samples: measurements.endpoints[ep.id]?.samples.toArray().slice(-16) ?? [],
+      }));
+    return buildCorrelation(
+      {
+        id: focusedEndpoint.id,
+        label: focusedEndpoint.label,
+        samples: measurements.endpoints[focusedEndpoint.id]?.samples.toArray().slice(-16) ?? [],
+      },
+      others,
+      16,
+    );
+  });
+
   interface SampleRow { round: number; total: number; segs: { phase: Tier2Phase; pctWidth: number; color: string; }[]; status: 'ok' | 'timeout' | 'error' | 'no-tier2'; }
   const sampleRows: readonly SampleRow[] = $derived.by(() => {
     return recentSamples.map((s) => {
@@ -135,7 +188,7 @@
 <section class="diagnose" aria-label="Diagnose">
   <header class="diagnose-header">
     <div class="diagnose-title-block">
-      <div class="diagnose-kicker">Diagnose · Request waterfall</div>
+      <div class="diagnose-kicker">Diagnose · Distribution and correlation</div>
       <h1 class="diagnose-title">
         {#if focusedEndpoint}
           <span class="diagnose-title-pip" style:background={focusedEndpoint.color || tokens.color.endpoint[0]} aria-hidden="true"></span>
@@ -172,70 +225,125 @@
 
   {#if !focusedEndpoint}
     <div class="diagnose-empty" role="note">
-      <p class="diagnose-empty-title">Select an endpoint from the left rail to diagnose a specific link.</p>
-      <p class="diagnose-empty-hint">Diagnose breaks one request into DNS · TCP · TLS · Server · Transfer phases and points at the slow one.</p>
-    </div>
-  {:else if phases === null}
-    <div class="diagnose-empty" role="note">
-      {#if mode === 'p95' && focusedStats?.tier2Averages}
-        <!-- P50 data exists, P95 hasn't been computed yet. Without this branch -->
-        <!-- the view reads as a regression when the user toggles to P95.      -->
-        <p class="diagnose-empty-title">P95 phase breakdown not yet available.</p>
-        <p class="diagnose-empty-hint">Switch to P50 to view the current breakdown, or wait for more samples.</p>
-      {:else}
-        <p class="diagnose-empty-title">Awaiting tier-2 samples…</p>
-        <p class="diagnose-empty-hint">Phase breakdown appears once the first tier-2 measurement lands.</p>
-      {/if}
+      <p class="diagnose-empty-title">Pick an endpoint from the left rail to look at it closely.</p>
+      <p class="diagnose-empty-hint">Detail shows you the latency distribution and whether spikes line up across other endpoints.</p>
     </div>
   {:else}
-    <!-- Hero waterfall -->
-    <div class="diagnose-waterfall" role="img" aria-label={heroAria}>
-      <div class="diagnose-bar">
-        {#each segments as seg (seg.phase)}
-          <div
-            class="diagnose-bar-seg"
-            class:dominant={seg.dominant}
-            style:width="{seg.pctWidth}%"
-            style:background={seg.color}
-          >
-            {#if seg.pctWidth >= 8}
-              <span class="diagnose-bar-label" style:color={tokens.color.tier2.labelText}>
-                {seg.short} · {fmt(seg.ms)}<span class="diagnose-bar-ms">ms</span>
-              </span>
-            {/if}
-          </div>
-        {/each}
-      </div>
-      <div class="diagnose-bar-scale">
-        {#each segments as seg (seg.phase)}
-          <span class="diagnose-bar-tick" style:flex="{seg.pctWidth}">
-            <span class="diagnose-bar-tick-label">{seg.short}</span>
-          </span>
-        {/each}
-      </div>
-    </div>
-
-    <!-- Hypothesis + evidence -->
-    {#if hypothesis}
-      <section class="diagnose-hypothesis" aria-label="Phase hypothesis">
-        <div class="diagnose-hypothesis-kicker">Verdict</div>
-        <p class="diagnose-hypothesis-text">{hypothesis.text}</p>
-
-        <div class="diagnose-hypothesis-kicker">Evidence</div>
-        <ul class="diagnose-evidence">
-          {#each segments as seg (seg.phase)}
-            <li class="diagnose-evidence-row" class:dominant={seg.dominant}>
-              <span class="diagnose-evidence-pip" style:background={seg.color} aria-hidden="true"></span>
-              <span class="diagnose-evidence-name">{PHASE_LABELS[seg.phase]}</span>
-              <span class="diagnose-evidence-ms">{fmt(seg.ms)} ms</span>
-              <span class="diagnose-evidence-bar" aria-hidden="true">
-                <span class="diagnose-evidence-fill" style:width="{seg.pctWidth}%" style:background={seg.color}></span>
-              </span>
-              <span class="diagnose-evidence-pct">{Math.round(seg.pct * 100)}%</span>
-            </li>
+    <!-- Distribution histogram — answers "what's this endpoint's typical latency,
+         and how much does it vary?" -->
+    <section class="diagnose-distro" aria-label="Latency distribution">
+      <div class="diagnose-section-kicker">Distribution</div>
+      {#if distroStats && histogram.bins.length > 0}
+        <div class="distro-stats">
+          <span class="distro-stat"><span class="distro-stat-label">p50</span> {fmt(distroStats.p50)} ms</span>
+          <span class="distro-stat"><span class="distro-stat-label">p95</span> {fmt(distroStats.p95)} ms</span>
+          <span class="distro-stat"><span class="distro-stat-label">spread</span> {distroStats.spread.toFixed(1)}×</span>
+          <span class="distro-stat-meta">over last {distroStats.n} samples</span>
+        </div>
+        <div class="distro-chart" role="img" aria-label="Latency histogram across last {distroStats.n} samples">
+          {#each histogram.bins as bin, i (i)}
+            <div class="distro-bin" title="{Math.round(bin.fromMs)}–{Math.round(bin.toMs)} ms · {bin.count} samples">
+              <div class="distro-bar" style:height="{histogram.maxCount > 0 ? (bin.count / histogram.maxCount) * 100 : 0}%"></div>
+            </div>
           {/each}
-        </ul>
+        </div>
+        <div class="distro-axis" aria-hidden="true">
+          <span>{fmt(histogram.bins[0]?.fromMs ?? 0)} ms</span>
+          <span>{fmt(histogram.bins[histogram.bins.length - 1]?.toMs ?? 0)} ms</span>
+        </div>
+      {:else}
+        <p class="distro-empty">Need at least 2 samples with different latencies before a distribution chart is meaningful. Run for a few more rounds.</p>
+      {/if}
+    </section>
+
+    <!-- Cross-endpoint correlation — answers "is this slowness specific to this
+         site, or shared across multiple sites at once (likely my network)?" -->
+    {#if correlation}
+      <section class="diagnose-correlation" aria-label="Cross-endpoint comparison">
+        <div class="diagnose-section-kicker">Compare with other endpoints</div>
+        <p class="correlation-headline">{correlation.verdict.headline}</p>
+        {#if correlation.rows[0]?.cells.length > 0}
+          <div class="correlation-grid" role="table" aria-label="Per-round latency across endpoints">
+            {#each correlation.rows as row, rowIdx (row.endpointId)}
+              <div class="correlation-row" class:focused={rowIdx === 0} role="row">
+                <span class="correlation-label" role="rowheader">{row.label}</span>
+                <div class="correlation-cells">
+                  {#each row.cells as cell (cell.round)}
+                    <span
+                      class="correlation-cell"
+                      class:spike={cell.isSpike}
+                      class:missing={cell.latencyMs === null}
+                      title="R{cell.round}{cell.latencyMs !== null ? ` · ${fmt(cell.latencyMs)} ms${cell.isSpike ? ' (spike)' : ''}` : ' · no data'}"
+                      role="cell"
+                    ></span>
+                  {/each}
+                </div>
+              </div>
+            {/each}
+          </div>
+          <p class="correlation-legend" aria-hidden="true">
+            <span class="correlation-legend-swatch correlation-legend-normal"></span> normal
+            <span class="correlation-legend-swatch correlation-legend-spike"></span> spike (>1.5× this endpoint's median)
+            <span class="correlation-legend-swatch correlation-legend-missing"></span> no data
+          </p>
+        {/if}
       </section>
+    {/if}
+
+    <!-- Phase breakdown — only meaningful for endpoints that send Timing-Allow-Origin
+         (or are same-origin). Collapsed by default since it's frequently empty
+         for cross-origin endpoints and can be tautological for same-origin
+         endpoints over warm QUIC connections. -->
+    {#if phases !== null}
+      <details class="diagnose-phases">
+        <summary>
+          <span class="diagnose-section-kicker">Phase breakdown (advanced)</span>
+          <span class="phases-summary-hint">DNS · TCP · TLS · Server · Transfer</span>
+        </summary>
+        <div class="diagnose-waterfall" role="img" aria-label={heroAria}>
+          <div class="diagnose-bar">
+            {#each segments as seg (seg.phase)}
+              <div
+                class="diagnose-bar-seg"
+                class:dominant={seg.dominant}
+                style:width="{seg.pctWidth}%"
+                style:background={seg.color}
+              >
+                {#if seg.pctWidth >= 8}
+                  <span class="diagnose-bar-label" style:color={tokens.color.tier2.labelText}>
+                    {seg.short} · {fmt(seg.ms)}<span class="diagnose-bar-ms">ms</span>
+                  </span>
+                {/if}
+              </div>
+            {/each}
+          </div>
+          <div class="diagnose-bar-scale">
+            {#each segments as seg (seg.phase)}
+              <span class="diagnose-bar-tick" style:flex="{seg.pctWidth}">
+                <span class="diagnose-bar-tick-label">{seg.short}</span>
+              </span>
+            {/each}
+          </div>
+        </div>
+        {#if hypothesis}
+          <ul class="diagnose-evidence">
+            {#each segments as seg (seg.phase)}
+              <li class="diagnose-evidence-row" class:dominant={seg.dominant}>
+                <span class="diagnose-evidence-pip" style:background={seg.color} aria-hidden="true"></span>
+                <span class="diagnose-evidence-name">{PHASE_LABELS[seg.phase]}</span>
+                <span class="diagnose-evidence-ms">{fmt(seg.ms)} ms</span>
+                <span class="diagnose-evidence-bar" aria-hidden="true">
+                  <span class="diagnose-evidence-fill" style:width="{seg.pctWidth}%" style:background={seg.color}></span>
+                </span>
+                <span class="diagnose-evidence-pct">{Math.round(seg.pct * 100)}%</span>
+              </li>
+            {/each}
+          </ul>
+          <p class="phases-caveat">
+            On warm-connection samples the browser reports zero for DNS/TCP/TLS — only TTFB and Transfer reflect per-request work. Cross-origin endpoints without <code>Timing-Allow-Origin</code> headers report only the total.
+          </p>
+        {/if}
+      </details>
     {/if}
 
     <!-- Sample strip -->
@@ -300,6 +408,218 @@
     color: var(--accent-cyan);
     text-transform: uppercase;
     margin-bottom: 4px;
+  }
+
+  /* Section kicker — used by the Distribution / Compare / Phase breakdown
+     section headers. Matches the diagnose-kicker visual rhythm but hangs off
+     a sibling element rather than the title. */
+  .diagnose-section-kicker {
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-kicker);
+    color: var(--t3);
+    text-transform: uppercase;
+    margin-bottom: 8px;
+  }
+
+  /* ── Distribution histogram ────────────────────────────────────────────── */
+  .diagnose-distro {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 16px;
+    background: rgba(255, 255, 255, 0.025);
+    border: 1px solid var(--border-mid);
+    border-radius: 10px;
+  }
+  .distro-stats {
+    display: flex;
+    align-items: baseline;
+    gap: 18px;
+    flex-wrap: wrap;
+    font-family: var(--mono);
+    font-size: var(--ts-sm);
+    color: var(--t1);
+  }
+  .distro-stat-label {
+    color: var(--t3);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-kicker);
+    text-transform: uppercase;
+    margin-right: 6px;
+  }
+  .distro-stat-meta {
+    color: var(--t4);
+    font-size: var(--ts-xs);
+    margin-left: auto;
+  }
+  .distro-chart {
+    display: flex;
+    align-items: flex-end;
+    gap: 3px;
+    height: 96px;
+    padding: 4px 0;
+  }
+  .distro-bin {
+    flex: 1;
+    display: flex;
+    align-items: flex-end;
+    height: 100%;
+  }
+  .distro-bar {
+    width: 100%;
+    background: linear-gradient(to top, color-mix(in srgb, var(--accent-cyan) 30%, transparent), color-mix(in srgb, var(--accent-cyan) 12%, transparent));
+    border: 1px solid color-mix(in srgb, var(--accent-cyan) 40%, transparent);
+    border-radius: 2px;
+    min-height: 1px;
+    transition: height 200ms ease;
+  }
+  .distro-axis {
+    display: flex;
+    justify-content: space-between;
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    color: var(--t4);
+  }
+  .distro-empty {
+    color: var(--t3);
+    font-size: var(--ts-sm);
+    margin: 0;
+    padding: 8px 0;
+  }
+
+  /* ── Cross-endpoint correlation ────────────────────────────────────────── */
+  .diagnose-correlation {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 16px;
+    background: rgba(255, 255, 255, 0.025);
+    border: 1px solid var(--border-mid);
+    border-radius: 10px;
+  }
+  .correlation-headline {
+    margin: 0;
+    color: var(--t1);
+    font-size: var(--ts-md);
+    line-height: 1.4;
+  }
+  .correlation-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-top: 4px;
+  }
+  .correlation-row {
+    display: grid;
+    grid-template-columns: 100px minmax(0, 1fr);
+    align-items: center;
+    gap: 10px;
+  }
+  .correlation-label {
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    color: var(--t3);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .correlation-row.focused .correlation-label {
+    color: var(--accent-cyan);
+    font-weight: 500;
+  }
+  .correlation-cells {
+    display: grid;
+    grid-template-columns: repeat(16, minmax(0, 1fr));
+    gap: 2px;
+  }
+  .correlation-cell {
+    height: 16px;
+    background: color-mix(in srgb, var(--t1) 12%, transparent);
+    border-radius: 2px;
+  }
+  .correlation-cell.spike {
+    background: var(--accent-pink);
+    box-shadow: 0 0 6px color-mix(in srgb, var(--accent-pink) 50%, transparent);
+  }
+  .correlation-cell.missing {
+    background: transparent;
+    border: 1px dashed color-mix(in srgb, var(--t1) 12%, transparent);
+  }
+  .correlation-row.focused .correlation-cell:not(.spike):not(.missing) {
+    background: color-mix(in srgb, var(--accent-cyan) 35%, transparent);
+  }
+  .correlation-legend {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    margin: 4px 0 0;
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    color: var(--t4);
+    flex-wrap: wrap;
+  }
+  .correlation-legend-swatch {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-radius: 2px;
+    margin-right: 4px;
+    vertical-align: middle;
+  }
+  .correlation-legend-normal { background: color-mix(in srgb, var(--t1) 12%, transparent); }
+  .correlation-legend-spike { background: var(--accent-pink); }
+  .correlation-legend-missing { background: transparent; border: 1px dashed color-mix(in srgb, var(--t1) 12%, transparent); }
+
+  /* ── Phase breakdown (collapsed by default) ────────────────────────────── */
+  .diagnose-phases {
+    background: rgba(255, 255, 255, 0.025);
+    border: 1px solid var(--border-mid);
+    border-radius: 10px;
+    padding: 16px;
+  }
+  .diagnose-phases summary {
+    cursor: pointer;
+    list-style: none;
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+  .diagnose-phases summary::-webkit-details-marker { display: none; }
+  .diagnose-phases summary::before {
+    content: '▸';
+    color: var(--t3);
+    transition: transform 150ms ease;
+    display: inline-block;
+  }
+  .diagnose-phases[open] summary::before {
+    transform: rotate(90deg);
+  }
+  .phases-summary-hint {
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    color: var(--t4);
+  }
+  .diagnose-phases[open] > *:not(summary) {
+    margin-top: 12px;
+  }
+  .phases-caveat {
+    margin: 12px 0 0;
+    padding: 10px 12px;
+    background: rgba(255, 255, 255, 0.025);
+    border-left: 2px solid var(--t4);
+    border-radius: 4px;
+    color: var(--t3);
+    font-size: var(--ts-xs);
+    line-height: 1.5;
+  }
+  .phases-caveat code {
+    font-family: var(--mono);
+    font-size: 0.95em;
+    background: rgba(255, 255, 255, 0.06);
+    padding: 1px 4px;
+    border-radius: 3px;
   }
   .diagnose-title {
     margin: 0;

--- a/src/lib/components/DiagnoseView.svelte
+++ b/src/lib/components/DiagnoseView.svelte
@@ -202,18 +202,6 @@
 
     {#if focusedEndpoint}
       <div class="diagnose-actions">
-        <div class="diagnose-segment" role="group" aria-label="Percentile mode">
-          <button
-            type="button" class="diagnose-chip"
-            class:on={mode === 'p50'} aria-pressed={mode === 'p50'}
-            onclick={() => handleSelectMode('p50')}
-          >P50</button>
-          <button
-            type="button" class="diagnose-chip"
-            class:on={mode === 'p95'} aria-pressed={mode === 'p95'}
-            onclick={() => handleSelectMode('p95')}
-          >P95</button>
-        </div>
         <button
           type="button" class="diagnose-chip diagnose-chip-action"
           onclick={handleBack}
@@ -300,6 +288,21 @@
           <span class="diagnose-section-kicker">Phase breakdown (advanced)</span>
           <span class="phases-summary-hint">DNS · TCP · TLS · Server · Transfer</span>
         </summary>
+        <!-- Percentile toggle lives inside the details so it only appears when the
+             section is expanded (it has no effect on Distribution or Correlation
+             panels — only on this waterfall). -->
+        <div class="diagnose-segment" role="group" aria-label="Percentile mode">
+          <button
+            type="button" class="diagnose-chip"
+            class:on={mode === 'p50'} aria-pressed={mode === 'p50'}
+            onclick={() => handleSelectMode('p50')}
+          >P50</button>
+          <button
+            type="button" class="diagnose-chip"
+            class:on={mode === 'p95'} aria-pressed={mode === 'p95'}
+            onclick={() => handleSelectMode('p95')}
+          >P95</button>
+        </div>
         <div class="diagnose-waterfall" role="img" aria-label={heroAria}>
           <div class="diagnose-bar">
             {#each segments as seg (seg.phase)}

--- a/src/lib/components/Topbar.svelte
+++ b/src/lib/components/Topbar.svelte
@@ -67,7 +67,7 @@
     </div>
     <div class="brand-meta">
       <div class="brand-name">Chronoscope</div>
-      <div class="brand-sub">HTTP latency diagnostic · v2</div>
+      <div class="brand-sub">HTTP latency monitor · multi-site</div>
     </div>
   </div>
 

--- a/src/lib/components/ViewSwitcher.svelte
+++ b/src/lib/components/ViewSwitcher.svelte
@@ -22,7 +22,7 @@
   const VIEWS: readonly ViewDef[] = [
     { id: 'overview', key: '1', label: 'Overview', hint: 'Is everything okay?',         enabled: true  },
     { id: 'live',     key: '2', label: 'Live',     hint: "What's happening right now?", enabled: true  },
-    { id: 'diagnose', key: '3', label: 'Diagnose', hint: 'Why is it slow?',             enabled: true  },
+    { id: 'diagnose', key: '3', label: 'Diagnose', hint: 'Is it me or them?',            enabled: true  },
     { id: 'strata',   key: '4', label: 'Strata',   hint: 'How is the distribution?',    enabled: false },
     { id: 'terminal', key: '5', label: 'Terminal', hint: "What's in the log?",          enabled: false },
   ];

--- a/src/lib/utils/diagnose-stats.ts
+++ b/src/lib/utils/diagnose-stats.ts
@@ -211,9 +211,19 @@ export function buildCorrelation(
     knownComparatorsPerSpike.push(knownCount);
   }
 
+  // Count of focused-row cells that landed within the visible window with a
+  // known (non-null) latency. This is distinct from `focusedOks.length` (which
+  // counts OK samples across the full history): if the user paused the run
+  // and resumed against a different endpoint, the focused endpoint may have
+  // OK samples in its history but zero known cells in the current window.
+  // Gating "steady" on this count prevents the verdict from claiming health
+  // for a window where focused produced no data at all.
+  const focusedKnownInWindow = focusedRow.cells.filter(c => c.latencyMs !== null).length;
+
   const headline = correlationHeadline({
     focusedLabel: focused.label,
     focusedOksCount: focusedOks.length,
+    focusedKnownInWindow,
     focusedSpikeCount: focusedSpikeRounds.length,
     otherSpikesPerFocusedSpike,
     knownComparatorsPerSpike,
@@ -229,6 +239,13 @@ export function buildCorrelation(
 interface HeadlineInput {
   readonly focusedLabel: string;
   readonly focusedOksCount: number;
+  /**
+   * Count of focused-row cells in the visible window with a non-null latency.
+   * Distinct from focusedOksCount, which spans the full sample history.
+   * Used to catch the case where focused has OK samples in history but zero
+   * known data in the current window (so calling it "steady" would be wrong).
+   */
+  readonly focusedKnownInWindow: number;
   readonly focusedSpikeCount: number;
   readonly otherSpikesPerFocusedSpike: readonly number[];
   /**
@@ -244,6 +261,7 @@ function correlationHeadline(input: HeadlineInput): string {
   const {
     focusedLabel,
     focusedOksCount,
+    focusedKnownInWindow,
     focusedSpikeCount,
     otherSpikesPerFocusedSpike,
     knownComparatorsPerSpike,
@@ -257,6 +275,11 @@ function correlationHeadline(input: HeadlineInput): string {
   }
   if (focusedOksCount === 0) {
     return `${focusedLabel} has no successful samples to compare — check the timeline for failures.`;
+  }
+  if (focusedKnownInWindow === 0) {
+    // History has OK samples but the current window is empty for this endpoint.
+    // Don't claim "steady" — we have no recent data to back it.
+    return `No recent samples for ${focusedLabel} in this window — comparator data shown for context.`;
   }
   if (focusedOksCount < MIN_SAMPLES_FOR_SPIKE) {
     return `Still learning ${focusedLabel}'s baseline — ${focusedOksCount} of ${MIN_SAMPLES_FOR_SPIKE} samples.`;

--- a/src/lib/utils/diagnose-stats.ts
+++ b/src/lib/utils/diagnose-stats.ts
@@ -1,0 +1,229 @@
+// src/lib/utils/diagnose-stats.ts
+// Pure helpers for the Diagnose view's distribution + cross-endpoint
+// correlation panels. No store imports, no DOM, no side effects.
+
+import type { MeasurementSample } from '../types';
+
+// ── Histogram ────────────────────────────────────────────────────────────────
+
+export interface HistogramBin {
+  /** Lower edge of the bin in milliseconds, inclusive. */
+  readonly fromMs: number;
+  /** Upper edge of the bin in milliseconds, exclusive (except the last bin). */
+  readonly toMs: number;
+  /** Number of samples that fell into this bin. */
+  readonly count: number;
+}
+
+export interface Histogram {
+  readonly bins: readonly HistogramBin[];
+  /** Highest bin count — for normalising bar heights at the call site. */
+  readonly maxCount: number;
+  /** Total OK-status samples that contributed to the histogram. */
+  readonly total: number;
+}
+
+/**
+ * Build a fixed-bin-count histogram of OK-status sample latencies. Returns
+ * empty bins when there are fewer than two distinct samples — a one-bar chart
+ * carries no visual information so we degrade gracefully.
+ */
+export function buildHistogram(
+  samples: readonly MeasurementSample[],
+  binCount = 10,
+): Histogram {
+  const oks: number[] = [];
+  for (const s of samples) {
+    if (s.status === 'ok' && typeof s.latency === 'number') oks.push(s.latency);
+  }
+  if (oks.length < 2) return { bins: [], maxCount: 0, total: oks.length };
+
+  const min = Math.min(...oks);
+  const max = Math.max(...oks);
+  if (max === min) return { bins: [], maxCount: 0, total: oks.length };
+
+  const span = max - min;
+  const step = span / binCount;
+  const bins: HistogramBin[] = [];
+  for (let i = 0; i < binCount; i++) {
+    const fromMs = min + step * i;
+    const toMs = i === binCount - 1 ? max : min + step * (i + 1);
+    let count = 0;
+    for (const v of oks) {
+      // Last bin is inclusive on the upper edge so max-valued samples land somewhere.
+      if (i === binCount - 1 ? v >= fromMs && v <= toMs : v >= fromMs && v < toMs) count++;
+    }
+    bins.push({ fromMs, toMs, count });
+  }
+  let maxCount = 0;
+  for (const b of bins) if (b.count > maxCount) maxCount = b.count;
+  return { bins, maxCount, total: oks.length };
+}
+
+// ── Cross-endpoint correlation ───────────────────────────────────────────────
+
+export interface CorrelationCell {
+  readonly round: number;
+  /** Latency in ms, or null when no sample landed for that endpoint+round. */
+  readonly latencyMs: number | null;
+  /** True when this endpoint's latency in this round is a spike for it. */
+  readonly isSpike: boolean;
+}
+
+export interface CorrelationRow {
+  readonly endpointId: string;
+  readonly label: string;
+  readonly cells: readonly CorrelationCell[];
+}
+
+export interface CorrelationVerdict {
+  readonly headline: string;
+  /** Spike rounds in the focused endpoint's window. */
+  readonly focusedSpikeRounds: readonly number[];
+  /**
+   * For each focused-endpoint spike round, the count of OTHER endpoints that
+   * also spiked in that same round. Same length as `focusedSpikeRounds`.
+   */
+  readonly otherSpikesPerFocusedSpike: readonly number[];
+}
+
+export interface CorrelationInput {
+  readonly id: string;
+  readonly label: string;
+  readonly samples: readonly MeasurementSample[];
+}
+
+/**
+ * Spike threshold: a sample is a spike when it exceeds 1.5× the endpoint's
+ * own median over the window. We use median-relative rather than absolute
+ * thresholds so endpoints with naturally-different baselines are compared on
+ * the same footing.
+ */
+const SPIKE_FACTOR = 1.5;
+
+function median(values: readonly number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    const a = sorted[mid - 1] ?? 0;
+    const b = sorted[mid] ?? 0;
+    return (a + b) / 2;
+  }
+  return sorted[mid] ?? 0;
+}
+
+function buildCells(
+  samples: readonly MeasurementSample[],
+  rounds: readonly number[],
+  endpointMedian: number,
+): CorrelationCell[] {
+  const byRound = new Map<number, MeasurementSample>();
+  for (const s of samples) byRound.set(s.round, s);
+  return rounds.map((round) => {
+    const s = byRound.get(round);
+    if (!s || s.status !== 'ok' || typeof s.latency !== 'number') {
+      return { round, latencyMs: null, isSpike: false };
+    }
+    const isSpike = endpointMedian > 0 && s.latency > endpointMedian * SPIKE_FACTOR;
+    return { round, latencyMs: s.latency, isSpike };
+  });
+}
+
+/**
+ * Build the per-round correlation grid for the focused endpoint (first input)
+ * and all comparison endpoints (rest). Window covers the most recent
+ * `windowRounds` rounds across the union of all inputs.
+ *
+ * Returns the grid + a one-line verdict explaining whether the focused
+ * endpoint's spikes correlate with others (network-wide) or are isolated
+ * (endpoint-specific).
+ */
+export function buildCorrelation(
+  focused: CorrelationInput,
+  others: readonly CorrelationInput[],
+  windowRounds = 16,
+): { rows: readonly CorrelationRow[]; verdict: CorrelationVerdict } {
+  // Determine the round window: the highest `windowRounds` round values across
+  // all endpoints, oldest-first.
+  const allRounds = new Set<number>();
+  for (const ep of [focused, ...others]) for (const s of ep.samples) allRounds.add(s.round);
+  const rounds = [...allRounds].sort((a, b) => a - b).slice(-windowRounds);
+
+  const focusedOks: number[] = [];
+  for (const s of focused.samples) {
+    if (s.status === 'ok' && typeof s.latency === 'number') focusedOks.push(s.latency);
+  }
+  const focusedMedian = median(focusedOks);
+
+  const focusedRow: CorrelationRow = {
+    endpointId: focused.id,
+    label: focused.label,
+    cells: buildCells(focused.samples, rounds, focusedMedian),
+  };
+  const otherRows: CorrelationRow[] = others.map((ep) => {
+    const oks: number[] = [];
+    for (const s of ep.samples) {
+      if (s.status === 'ok' && typeof s.latency === 'number') oks.push(s.latency);
+    }
+    return {
+      endpointId: ep.id,
+      label: ep.label,
+      cells: buildCells(ep.samples, rounds, median(oks)),
+    };
+  });
+
+  // Verdict: for each spike on the focused row, count how many other rows
+  // also spiked in the same column. Majority-correlated → network-wide.
+  const focusedSpikeRounds: number[] = [];
+  const otherSpikesPerFocusedSpike: number[] = [];
+  for (let i = 0; i < focusedRow.cells.length; i++) {
+    const focusedCell = focusedRow.cells[i];
+    if (!focusedCell || !focusedCell.isSpike) continue;
+    focusedSpikeRounds.push(focusedCell.round);
+    let coCount = 0;
+    for (const row of otherRows) {
+      if (row.cells[i]?.isSpike) coCount++;
+    }
+    otherSpikesPerFocusedSpike.push(coCount);
+  }
+
+  const headline = correlationHeadline(
+    focused.label,
+    focusedSpikeRounds.length,
+    otherSpikesPerFocusedSpike,
+    otherRows.length,
+  );
+
+  return {
+    rows: [focusedRow, ...otherRows],
+    verdict: { headline, focusedSpikeRounds, otherSpikesPerFocusedSpike },
+  };
+}
+
+function correlationHeadline(
+  focusedLabel: string,
+  focusedSpikeCount: number,
+  otherSpikesPerFocusedSpike: readonly number[],
+  otherCount: number,
+): string {
+  if (otherCount === 0) {
+    return `Add other endpoints to compare ${focusedLabel} against.`;
+  }
+  if (focusedSpikeCount === 0) {
+    return `${focusedLabel} has been steady — no notable spikes in this window.`;
+  }
+  // A spike is "shared" when at least half of the other endpoints also spiked.
+  const sharedThreshold = Math.ceil(otherCount / 2);
+  let shared = 0;
+  for (const co of otherSpikesPerFocusedSpike) if (co >= sharedThreshold) shared++;
+  const sharedPct = shared / focusedSpikeCount;
+
+  if (sharedPct >= 0.6) {
+    return `Spikes happen across multiple sites at once — likely your network or local infrastructure.`;
+  }
+  if (sharedPct <= 0.2) {
+    return `Spikes are isolated to ${focusedLabel} — likely that site or its origin, not your connection.`;
+  }
+  return `Spikes are mixed — sometimes shared with other sites, sometimes ${focusedLabel}-specific.`;
+}

--- a/src/lib/utils/diagnose-stats.ts
+++ b/src/lib/utils/diagnose-stats.ts
@@ -101,6 +101,15 @@ export interface CorrelationInput {
  */
 const SPIKE_FACTOR = 1.5;
 
+/**
+ * Minimum OK sample count before spike detection produces meaningful results.
+ * Below this, the median is too noisy for the 1.5× threshold to be reliable —
+ * a fresh endpoint with 2 samples could see its second sample marked a spike
+ * just because the first one was unusually low. Surface "still learning" in
+ * the verdict instead of mis-flagging early variance.
+ */
+const MIN_SAMPLES_FOR_SPIKE = 8;
+
 function median(values: readonly number[]): number {
   if (values.length === 0) return 0;
   const sorted = [...values].sort((a, b) => a - b);
@@ -117,15 +126,21 @@ function buildCells(
   samples: readonly MeasurementSample[],
   rounds: readonly number[],
   endpointMedian: number,
+  okSampleCount: number,
 ): CorrelationCell[] {
   const byRound = new Map<number, MeasurementSample>();
   for (const s of samples) byRound.set(s.round, s);
+  // Skip spike detection entirely until we have enough OK samples for the
+  // median-relative threshold to be reliable. Without this guard, an endpoint
+  // with 2 samples [40, 65] would produce median=52.5 and flag any 80ms+
+  // sample as a "spike" — wild call from a 2-point baseline.
+  const spikesEnabled = okSampleCount >= MIN_SAMPLES_FOR_SPIKE;
   return rounds.map((round) => {
     const s = byRound.get(round);
     if (!s || s.status !== 'ok' || typeof s.latency !== 'number') {
       return { round, latencyMs: null, isSpike: false };
     }
-    const isSpike = endpointMedian > 0 && s.latency > endpointMedian * SPIKE_FACTOR;
+    const isSpike = spikesEnabled && endpointMedian > 0 && s.latency > endpointMedian * SPIKE_FACTOR;
     return { round, latencyMs: s.latency, isSpike };
   });
 }
@@ -159,7 +174,7 @@ export function buildCorrelation(
   const focusedRow: CorrelationRow = {
     endpointId: focused.id,
     label: focused.label,
-    cells: buildCells(focused.samples, rounds, focusedMedian),
+    cells: buildCells(focused.samples, rounds, focusedMedian, focusedOks.length),
   };
   const otherRows: CorrelationRow[] = others.map((ep) => {
     const oks: number[] = [];
@@ -169,31 +184,41 @@ export function buildCorrelation(
     return {
       endpointId: ep.id,
       label: ep.label,
-      cells: buildCells(ep.samples, rounds, median(oks)),
+      cells: buildCells(ep.samples, rounds, median(oks), oks.length),
     };
   });
 
-  // Verdict: for each spike on the focused row, count how many other rows
-  // also spiked in the same column. Majority-correlated → network-wide.
+  // Verdict: for each spike on the focused row, count how many *known* (non-null)
+  // comparators also spiked. Treating a null cell as "did not spike" silently
+  // misclassifies network-wide events: when comparators time out alongside the
+  // focused endpoint, their cells are null and the verdict drifts toward
+  // "isolated" — the opposite of the truth.
   const focusedSpikeRounds: number[] = [];
   const otherSpikesPerFocusedSpike: number[] = [];
+  const knownComparatorsPerSpike: number[] = [];
   for (let i = 0; i < focusedRow.cells.length; i++) {
     const focusedCell = focusedRow.cells[i];
     if (!focusedCell || !focusedCell.isSpike) continue;
     focusedSpikeRounds.push(focusedCell.round);
     let coCount = 0;
+    let knownCount = 0;
     for (const row of otherRows) {
-      if (row.cells[i]?.isSpike) coCount++;
+      const cell = row.cells[i];
+      if (cell?.latencyMs !== null && cell?.latencyMs !== undefined) knownCount++;
+      if (cell?.isSpike) coCount++;
     }
     otherSpikesPerFocusedSpike.push(coCount);
+    knownComparatorsPerSpike.push(knownCount);
   }
 
-  const headline = correlationHeadline(
-    focused.label,
-    focusedSpikeRounds.length,
+  const headline = correlationHeadline({
+    focusedLabel: focused.label,
+    focusedOksCount: focusedOks.length,
+    focusedSpikeCount: focusedSpikeRounds.length,
     otherSpikesPerFocusedSpike,
-    otherRows.length,
-  );
+    knownComparatorsPerSpike,
+    otherCount: otherRows.length,
+  });
 
   return {
     rows: [focusedRow, ...otherRows],
@@ -201,24 +226,64 @@ export function buildCorrelation(
   };
 }
 
-function correlationHeadline(
-  focusedLabel: string,
-  focusedSpikeCount: number,
-  otherSpikesPerFocusedSpike: readonly number[],
-  otherCount: number,
-): string {
+interface HeadlineInput {
+  readonly focusedLabel: string;
+  readonly focusedOksCount: number;
+  readonly focusedSpikeCount: number;
+  readonly otherSpikesPerFocusedSpike: readonly number[];
+  /**
+   * For each focused-spike round, how many comparator endpoints had a known
+   * (non-null) value in that round. Used to gate the shared/isolated verdict
+   * on whether the panel actually has enough comparator coverage to call it.
+   */
+  readonly knownComparatorsPerSpike: readonly number[];
+  readonly otherCount: number;
+}
+
+function correlationHeadline(input: HeadlineInput): string {
+  const {
+    focusedLabel,
+    focusedOksCount,
+    focusedSpikeCount,
+    otherSpikesPerFocusedSpike,
+    knownComparatorsPerSpike,
+    otherCount,
+  } = input;
+
+  // Confidence gates — branch on data quality first so we never produce a
+  // confident-sounding verdict from inadequate data.
   if (otherCount === 0) {
     return `Add other endpoints to compare ${focusedLabel} against.`;
+  }
+  if (focusedOksCount === 0) {
+    return `${focusedLabel} has no successful samples to compare — check the timeline for failures.`;
+  }
+  if (focusedOksCount < MIN_SAMPLES_FOR_SPIKE) {
+    return `Still learning ${focusedLabel}'s baseline — ${focusedOksCount} of ${MIN_SAMPLES_FOR_SPIKE} samples.`;
   }
   if (focusedSpikeCount === 0) {
     return `${focusedLabel} has been steady — no notable spikes in this window.`;
   }
-  // A spike is "shared" when at least half of the other endpoints also spiked.
+
+  // For each focused-spike round, decide whether comparators give us enough
+  // coverage to make a shared/isolated call. A spike round with < 2 known
+  // comparators is "inconclusive" — we don't know what the others were doing.
+  const MIN_COMPARATORS_FOR_VERDICT = 2;
   const sharedThreshold = Math.ceil(otherCount / 2);
   let shared = 0;
-  for (const co of otherSpikesPerFocusedSpike) if (co >= sharedThreshold) shared++;
-  const sharedPct = shared / focusedSpikeCount;
+  let conclusiveSpikes = 0;
+  for (let i = 0; i < focusedSpikeCount; i++) {
+    if ((knownComparatorsPerSpike[i] ?? 0) < MIN_COMPARATORS_FOR_VERDICT) continue;
+    conclusiveSpikes++;
+    if ((otherSpikesPerFocusedSpike[i] ?? 0) >= sharedThreshold) shared++;
+  }
 
+  if (conclusiveSpikes === 0) {
+    // All spike rounds had comparator gaps — we can't make a network/site call.
+    return `Spikes detected on ${focusedLabel}, but comparator data is sparse — try running for longer to compare.`;
+  }
+
+  const sharedPct = shared / conclusiveSpikes;
   if (sharedPct >= 0.6) {
     return 'Spikes happen across multiple sites at once — likely your network or local infrastructure.';
   }

--- a/src/lib/utils/diagnose-stats.ts
+++ b/src/lib/utils/diagnose-stats.ts
@@ -220,7 +220,7 @@ function correlationHeadline(
   const sharedPct = shared / focusedSpikeCount;
 
   if (sharedPct >= 0.6) {
-    return `Spikes happen across multiple sites at once — likely your network or local infrastructure.`;
+    return 'Spikes happen across multiple sites at once — likely your network or local infrastructure.';
   }
   if (sharedPct <= 0.2) {
     return `Spikes are isolated to ${focusedLabel} — likely that site or its origin, not your connection.`;

--- a/src/lib/utils/verdict.ts
+++ b/src/lib/utils/verdict.ts
@@ -132,7 +132,7 @@ export function computeCausalVerdict(
   threshold: number,
 ): Verdict {
   if (rows.length === 0) {
-    return { tone: 'good', headline: 'Calibrating…' };
+    return { tone: 'good', headline: 'Measuring…' };
   }
 
   const overRows = rows.filter((r) => r.stats.p50 > threshold);
@@ -141,16 +141,19 @@ export function computeCausalVerdict(
   const avgJit = mean(rows.map((r) => r.stats.stddev));
 
   if (overCount === 0 && avgLoss < LOSS_WARN_PERCENT && avgJit < JITTER_WARN_MS) {
-    return { tone: 'good', headline: 'All links within tolerance.' };
+    return { tone: 'good', headline: 'Everything looks normal.' };
   }
 
   const phaseCounts = countByPhase(rows, threshold);
   const topPhase = topPhaseWithCount(phaseCounts);
 
+  // ≥2 endpoints sharing a slow phase → likely shared cause (network/local infra),
+  // not a per-site issue. Phrase this from the user's perspective rather than
+  // citing the technical phase ("DNS", "TCP") which doesn't help non-engineers act.
   if (overCount >= 2 && topPhase !== null && topPhase.count >= 2) {
     return {
       tone: 'warn',
-      headline: `${PHASE_LABELS[topPhase.phase]} slow on ${topPhase.count} endpoints — likely upstream.`,
+      headline: `${topPhase.count} sites slow at the same time — likely your network.`,
       phase: topPhase.phase,
     };
   }
@@ -159,7 +162,7 @@ export function computeCausalVerdict(
     const bad = overRows[0];
     return {
       tone: 'warn',
-      headline: `${bad.ep.label} degraded alone — endpoint-specific.`,
+      headline: `Only ${bad.ep.label} looks slow — likely that site, not you.`,
       worstEpId: bad.ep.id,
     };
   }
@@ -167,14 +170,14 @@ export function computeCausalVerdict(
   if (avgLoss > LOSS_WARN_PERCENT) {
     return {
       tone: 'warn',
-      headline: `Packet loss elevated to ${avgLoss.toFixed(1)}%.`,
+      headline: `Some requests are failing — ${avgLoss.toFixed(1)}% so far.`,
     };
   }
 
   if (avgJit > JITTER_WARN_MS) {
     return {
       tone: 'warn',
-      headline: `Jitter elevated — σ ${avgJit.toFixed(1)}ms.`,
+      headline: `Latency is bouncing around — connection isn't steady.`,
     };
   }
 
@@ -182,7 +185,7 @@ export function computeCausalVerdict(
     tone: 'warn',
     // Singular form is unreachable — overCount === 1 is handled above by the
     // endpoint-specific branch; this fallback only fires for 0 or ≥2.
-    headline: `${overCount} endpoints above threshold.`,
+    headline: `${overCount} sites are slow.`,
   };
 }
 

--- a/src/lib/utils/verdict.ts
+++ b/src/lib/utils/verdict.ts
@@ -181,10 +181,18 @@ export function computeCausalVerdict(
     };
   }
 
+  // Equality-edge guard: if everyone's under threshold AND the strict-greater-than
+  // loss/jitter checks didn't match (because avgLoss === LOSS_WARN_PERCENT or
+  // avgJit === JITTER_WARN_MS exactly), we'd otherwise render a nonsensical
+  // "0 sites are slow." Surface the all-healthy verdict instead.
+  if (overCount === 0) {
+    return { tone: 'good', headline: 'Everything looks normal.' };
+  }
+
   return {
     tone: 'warn',
     // Singular form is unreachable — overCount === 1 is handled above by the
-    // endpoint-specific branch; this fallback only fires for 0 or ≥2.
+    // endpoint-specific branch; this fallback only fires for ≥2.
     headline: `${overCount} sites are slow.`,
   };
 }

--- a/src/lib/utils/verdict.ts
+++ b/src/lib/utils/verdict.ts
@@ -177,7 +177,7 @@ export function computeCausalVerdict(
   if (avgJit > JITTER_WARN_MS) {
     return {
       tone: 'warn',
-      headline: `Latency is bouncing around — connection isn't steady.`,
+      headline: "Latency is bouncing around — connection isn't steady.",
     };
   }
 

--- a/tests/unit/utils/diagnose-stats.test.ts
+++ b/tests/unit/utils/diagnose-stats.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { buildHistogram, buildCorrelation } from '../../../src/lib/utils/diagnose-stats';
+import type { MeasurementSample } from '../../../src/lib/types';
+
+const okSample = (round: number, latency: number): MeasurementSample => ({
+  round,
+  latency,
+  status: 'ok',
+  errorMessage: null,
+  startedAt: 0,
+  finishedAt: latency,
+});
+
+const badSample = (round: number, status: 'timeout' | 'error'): MeasurementSample => ({
+  round,
+  latency: null,
+  status,
+  errorMessage: status === 'error' ? 'failed' : null,
+  startedAt: 0,
+  finishedAt: 0,
+});
+
+describe('buildHistogram', () => {
+  it('returns empty bins when fewer than 2 samples', () => {
+    const h = buildHistogram([okSample(1, 50)]);
+    expect(h.bins).toEqual([]);
+    expect(h.maxCount).toBe(0);
+    expect(h.total).toBe(1);
+  });
+
+  it('returns empty bins when all samples have the same latency', () => {
+    const h = buildHistogram([okSample(1, 50), okSample(2, 50), okSample(3, 50)]);
+    expect(h.bins).toEqual([]);
+    expect(h.maxCount).toBe(0);
+  });
+
+  it('ignores non-OK samples', () => {
+    const h = buildHistogram([okSample(1, 50), okSample(2, 100), badSample(3, 'timeout'), badSample(4, 'error')]);
+    expect(h.total).toBe(2);
+  });
+
+  it('distributes samples across the requested bin count', () => {
+    const samples = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100].map((v, i) => okSample(i, v));
+    const h = buildHistogram(samples, 5);
+    expect(h.bins).toHaveLength(5);
+    // Bins evenly spaced from 10 to 100 → 90 / 5 = 18 ms each.
+    expect(h.bins[0]?.fromMs).toBe(10);
+    expect(h.bins[4]?.toMs).toBe(100);
+    // Each bin should have 2 samples (last bin includes upper edge).
+    expect(h.bins.every(b => b.count >= 1)).toBe(true);
+    expect(h.maxCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('puts max-valued samples in the last bin (inclusive upper edge)', () => {
+    const samples = [10, 100, 100].map((v, i) => okSample(i, v));
+    const h = buildHistogram(samples, 5);
+    // The max sample (100) must be counted somewhere — without the inclusive
+    // last-bin rule it would fall through.
+    const total = h.bins.reduce((sum, b) => sum + b.count, 0);
+    expect(total).toBe(3);
+  });
+});
+
+describe('buildCorrelation', () => {
+  const focused = {
+    id: 'edge',
+    label: 'Edge',
+    samples: [okSample(1, 50), okSample(2, 52), okSample(3, 51), okSample(4, 200), okSample(5, 49)],
+  };
+
+  it('produces a row per endpoint with cells for each round in the window', () => {
+    const others = [
+      { id: 'g', label: 'Google', samples: [okSample(1, 80), okSample(2, 82), okSample(3, 79), okSample(4, 81), okSample(5, 78)] },
+    ];
+    const result = buildCorrelation(focused, others);
+    expect(result.rows).toHaveLength(2);
+    expect(result.rows[0]?.endpointId).toBe('edge');
+    expect(result.rows[1]?.endpointId).toBe('g');
+    expect(result.rows[0]?.cells).toHaveLength(5);
+  });
+
+  it('marks a sample as a spike when it exceeds 1.5x the endpoint median', () => {
+    const result = buildCorrelation(focused, []);
+    const focusedRow = result.rows[0]!;
+    // median of [50, 52, 51, 200, 49] is 51 → 1.5x = 76.5 → only 200 is a spike
+    const spikeRounds = focusedRow.cells.filter(c => c.isSpike).map(c => c.round);
+    expect(spikeRounds).toEqual([4]);
+  });
+
+  it('verdict says isolated when other endpoints did NOT spike on the focused-spike rounds', () => {
+    const others = [
+      { id: 'g', label: 'Google', samples: [okSample(1, 80), okSample(2, 82), okSample(3, 79), okSample(4, 81), okSample(5, 78)] },
+      { id: 'a', label: 'AWS', samples: [okSample(1, 35), okSample(2, 36), okSample(3, 34), okSample(4, 36), okSample(5, 35)] },
+    ];
+    const result = buildCorrelation(focused, others);
+    expect(result.verdict.focusedSpikeRounds).toEqual([4]);
+    // Neither Google nor AWS spiked at round 4
+    expect(result.verdict.otherSpikesPerFocusedSpike).toEqual([0]);
+    expect(result.verdict.headline).toContain('isolated to Edge');
+    expect(result.verdict.headline).toContain('that site');
+  });
+
+  it('verdict says network-wide when most others spiked alongside focused', () => {
+    // Focused spikes on round 4 (200ms vs median 51).
+    // Both others ALSO spike on round 4.
+    const others = [
+      { id: 'g', label: 'Google', samples: [okSample(1, 80), okSample(2, 82), okSample(3, 79), okSample(4, 250), okSample(5, 78)] },
+      { id: 'a', label: 'AWS', samples: [okSample(1, 35), okSample(2, 36), okSample(3, 34), okSample(4, 100), okSample(5, 35)] },
+    ];
+    const result = buildCorrelation(focused, others);
+    expect(result.verdict.focusedSpikeRounds).toEqual([4]);
+    expect(result.verdict.otherSpikesPerFocusedSpike[0]).toBeGreaterThanOrEqual(1);
+    expect(result.verdict.headline).toContain('network');
+  });
+
+  it('verdict acknowledges no spikes', () => {
+    const steady = {
+      id: 'edge',
+      label: 'Edge',
+      samples: [okSample(1, 50), okSample(2, 52), okSample(3, 51), okSample(4, 50), okSample(5, 53)],
+    };
+    const result = buildCorrelation(steady, [{ id: 'g', label: 'Google', samples: [okSample(1, 80), okSample(2, 82), okSample(3, 79), okSample(4, 81), okSample(5, 78)] }]);
+    expect(result.verdict.focusedSpikeRounds).toEqual([]);
+    expect(result.verdict.headline).toContain('steady');
+    expect(result.verdict.headline).toContain('no notable spikes');
+  });
+
+  it('verdict prompts for comparison endpoints when only the focused one is provided', () => {
+    const result = buildCorrelation(focused, []);
+    expect(result.verdict.headline).toContain('compare');
+  });
+
+  it('cells with no sample for the round are null and not spikes', () => {
+    const sparse = {
+      id: 'edge',
+      label: 'Edge',
+      samples: [okSample(1, 50), okSample(3, 51)],
+    };
+    const others = [{ id: 'g', label: 'Google', samples: [okSample(1, 80), okSample(2, 82), okSample(3, 79)] }];
+    const result = buildCorrelation(sparse, others, 5);
+    const sparseRow = result.rows[0]!;
+    // Round 2 (the gap in `sparse`) should be null
+    const round2 = sparseRow.cells.find(c => c.round === 2);
+    expect(round2?.latencyMs).toBeNull();
+    expect(round2?.isSpike).toBe(false);
+  });
+});

--- a/tests/unit/utils/diagnose-stats.test.ts
+++ b/tests/unit/utils/diagnose-stats.test.ts
@@ -156,6 +156,25 @@ describe('buildCorrelation', () => {
     expect(result.verdict.headline).toContain('no successful samples');
   });
 
+  it('verdict says "no recent samples in this window" when focused has history but the window is empty', () => {
+    // Focused has plenty of OK samples but they're all in old rounds 1-12.
+    // Comparators have data in rounds 50-65. The window slice picks the
+    // highest 16 rounds (50-65) → focused has no cells, comparators do.
+    const focusedOld = {
+      id: 'edge', label: 'Edge',
+      samples: Array.from({ length: 12 }, (_, i) => okSample(i + 1, 50)),
+    };
+    const recentComparator = {
+      id: 'g', label: 'Google',
+      samples: Array.from({ length: 16 }, (_, i) => okSample(i + 50, 80)),
+    };
+    const result = buildCorrelation(focusedOld, [recentComparator]);
+    // Must NOT say "steady" — we have no data for focused in this window.
+    expect(result.verdict.headline).not.toContain('steady');
+    expect(result.verdict.headline).toContain('No recent samples');
+    expect(result.verdict.headline).toContain('Edge');
+  });
+
   it('verdict says "still learning baseline" when focused has too few OK samples', () => {
     const earlyDays = {
       id: 'edge', label: 'Edge',

--- a/tests/unit/utils/diagnose-stats.test.ts
+++ b/tests/unit/utils/diagnose-stats.test.ts
@@ -2,22 +2,21 @@ import { describe, it, expect } from 'vitest';
 import { buildHistogram, buildCorrelation } from '../../../src/lib/utils/diagnose-stats';
 import type { MeasurementSample } from '../../../src/lib/types';
 
+// Test factories matched to the actual MeasurementSample shape:
+// { round, latency: number, status, timestamp, tier2?, errorMessage?, timingFallback? }
 const okSample = (round: number, latency: number): MeasurementSample => ({
   round,
   latency,
   status: 'ok',
-  errorMessage: null,
-  startedAt: 0,
-  finishedAt: latency,
+  timestamp: 0,
 });
 
 const badSample = (round: number, status: 'timeout' | 'error'): MeasurementSample => ({
   round,
-  latency: null,
+  latency: 0,
   status,
-  errorMessage: status === 'error' ? 'failed' : null,
-  startedAt: 0,
-  finishedAt: 0,
+  timestamp: 0,
+  ...(status === 'error' ? { errorMessage: 'failed' } : {}),
 });
 
 describe('buildHistogram', () => {
@@ -79,55 +78,110 @@ describe('buildCorrelation', () => {
     expect(result.rows[0]?.cells).toHaveLength(5);
   });
 
-  it('marks a sample as a spike when it exceeds 1.5x the endpoint median', () => {
+  it('does NOT mark spikes when focused has fewer than the minimum baseline samples', () => {
+    // 5 samples is below the 8-sample minimum — median is too noisy to call spikes from
     const result = buildCorrelation(focused, []);
     const focusedRow = result.rows[0]!;
-    // median of [50, 52, 51, 200, 49] is 51 → 1.5x = 76.5 → only 200 is a spike
     const spikeRounds = focusedRow.cells.filter(c => c.isSpike).map(c => c.round);
-    expect(spikeRounds).toEqual([4]);
+    expect(spikeRounds).toEqual([]);
+  });
+
+  it('marks a sample as a spike once enough baseline samples exist', () => {
+    // 10 samples — over the 8-sample threshold — with one obvious outlier.
+    const wide = {
+      id: 'edge', label: 'Edge',
+      samples: [50, 52, 51, 49, 53, 50, 51, 52, 200, 49].map((v, i) => okSample(i + 1, v)),
+    };
+    const result = buildCorrelation(wide, []);
+    const focusedRow = result.rows[0]!;
+    const spikeRounds = focusedRow.cells.filter(c => c.isSpike).map(c => c.round);
+    expect(spikeRounds).toEqual([9]); // round 9 = the 200ms outlier
+  });
+
+  // Helpers for the larger samples needed once spike detection requires ≥8 OK samples
+  const longSeries = (label: string, normal: number, spikeAt: number, spikeMs: number): { id: string; label: string; samples: MeasurementSample[] } => ({
+    id: label.toLowerCase(),
+    label,
+    samples: Array.from({ length: 16 }, (_, i) => okSample(i + 1, i + 1 === spikeAt ? spikeMs : normal)),
   });
 
   it('verdict says isolated when other endpoints did NOT spike on the focused-spike rounds', () => {
-    const others = [
-      { id: 'g', label: 'Google', samples: [okSample(1, 80), okSample(2, 82), okSample(3, 79), okSample(4, 81), okSample(5, 78)] },
-      { id: 'a', label: 'AWS', samples: [okSample(1, 35), okSample(2, 36), okSample(3, 34), okSample(4, 36), okSample(5, 35)] },
-    ];
-    const result = buildCorrelation(focused, others);
-    expect(result.verdict.focusedSpikeRounds).toEqual([4]);
-    // Neither Google nor AWS spiked at round 4
+    const focusedLong = longSeries('Edge', 50, 8, 200);
+    const others = [longSeries('Google', 80, 0, 0), longSeries('AWS', 35, 0, 0)];
+    const result = buildCorrelation(focusedLong, others);
+    expect(result.verdict.focusedSpikeRounds).toEqual([8]);
     expect(result.verdict.otherSpikesPerFocusedSpike).toEqual([0]);
     expect(result.verdict.headline).toContain('isolated to Edge');
     expect(result.verdict.headline).toContain('that site');
   });
 
   it('verdict says network-wide when most others spiked alongside focused', () => {
-    // Focused spikes on round 4 (200ms vs median 51).
-    // Both others ALSO spike on round 4.
-    const others = [
-      { id: 'g', label: 'Google', samples: [okSample(1, 80), okSample(2, 82), okSample(3, 79), okSample(4, 250), okSample(5, 78)] },
-      { id: 'a', label: 'AWS', samples: [okSample(1, 35), okSample(2, 36), okSample(3, 34), okSample(4, 100), okSample(5, 35)] },
-    ];
-    const result = buildCorrelation(focused, others);
-    expect(result.verdict.focusedSpikeRounds).toEqual([4]);
+    const focusedLong = longSeries('Edge', 50, 8, 200);
+    const others = [longSeries('Google', 80, 8, 250), longSeries('AWS', 35, 8, 100)];
+    const result = buildCorrelation(focusedLong, others);
+    expect(result.verdict.focusedSpikeRounds).toEqual([8]);
     expect(result.verdict.otherSpikesPerFocusedSpike[0]).toBeGreaterThanOrEqual(1);
     expect(result.verdict.headline).toContain('network');
   });
 
   it('verdict acknowledges no spikes', () => {
     const steady = {
-      id: 'edge',
-      label: 'Edge',
-      samples: [okSample(1, 50), okSample(2, 52), okSample(3, 51), okSample(4, 50), okSample(5, 53)],
+      id: 'edge', label: 'Edge',
+      samples: Array.from({ length: 12 }, (_, i) => okSample(i + 1, 50 + (i % 3))),
     };
-    const result = buildCorrelation(steady, [{ id: 'g', label: 'Google', samples: [okSample(1, 80), okSample(2, 82), okSample(3, 79), okSample(4, 81), okSample(5, 78)] }]);
+    const result = buildCorrelation(steady, [longSeries('Google', 80, 0, 0)]);
     expect(result.verdict.focusedSpikeRounds).toEqual([]);
     expect(result.verdict.headline).toContain('steady');
     expect(result.verdict.headline).toContain('no notable spikes');
   });
 
   it('verdict prompts for comparison endpoints when only the focused one is provided', () => {
-    const result = buildCorrelation(focused, []);
+    const focusedLong = longSeries('Edge', 50, 0, 0);
+    const result = buildCorrelation(focusedLong, []);
     expect(result.verdict.headline).toContain('compare');
+  });
+
+  // Silent-failure regression guards — these cases previously produced misleading
+  // "steady" or "isolated" verdicts when the underlying data was actually broken
+  // or sparse.
+
+  it('verdict says "no successful samples" when focused has all-failed samples', () => {
+    const allFailed = {
+      id: 'edge', label: 'Edge',
+      samples: Array.from({ length: 8 }, (_, i) => badSample(i + 1, 'timeout')),
+    };
+    const result = buildCorrelation(allFailed, [longSeries('Google', 80, 0, 0)]);
+    // Must NOT say "steady" — that would conflict with the all-failed reality.
+    expect(result.verdict.headline).not.toContain('steady');
+    expect(result.verdict.headline).toContain('no successful samples');
+  });
+
+  it('verdict says "still learning baseline" when focused has too few OK samples', () => {
+    const earlyDays = {
+      id: 'edge', label: 'Edge',
+      samples: [okSample(1, 50), okSample(2, 52), okSample(3, 51)],
+    };
+    const result = buildCorrelation(earlyDays, [longSeries('Google', 80, 0, 0)]);
+    expect(result.verdict.headline).toContain('learning');
+    expect(result.verdict.headline).toContain('Edge');
+  });
+
+  it('verdict acknowledges sparse comparator data when comparators have gaps on spike rounds', () => {
+    // Focused has a clear spike at round 8. Both comparators happen to have
+    // non-OK samples for that exact round → their cells are null. The old
+    // logic would call this "isolated to Edge" because nulls counted as
+    // "did not spike". The new logic flags it as inconclusive.
+    const focusedLong = longSeries('Edge', 50, 8, 200);
+    const sparseAtSpike = (label: string): { id: string; label: string; samples: MeasurementSample[] } => ({
+      id: label.toLowerCase(),
+      label,
+      samples: Array.from({ length: 16 }, (_, i) => i + 1 === 8 ? badSample(i + 1, 'timeout') : okSample(i + 1, 80)),
+    });
+    const result = buildCorrelation(focusedLong, [sparseAtSpike('Google'), sparseAtSpike('AWS')]);
+    expect(result.verdict.focusedSpikeRounds).toEqual([8]);
+    // Headline must NOT confidently claim "isolated" when comparators had gaps.
+    expect(result.verdict.headline).not.toContain('isolated');
+    expect(result.verdict.headline).toContain('sparse');
   });
 
   it('cells with no sample for the round are null and not spikes', () => {

--- a/tests/unit/verdict.test.ts
+++ b/tests/unit/verdict.test.ts
@@ -224,6 +224,29 @@ describe('computeCausalVerdict — fallback', () => {
     expect(v.headline).toBe('2 sites are slow.');
   });
 
+  it('returns the all-healthy verdict on equality-edge avgLoss === LOSS_WARN_PERCENT', () => {
+    // Strict comparisons in the all-healthy guard and the loss branch both use
+    // strict <, > — so avgLoss === 1.0 (the threshold) used to fall through to
+    // the "0 sites are slow." fallback nonsense. Regression guard.
+    const rows = [
+      makeRow({ id: 'a', label: 'a' }, { p50: 40, lossPercent: 1.0 }),
+      makeRow({ id: 'b', label: 'b' }, { p50: 50, lossPercent: 1.0 }),
+    ];
+    const v = computeCausalVerdict(rows, THRESHOLD);
+    expect(v.tone).toBe('good');
+    expect(v.headline).toBe('Everything looks normal.');
+  });
+
+  it('returns the all-healthy verdict on equality-edge avgJit === JITTER_WARN_MS', () => {
+    const rows = [
+      makeRow({ id: 'a', label: 'a' }, { p50: 40, stddev: 25 }),
+      makeRow({ id: 'b', label: 'b' }, { p50: 50, stddev: 25 }),
+    ];
+    const v = computeCausalVerdict(rows, THRESHOLD);
+    expect(v.tone).toBe('good');
+    expect(v.headline).toBe('Everything looks normal.');
+  });
+
   it('endpoint-specific branch pre-empts the count fallback when overCount=1', () => {
     // With a single row over threshold the endpoint-specific branch wins even
     // though tier2 is missing and would otherwise hit the count fallback.

--- a/tests/unit/verdict.test.ts
+++ b/tests/unit/verdict.test.ts
@@ -56,10 +56,10 @@ const THRESHOLD = 120;
 
 // ── Branch 1: empty rows ────────────────────────────────────────────────────
 describe('computeCausalVerdict — empty', () => {
-  it('returns Calibrating… when no rows', () => {
+  it('returns Measuring… when no rows', () => {
     const v = computeCausalVerdict([], THRESHOLD);
     expect(v.tone).toBe('good');
-    expect(v.headline).toBe('Calibrating…');
+    expect(v.headline).toBe('Measuring…');
     expect(v.phase).toBeUndefined();
     expect(v.worstEpId).toBeUndefined();
   });
@@ -67,20 +67,20 @@ describe('computeCausalVerdict — empty', () => {
 
 // ── Branch 2: all-healthy happy path ────────────────────────────────────────
 describe('computeCausalVerdict — all healthy', () => {
-  it('returns "All links within tolerance." when no one is over threshold and loss+jit are low', () => {
+  it('returns "Everything looks normal." when no one is over threshold and loss+jit are low', () => {
     const rows = [
       makeRow({ id: 'a', label: 'a' }, { p50: 40, stddev: 4, lossPercent: 0.2 }),
       makeRow({ id: 'b', label: 'b' }, { p50: 60, stddev: 6, lossPercent: 0.5 }),
     ];
     const v = computeCausalVerdict(rows, THRESHOLD);
     expect(v.tone).toBe('good');
-    expect(v.headline).toBe('All links within tolerance.');
+    expect(v.headline).toBe('Everything looks normal.');
   });
 });
 
 // ── Branch 3: shared-phase upstream ─────────────────────────────────────────
 describe('computeCausalVerdict — shared upstream phase', () => {
-  it('calls out "DNS slow on N endpoints — likely upstream." when ≥2 share DNS dominance', () => {
+  it('calls out shared-network slowness when ≥2 share DNS dominance', () => {
     const rows = [
       makeRow({ id: 'a', label: 'a' }, { p50: 200, tier2Averages: tier2Dominating('dns') }),
       makeRow({ id: 'b', label: 'b' }, { p50: 180, tier2Averages: tier2Dominating('dns') }),
@@ -88,7 +88,8 @@ describe('computeCausalVerdict — shared upstream phase', () => {
     ];
     const v = computeCausalVerdict(rows, THRESHOLD);
     expect(v.tone).toBe('warn');
-    expect(v.headline).toBe('DNS slow on 2 endpoints — likely upstream.');
+    expect(v.headline).toBe('2 sites slow at the same time — likely your network.');
+    // phase still propagates so consumers (color cues, accents) stay deterministic
     expect(v.phase).toBe('dns');
   });
 
@@ -101,7 +102,7 @@ describe('computeCausalVerdict — shared upstream phase', () => {
       makeRow({ id: 'c', label: 'c' }, { p50: 90,  tier2Averages: tier2Dominating('ttfb') }),
     ];
     const v = computeCausalVerdict(rows, THRESHOLD);
-    expect(v.headline).toBe('TTFB slow on 3 endpoints — likely upstream.');
+    expect(v.headline).toBe('3 sites slow at the same time — likely your network.');
     expect(v.phase).toBe('ttfb');
   });
 
@@ -112,7 +113,7 @@ describe('computeCausalVerdict — shared upstream phase', () => {
     ];
     const v = computeCausalVerdict(rows, THRESHOLD);
     // Should fall through to "endpoint-specific" branch (overCount === 1).
-    expect(v.headline).toBe('a degraded alone — endpoint-specific.');
+    expect(v.headline).toBe('Only a looks slow — likely that site, not you.');
     expect(v.worstEpId).toBe(rows[0].ep.id);
   });
 });
@@ -165,7 +166,7 @@ describe('computeCausalVerdict — endpoint-specific', () => {
       makeRow({ id: 'c', label: 'api' },         { p50: 40 }),
     ];
     const v = computeCausalVerdict(rows, THRESHOLD);
-    expect(v.headline).toBe('auth-service degraded alone — endpoint-specific.');
+    expect(v.headline).toBe('Only auth-service looks slow — likely that site, not you.');
     expect(v.worstEpId).toBe(rows[0].ep.id);
   });
 });
@@ -178,7 +179,7 @@ describe('computeCausalVerdict — packet loss', () => {
       makeRow({ id: 'b', label: 'b' }, { p50: 50, lossPercent: 1.2 }),
     ];
     const v = computeCausalVerdict(rows, THRESHOLD);
-    expect(v.headline).toBe('Packet loss elevated to 2.1%.');
+    expect(v.headline).toBe('Some requests are failing — 2.1% so far.');
   });
 
   it('does not cite packet loss when exactly 1 endpoint is over — that branch wins first', () => {
@@ -187,19 +188,19 @@ describe('computeCausalVerdict — packet loss', () => {
       makeRow({ id: 'b', label: 'b' }, { p50: 30,  lossPercent: 0 }),
     ];
     const v = computeCausalVerdict(rows, THRESHOLD);
-    expect(v.headline).toContain('degraded alone');
+    expect(v.headline).toContain('looks slow');
   });
 });
 
 // ── Branch 6: jitter ────────────────────────────────────────────────────────
 describe('computeCausalVerdict — jitter', () => {
-  it('cites jitter when avg stddev > 25ms and no other branch matched', () => {
+  it('cites jitter in plain language when avg stddev > 25ms and no other branch matched', () => {
     const rows = [
       makeRow({ id: 'a', label: 'a' }, { p50: 40, stddev: 30 }),
       makeRow({ id: 'b', label: 'b' }, { p50: 50, stddev: 40 }),
     ];
     const v = computeCausalVerdict(rows, THRESHOLD);
-    expect(v.headline).toBe('Jitter elevated — σ 35.0ms.');
+    expect(v.headline).toBe(`Latency is bouncing around — connection isn't steady.`);
   });
 
   it('packet loss takes precedence over jitter when both elevated', () => {
@@ -207,7 +208,7 @@ describe('computeCausalVerdict — jitter', () => {
       makeRow({ id: 'a', label: 'a' }, { p50: 40, stddev: 40, lossPercent: 5 }),
     ];
     const v = computeCausalVerdict(rows, THRESHOLD);
-    expect(v.headline).toContain('Packet loss');
+    expect(v.headline).toContain('failing');
   });
 });
 
@@ -220,7 +221,7 @@ describe('computeCausalVerdict — fallback', () => {
       makeRow({ id: 'b', label: 'b' }, { p50: 200, tier2Averages: undefined }),
     ];
     const v = computeCausalVerdict(rows, THRESHOLD);
-    expect(v.headline).toBe('2 endpoints above threshold.');
+    expect(v.headline).toBe('2 sites are slow.');
   });
 
   it('endpoint-specific branch pre-empts the count fallback when overCount=1', () => {
@@ -233,7 +234,7 @@ describe('computeCausalVerdict — fallback', () => {
       makeRow({ id: 'a', label: 'a' }, { p50: 200, tier2Averages: undefined }),
     ];
     const v = computeCausalVerdict(rows, THRESHOLD);
-    expect(v.headline).toBe('a degraded alone — endpoint-specific.');
+    expect(v.headline).toBe('Only a looks slow — likely that site, not you.');
     expect(v.worstEpId).toBe(rows[0].ep.id);
   });
 });

--- a/tests/unit/verdict.test.ts
+++ b/tests/unit/verdict.test.ts
@@ -200,7 +200,7 @@ describe('computeCausalVerdict — jitter', () => {
       makeRow({ id: 'b', label: 'b' }, { p50: 50, stddev: 40 }),
     ];
     const v = computeCausalVerdict(rows, THRESHOLD);
-    expect(v.headline).toBe(`Latency is bouncing around — connection isn't steady.`);
+    expect(v.headline).toBe("Latency is bouncing around — connection isn't steady.");
   });
 
   it('packet loss takes precedence over jitter when both elevated', () => {


### PR DESCRIPTION
## Why

Yesterday's live measurement walkthrough confirmed that Diagnose was structurally broken for the only endpoint that actually produced phase data: once QUIC connection reuse kicked in, TTFB-dominance was tautologically true and the verdict reduced to "97% TTFB" regardless of what was happening. The page **claimed** root-cause diagnosis but **delivered** a measurement that didn't vary. A network-engineer friend's "not useful" reaction was ultimately reading the gap between claim and delivery.

This PR fixes the actual broken thing without committing to a full positioning pivot.

## What changes

### Diagnose tab is now content-led, not phase-led

| Old (above the fold) | New (above the fold) |
|---|---|
| Phase waterfall (DNS · TCP · TLS · TTFB · Transfer) | **Distribution** (p50 / p95 / spread + 10-bin histogram) |
| Verdict panel ("Slow TTFB — 97%" tautology) | **Compare with other endpoints** (16-round correlation grid + 1-line verdict) |
| Evidence rows (per-phase percentages) | Phase breakdown — collapsed `<details>`, with a caveat about warm-QUIC + TAO limits |

**Distribution** answers *"what's this endpoint's typical latency, how much does it vary?"* — works without TAO data. The spread ratio is a single-number diagnostic that's never tautological.

**Compare with other endpoints** is the headline diagnostic value: it shows the focused endpoint's last 16 rounds alongside every other monitored endpoint, with spike cells marked. The verdict is one of:

- *"Spikes happen across multiple sites at once — likely your network or local infrastructure."*
- *"Spikes are isolated to {endpoint} — likely that site or its origin, not your connection."*
- *"{endpoint} has been steady — no notable spikes in this window."*

This is the *"is it me or them?"* answer the friend was looking for. It works for TAO-blocked endpoints because it only needs `total` ms.

### Verdict copy in plain language

`utils/verdict.ts`:

| Old | New |
|---|---|
| `"All links within tolerance."` | `"Everything looks normal."` |
| `"DNS slow on 2 endpoints — likely upstream."` | `"2 sites slow at the same time — likely your network."` |
| `"Edge degraded alone — endpoint-specific."` | `"Only Edge looks slow — likely that site, not you."` |
| `"Jitter elevated — σ 27.3ms."` | `"Latency is bouncing around — connection isn't steady."` |
| `"Packet loss elevated to 1.2%."` | `"Some requests are failing — 1.2% so far."` |
| `"Calibrating…"` | `"Measuring…"` |

No σ, no "upstream," no "endpoint-specific."

### Topbar subtitle

`"HTTP latency diagnostic · v2"` → `"HTTP latency monitor · multi-site"`. Drops the "diagnostic" overpromise; "monitor" describes what the tool does (watch); "multi-site" calls out the actual differentiator from speedtest-style single-target tools. Same kicker styling as before — no visual disruption.

### Diagnose tab hint

`"Why is it slow?"` → `"Is it me or them?"`. Matches the new correlation-led content.

## What this PR explicitly does NOT do

- No reframe away from "diagnostic" — page title / `index.html` unchanged.
- No default-endpoint changes; Edge stays.
- No settings simplification.
- No tab structural changes (Diagnose name, Strata/Terminal, etc.).
- No onboarding hero.

Those are defensible reframe moves but none are *broken* — addressing them would commit to a positioning pivot we don't yet have evidence to justify (one network engineer's reaction is N=1 from outside the target market). After this PR ships, ask 2-3 non-engineer testers whether the new Diagnose feels useful; if they bounce, revisit positioning. If they get it within 30 seconds, the work is done.

## Verification

- 712 Vitest pass (700 baseline + 12 new tests for `diagnose-stats` helper)
- `npm run typecheck` clean
- `npm run lint` clean
- Visual verification at 1440×900 desktop and 393×752 mobile (iPhone 14 Pro size) — both render correctly with the new Distribution / Compare / Phase Breakdown sections
- Verdict test sweep: `verdict.test.ts` updated for the new copy, all 22 tests pass

## Files

- `src/lib/utils/diagnose-stats.ts` — new pure helpers: `buildHistogram`, `buildCorrelation`, with `CorrelationVerdict` headlines
- `src/lib/components/DiagnoseView.svelte` — template restructure + CSS for new sections
- `src/lib/utils/verdict.ts` — verdict string table rewritten
- `src/lib/components/Topbar.svelte` — subtitle text
- `src/lib/components/ViewSwitcher.svelte` — Diagnose hint
- `tests/unit/utils/diagnose-stats.test.ts` — new (12 tests)
- `tests/unit/verdict.test.ts` — updated assertions

## Test plan

- [x] Diagnose with focused endpoint shows histogram + correlation as primary content
- [x] Phase breakdown collapsed by default; expands cleanly
- [x] Correlation verdict reads correctly for: isolated spikes, network-wide spikes, steady period, no-other-endpoints case
- [x] Histogram degrades gracefully (empty bins) when fewer than 2 distinct samples
- [x] Verdict strings render in plain language
- [x] Mobile drawer + Diagnose view both readable at 393×752
- [ ] Show to a non-engineer tester after deploy — see if "is it me or them?" reads as useful

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added latency distribution histogram with percentile metrics (p50/p95)
  - Added cross-endpoint correlation grid to compare your performance with other monitored sites
  - Made phase breakdown a collapsible advanced section

* **Improvements**
  - Updated product branding to reflect multi-site monitoring capability
  - Redesigned diagnose view to prioritize distribution analysis
  - Simplified verdict messaging for greater clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->