### PR TITLE
fix(cap): add MAX_CAP=3600 + clamp at every write boundary and engine read

### DIFF
--- a/src/lib/components/FooterBar.svelte
+++ b/src/lib/components/FooterBar.svelte
@@ -16,9 +16,8 @@
   let errorCount = $derived({ errors: $measurementStore.errorCount, timeouts: $measurementStore.timeoutCount });
 
   let progressLabel = $derived.by(() => {
-    const total = cap > 0 ? cap : '∞';
     const { errors, timeouts } = errorCount;
-    const parts: string[] = [`${roundCounter} of ${total} complete`];
+    const parts: string[] = [`${roundCounter} of ${cap} complete`];
     if (errors > 0) parts.push(`${errors} error${errors === 1 ? '' : 's'}`);
     if (timeouts > 0) parts.push(`${timeouts} timeout${timeouts === 1 ? '' : 's'}`);
     if (startedAt !== null) parts.push(`${formatElapsed(elapsed)} elapsed`);

--- a/src/lib/components/SettingsDrawer.svelte
+++ b/src/lib/components/SettingsDrawer.svelte
@@ -10,6 +10,7 @@
   import { endpointStore } from '$lib/stores/endpoints';
   import { clearPersistedSettings } from '$lib/utils/persistence';
   import { DEFAULT_SETTINGS } from '$lib/types';
+  import { clampCap, MAX_CAP } from '$lib/limits';
   import { tokens } from '$lib/tokens';
   import { REGIONS, REGION_DISPLAY_NAMES, detectRegion } from '$lib/regional-defaults';
   import type { Region } from '$lib/regional-defaults';
@@ -122,8 +123,8 @@
 
   function applyCap(e: Event): void {
     const raw = parseInt((e.target as HTMLInputElement).value, 10);
-    if (isNaN(raw)) return;
-    const val = Math.max(0, Math.min(10000, raw));
+    if (isNaN(raw)) return; // preserve previous value on empty input — matches sibling apply functions
+    const val = clampCap(raw);
     cap = val;
     settingsStore.update(s => ({ ...s, cap: val }));
   }
@@ -282,9 +283,9 @@
       <div class="field">
         <label class="field-label" for="setting-cap">
           Round cap
-          <span class="field-hint">0 = unlimited</span>
+          <span class="field-hint">1–{MAX_CAP} rounds</span>
         </label>
-        <input id="setting-cap" type="number" class="field-input" min="0" max="10000" step="1" bind:value={cap} onchange={applyCap} />
+        <input id="setting-cap" type="number" class="field-input" min="1" max={MAX_CAP} step="1" bind:value={cap} onchange={applyCap} />
       </div>
 
       <!-- CORS mode -->

--- a/src/lib/engine/measurement-engine.ts
+++ b/src/lib/engine/measurement-engine.ts
@@ -12,6 +12,7 @@ import type { WorkerFactory } from './worker-factory';
 import type { Endpoint } from '../types';
 import type { MainToWorkerMessage, WorkerToMainMessage } from '../types';
 import { isSafeProbeUrl } from '../utils/url-safety';
+import { clampCap } from '../limits';
 
 interface ManagedWorker {
   worker: Worker;
@@ -331,7 +332,11 @@ export class MeasurementEngine {
     const { timeout, corsMode, cap } = get(settingsStore);
     const { epoch, roundCounter } = get(measurementStore);
 
-    if (cap > 0 && roundCounter >= cap) {
+    const effectiveCap = clampCap(cap);
+    if (cap !== effectiveCap) {
+      console.warn(`[Chronoscope] settings.cap (${cap}) was out of range at engine read — parse-path bypass suspected`);
+    }
+    if (roundCounter >= effectiveCap) {
       measurementStore.setLifecycle('completed');
       return;
     }

--- a/src/lib/engine/measurement-engine.ts
+++ b/src/lib/engine/measurement-engine.ts
@@ -30,6 +30,10 @@ export class MeasurementEngine {
   private lastFlushedRound = -1;
   _paused = false;
   private _visibilityHandler: (() => void) | null = null;
+  // Engine-side cap clamp regression detector. Reset per session in start().
+  // Once-per-session cadence prevents 3600× warn spam if a parse-path bypass
+  // ever puts cap > MAX_CAP into settingsStore.
+  private _capWarnEmitted = false;
 
   constructor(workerFactory?: WorkerFactory) {
     this.workerFactory = workerFactory ?? defaultWorkerFactory;
@@ -50,6 +54,7 @@ export class MeasurementEngine {
     // Step 1: increment epoch and transition lifecycle — always happens.
     measurementStore.incrementEpoch();
     measurementStore.setLifecycle('starting');
+    this._capWarnEmitted = false;
 
     // Preserve startedAt across stop/start cycles so elapsed time is cumulative.
     // Only set on first start (idle → running).
@@ -333,8 +338,9 @@ export class MeasurementEngine {
     const { epoch, roundCounter } = get(measurementStore);
 
     const effectiveCap = clampCap(cap);
-    if (cap !== effectiveCap) {
+    if (cap !== effectiveCap && !this._capWarnEmitted) {
       console.warn(`[Chronoscope] settings.cap (${cap}) was out of range at engine read — parse-path bypass suspected`);
+      this._capWarnEmitted = true;
     }
     if (roundCounter >= effectiveCap) {
       measurementStore.setLifecycle('completed');

--- a/src/lib/limits.ts
+++ b/src/lib/limits.ts
@@ -1,0 +1,34 @@
+// src/lib/limits.ts
+// Safety-critical bounds for the measurement engine.
+// MAX_CAP is not a security boundary — it is functionality abuse mitigation
+// (OWASP DoS Cheat Sheet + API4:2023 Unrestricted Resource Consumption).
+// Client-side code cannot defend against determined attackers who modify the
+// JS bundle; this prevents non-malicious volume problems and raises the bar
+// against casual tampering.
+
+/** Maximum number of rounds a measurement session may run. */
+export const MAX_CAP = 3600;
+
+/**
+ * Clamp an arbitrary input to a finite integer in [1, MAX_CAP].
+ *
+ * Contract:
+ *   - Finite integer in [1, MAX_CAP]    → returned unchanged
+ *   - Finite integer > MAX_CAP          → MAX_CAP
+ *   - 0 (legacy "unlimited" sentinel)   → MAX_CAP (preserves user intent as "max")
+ *   - Finite integer < 0 (negative)     → 1 (minimum)
+ *   - Finite non-integer (e.g., 100.5)  → Math.round(n) then re-clamp
+ *   - NaN, Infinity, -Infinity          → MAX_CAP (garbage in → safe default)
+ *   - Non-numeric (string, null, etc.)  → MAX_CAP (parse failure → safe default)
+ *
+ * CRITICAL: this function MUST never return NaN. roundCounter >= NaN is always
+ * false, which would silently disable the engine cap check entirely.
+ */
+export function clampCap(n: unknown): number {
+  if (typeof n !== 'number' || !Number.isFinite(n)) return MAX_CAP;
+  if (n === 0) return MAX_CAP; // legacy "unlimited" sentinel
+  const rounded = Math.round(n);
+  if (rounded < 1) return 1;
+  if (rounded > MAX_CAP) return MAX_CAP;
+  return rounded;
+}

--- a/src/lib/share/share-manager.ts
+++ b/src/lib/share/share-manager.ts
@@ -5,6 +5,7 @@
 import LZString from 'lz-string';
 import type { SharePayload, Settings } from '../types';
 import { isSafeSharedUrl } from '../utils/url-safety';
+import { MAX_CAP } from '../limits';
 
 // ── Share settings helper ──────────────────────────────────────────────────
 // Explicitly destructures only the 6 allowed share fields.
@@ -85,7 +86,7 @@ function validateSharePayload(data: unknown): SharePayload | null {
   const s = settings as Record<string, unknown>;
   if (!isNonNegativeFiniteNumber(s['timeout']) || (s['timeout'] as number) > 15000) return null;
   if (!isNonNegativeFiniteNumber(s['delay'])) return null;
-  if (!isNonNegativeFiniteNumber(s['cap']) || (s['cap'] as number) > 10000) return null;
+  if (!isNonNegativeFiniteNumber(s['cap']) || (s['cap'] as number) > MAX_CAP) return null;
   if (s['burstRounds'] !== undefined && (!isNonNegativeFiniteNumber(s['burstRounds']) || (s['burstRounds'] as number) > 500)) return null;
   if (s['monitorDelay'] !== undefined && (!isNonNegativeFiniteNumber(s['monitorDelay']) || (s['monitorDelay'] as number) > 60000)) return null;
   if (s['corsMode'] !== 'no-cors' && s['corsMode'] !== 'cors') return null;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,6 +3,7 @@
 // share payloads are defined here. No logic — only types and interfaces.
 
 import type { Region } from './regional-defaults';
+import { MAX_CAP } from './limits';
 
 // ── Lifecycle ──────────────────────────────────────────────────────────────
 export type TestLifecycleState =
@@ -203,7 +204,7 @@ export const DEFAULT_SETTINGS: Settings = {
   delay: 0,
   burstRounds: 50,
   monitorDelay: 1000,
-  cap: 0,
+  cap: MAX_CAP, // 3600 — sessions complete after 1 hour by default
   corsMode: 'no-cors',
   healthThreshold: 120,
 };

--- a/src/lib/utils/persistence.ts
+++ b/src/lib/utils/persistence.ts
@@ -9,6 +9,7 @@ import { DEFAULT_SETTINGS } from '../types';
 import { isValidRegion } from '../regional-defaults';
 import { isSafeProbeUrl } from './url-safety';
 import { isValidNickname } from '../endpoint/displayLabel';
+import { clampCap } from '../limits';
 import type {
   ActiveView,
   LiveTimeRange,
@@ -205,7 +206,7 @@ function readSettingsField(record: Record<string, unknown>): Settings {
     delay:           typeof raw['delay']           === 'number' ? raw['delay']           : DEFAULT_SETTINGS.delay,
     burstRounds:     typeof raw['burstRounds']     === 'number' ? raw['burstRounds']     : DEFAULT_SETTINGS.burstRounds,
     monitorDelay:    typeof raw['monitorDelay']    === 'number' ? raw['monitorDelay']    : DEFAULT_SETTINGS.monitorDelay,
-    cap:             typeof raw['cap']             === 'number' ? raw['cap']             : DEFAULT_SETTINGS.cap,
+    cap:             clampCap(raw['cap']),
     healthThreshold: typeof raw['healthThreshold'] === 'number' ? raw['healthThreshold'] : DEFAULT_SETTINGS.healthThreshold,
     corsMode,
     ...(region !== undefined ? { region } : {}),

--- a/tests/unit/components/footer-bar.test.ts
+++ b/tests/unit/components/footer-bar.test.ts
@@ -1,8 +1,15 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { render } from '@testing-library/svelte';
 import FooterBar from '../../../src/lib/components/FooterBar.svelte';
+import { settingsStore } from '../../../src/lib/stores/settings';
+import { MAX_CAP } from '../../../src/lib/limits';
+import { DEFAULT_SETTINGS } from '../../../src/lib/types';
 
 describe('FooterBar', () => {
+  beforeEach(() => {
+    settingsStore.set({ ...DEFAULT_SETTINGS, region: undefined });
+  });
+
   it('renders "Measuring from your browser" text', () => {
     const { getByText } = render(FooterBar, { props: {} });
     expect(getByText(/Measuring from your browser/i)).toBeTruthy();
@@ -23,5 +30,25 @@ describe('FooterBar', () => {
     const highlight = container.querySelector('.highlight');
     expect(highlight).not.toBeNull();
     expect(highlight?.textContent).toContain('Measuring from your browser');
+  });
+});
+
+describe('FooterBar — AC5: no infinity glyph', () => {
+  beforeEach(() => {
+    settingsStore.set({ ...DEFAULT_SETTINGS, region: undefined });
+  });
+
+  it.each([1, 100, MAX_CAP])('renders no ∞ glyph when cap = %i', (capValue) => {
+    settingsStore.update(s => ({ ...s, cap: capValue }));
+    const { container } = render(FooterBar, { props: {} });
+    expect(container.textContent).not.toContain('∞');
+  });
+
+  it('progress label interpolates cap directly as a number', () => {
+    settingsStore.update(s => ({ ...s, cap: 42 }));
+    const { container } = render(FooterBar, { props: {} });
+    // "0 of 42 complete" — cap appears as a digit, not ∞
+    expect(container.textContent).toContain('42');
+    expect(container.textContent).not.toContain('∞');
   });
 });

--- a/tests/unit/components/footer-bar.test.ts
+++ b/tests/unit/components/footer-bar.test.ts
@@ -5,11 +5,13 @@ import { settingsStore } from '../../../src/lib/stores/settings';
 import { MAX_CAP } from '../../../src/lib/limits';
 import { DEFAULT_SETTINGS } from '../../../src/lib/types';
 
-describe('FooterBar', () => {
-  beforeEach(() => {
-    settingsStore.set({ ...DEFAULT_SETTINGS, region: undefined });
-  });
+// File-level reset so settingsStore.cap doesn't leak between tests or describe
+// blocks; each test sets cap explicitly when needed.
+beforeEach(() => {
+  settingsStore.set({ ...DEFAULT_SETTINGS, region: undefined });
+});
 
+describe('FooterBar', () => {
   it('renders "Measuring from your browser" text', () => {
     const { getByText } = render(FooterBar, { props: {} });
     expect(getByText(/Measuring from your browser/i)).toBeTruthy();
@@ -34,10 +36,6 @@ describe('FooterBar', () => {
 });
 
 describe('FooterBar — AC5: no infinity glyph', () => {
-  beforeEach(() => {
-    settingsStore.set({ ...DEFAULT_SETTINGS, region: undefined });
-  });
-
   it.each([1, 100, MAX_CAP])('renders no ∞ glyph when cap = %i', (capValue) => {
     settingsStore.update(s => ({ ...s, cap: capValue }));
     const { container } = render(FooterBar, { props: {} });

--- a/tests/unit/components/settings-drawer.test.ts
+++ b/tests/unit/components/settings-drawer.test.ts
@@ -1,0 +1,85 @@
+// tests/unit/components/settings-drawer.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+import SettingsDrawer from '../../../src/lib/components/SettingsDrawer.svelte';
+import { settingsStore } from '../../../src/lib/stores/settings';
+import { uiStore } from '../../../src/lib/stores/ui';
+import { MAX_CAP } from '../../../src/lib/limits';
+
+beforeEach(() => {
+  settingsStore.reset();
+  uiStore.reset();
+  // Ensure drawer is open BEFORE rendering so dialog content is in the initial DOM.
+  // uiStore initial state has showSettings: false; toggleSettings() flips to true.
+  uiStore.toggleSettings();
+});
+
+describe('SettingsDrawer — AC3: cap input constraints', () => {
+  it('cap input has max attribute of MAX_CAP (3600)', () => {
+    const { container } = render(SettingsDrawer, { props: {} });
+    const input = container.querySelector('#setting-cap') as HTMLInputElement | null;
+    // Sanity: if this assertion fails, the drawer did not mount — check uiStore.toggleSettings() ordering above.
+    expect(input, 'cap input not found in DOM — drawer may not have mounted').not.toBeNull();
+    if (!input) return;
+    expect(input.getAttribute('max')).toBe(String(MAX_CAP));
+  });
+
+  it('cap input has min attribute of 1', () => {
+    const { container } = render(SettingsDrawer, { props: {} });
+    const input = container.querySelector('#setting-cap') as HTMLInputElement | null;
+    expect(input, 'cap input not found in DOM — drawer may not have mounted').not.toBeNull();
+    if (!input) return;
+    expect(input.getAttribute('min')).toBe('1');
+  });
+
+  it('applyCap clamps value above MAX_CAP to MAX_CAP', async () => {
+    const { container } = render(SettingsDrawer, { props: {} });
+    const input = container.querySelector('#setting-cap') as HTMLInputElement | null;
+    expect(input, 'cap input not found in DOM — drawer may not have mounted').not.toBeNull();
+    if (!input) return;
+    // Simulate user typing 9999
+    input.value = '9999';
+    await fireEvent.change(input);
+    expect(get(settingsStore).cap).toBe(MAX_CAP);
+  });
+
+  it('applyCap clamps 0 to MAX_CAP (legacy unlimited sentinel)', async () => {
+    const { container } = render(SettingsDrawer, { props: {} });
+    const input = container.querySelector('#setting-cap') as HTMLInputElement | null;
+    expect(input, 'cap input not found in DOM — drawer may not have mounted').not.toBeNull();
+    if (!input) return;
+    input.value = '0';
+    await fireEvent.change(input);
+    expect(get(settingsStore).cap).toBe(MAX_CAP);
+  });
+
+  it('applyCap clamps negative value to 1', async () => {
+    const { container } = render(SettingsDrawer, { props: {} });
+    const input = container.querySelector('#setting-cap') as HTMLInputElement | null;
+    expect(input, 'cap input not found in DOM — drawer may not have mounted').not.toBeNull();
+    if (!input) return;
+    input.value = '-100';
+    await fireEvent.change(input);
+    expect(get(settingsStore).cap).toBe(1);
+  });
+
+  it('applyCap accepts valid value in range', async () => {
+    const { container } = render(SettingsDrawer, { props: {} });
+    const input = container.querySelector('#setting-cap') as HTMLInputElement | null;
+    expect(input, 'cap input not found in DOM — drawer may not have mounted').not.toBeNull();
+    if (!input) return;
+    input.value = '500';
+    await fireEvent.change(input);
+    expect(get(settingsStore).cap).toBe(500);
+  });
+
+  it('hint text reflects new range (no "0 = unlimited")', () => {
+    const { container } = render(SettingsDrawer, { props: {} });
+    const hints = container.querySelectorAll('.field-hint');
+    const capHints = Array.from(hints).map(h => h.textContent ?? '');
+    expect(capHints.some(h => h.includes('0 = unlimited'))).toBe(false);
+    // Hint should reference MAX_CAP
+    expect(capHints.some(h => h.includes(String(MAX_CAP)))).toBe(true);
+  });
+});

--- a/tests/unit/limits.test.ts
+++ b/tests/unit/limits.test.ts
@@ -1,0 +1,130 @@
+// tests/unit/limits.test.ts
+import { describe, it, expect } from 'vitest';
+import { clampCap, MAX_CAP } from '../../src/lib/limits';
+
+describe('clampCap', () => {
+  // ── Pass-through: valid inputs ─────────────────────────────────────────────
+
+  it('returns 1 unchanged (minimum valid)', () => {
+    expect(clampCap(1)).toBe(1);
+  });
+
+  it('returns MAX_CAP unchanged (maximum valid)', () => {
+    expect(clampCap(MAX_CAP)).toBe(MAX_CAP);
+  });
+
+  it('returns a mid-range integer unchanged', () => {
+    expect(clampCap(100)).toBe(100);
+  });
+
+  // ── Upper clamp ─────────────────────────────────────────────────────────────
+
+  it('clamps value above MAX_CAP to MAX_CAP', () => {
+    expect(clampCap(MAX_CAP + 1)).toBe(MAX_CAP);
+  });
+
+  it('clamps 999_999 to MAX_CAP', () => {
+    expect(clampCap(999_999)).toBe(MAX_CAP);
+  });
+
+  it('clamps 10001 to MAX_CAP', () => {
+    // Old guard used 10000; new MAX_CAP is 3600
+    expect(clampCap(10001)).toBe(MAX_CAP);
+  });
+
+  // ── Lower clamp ─────────────────────────────────────────────────────────────
+
+  it('clamps -1 (negative) to 1', () => {
+    expect(clampCap(-1)).toBe(1);
+  });
+
+  it('clamps -9999 to 1', () => {
+    expect(clampCap(-9999)).toBe(1);
+  });
+
+  // ── Legacy zero sentinel ────────────────────────────────────────────────────
+
+  it('maps 0 (legacy unlimited sentinel) to MAX_CAP', () => {
+    // AC2: existing users with cap: 0 in localStorage get MAX_CAP on next load
+    expect(clampCap(0)).toBe(MAX_CAP);
+  });
+
+  // ── Non-integer rounding ─────────────────────────────────────────────────────
+
+  it('rounds 100.5 to 101 (within range)', () => {
+    expect(clampCap(100.5)).toBe(101);
+  });
+
+  it('rounds 0.4 to 0, then clamps to 1 (minimum)', () => {
+    // Math.round(0.4) = 0 → rounded < 1 → return 1
+    // The zero sentinel applies only to exact integer 0, not rounded-to-zero floats.
+    expect(clampCap(0.4)).toBe(1);
+  });
+
+  it('rounds 0.6 to 1 (minimum boundary)', () => {
+    // Math.round(0.6) = 1 → 1
+    expect(clampCap(0.6)).toBe(1);
+  });
+
+  it('rounds MAX_CAP + 0.4 to MAX_CAP (rounds down, still at boundary)', () => {
+    expect(clampCap(MAX_CAP + 0.4)).toBe(MAX_CAP);
+  });
+
+  // ── NaN / Infinity — NEVER return NaN ──────────────────────────────────────
+
+  it('maps NaN to MAX_CAP (NEVER return NaN — would disable engine check)', () => {
+    // AC1: roundCounter >= NaN is always false, silently disabling the cap.
+    expect(clampCap(NaN)).toBe(MAX_CAP);
+    expect(typeof clampCap(NaN)).toBe('number');
+    expect(Number.isFinite(clampCap(NaN))).toBe(true);
+  });
+
+  it('maps Infinity to MAX_CAP', () => {
+    expect(clampCap(Infinity)).toBe(MAX_CAP);
+  });
+
+  it('maps -Infinity to MAX_CAP', () => {
+    expect(clampCap(-Infinity)).toBe(MAX_CAP);
+  });
+
+  // ── Non-numeric inputs ──────────────────────────────────────────────────────
+
+  it('maps string "abc" to MAX_CAP', () => {
+    expect(clampCap('abc')).toBe(MAX_CAP);
+  });
+
+  it('maps string "100" to MAX_CAP (no implicit coercion)', () => {
+    // Strings that look like numbers are still non-numeric — no implicit cast
+    expect(clampCap('100')).toBe(MAX_CAP);
+  });
+
+  it('maps null to MAX_CAP', () => {
+    expect(clampCap(null)).toBe(MAX_CAP);
+  });
+
+  it('maps undefined to MAX_CAP', () => {
+    expect(clampCap(undefined)).toBe(MAX_CAP);
+  });
+
+  it('maps plain object to MAX_CAP', () => {
+    expect(clampCap({})).toBe(MAX_CAP);
+  });
+
+  it('maps array to MAX_CAP', () => {
+    expect(clampCap([])).toBe(MAX_CAP);
+  });
+
+  // ── Output is always a finite integer ──────────────────────────────────────
+
+  it.each([
+    0, -1, 1, 100, MAX_CAP, MAX_CAP + 1, NaN, Infinity, -Infinity,
+    'abc', null, undefined, {}, [],
+  ] as unknown[])('output is always a finite integer (input: %s)', (input) => {
+    const result = clampCap(input);
+    expect(typeof result).toBe('number');
+    expect(Number.isFinite(result)).toBe(true);
+    expect(Number.isInteger(result)).toBe(true);
+    expect(result).toBeGreaterThanOrEqual(1);
+    expect(result).toBeLessThanOrEqual(MAX_CAP);
+  });
+});

--- a/tests/unit/limits.test.ts
+++ b/tests/unit/limits.test.ts
@@ -103,7 +103,9 @@ describe('clampCap', () => {
   });
 
   it('maps undefined to MAX_CAP', () => {
-    expect(clampCap(undefined)).toBe(MAX_CAP);
+    // The `as unknown` cast avoids a redundant-undefined-arg lint flag while
+    // still exercising the contract that non-numeric inputs map to MAX_CAP.
+    expect(clampCap(undefined as unknown)).toBe(MAX_CAP);
   });
 
   it('maps plain object to MAX_CAP', () => {

--- a/tests/unit/measurement-engine.test.ts
+++ b/tests/unit/measurement-engine.test.ts
@@ -1,10 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { MeasurementEngine } from '../../src/lib/engine/measurement-engine';
 import { measurementStore } from '../../src/lib/stores/measurements';
 import { endpointStore } from '../../src/lib/stores/endpoints';
 import { settingsStore } from '../../src/lib/stores/settings';
 import { get } from 'svelte/store';
 import type { WorkerToMainMessage } from '../../src/lib/types';
+import { MAX_CAP } from '../../src/lib/limits';
+import { DEFAULT_SETTINGS } from '../../src/lib/types';
+import type { WorkerFactory } from '../../src/lib/engine/worker-factory';
 
 describe('MeasurementEngine', () => {
   let engine: MeasurementEngine;
@@ -246,5 +249,122 @@ describe('MeasurementEngine', () => {
 
     // Now it should be flushed
     expect(get(measurementStore).endpoints[testId]?.samples).toHaveLength(1);
+  });
+});
+
+// Mock worker that does nothing — we drive the engine via direct _dispatchRound calls,
+// not via the worker round-trip. Required because engine.start() would call
+// new MeasurementWorker() which throws in jsdom (no Vite worker bundle).
+function createMockWorkerFactory(): WorkerFactory {
+  return {
+    create: () => ({
+      addEventListener: () => {},
+      postMessage: () => {},
+      terminate: () => {},
+    }) as unknown as Worker,
+  };
+}
+
+describe('MeasurementEngine — AC1: cap clamping at engine read', () => {
+  let engine: MeasurementEngine;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    measurementStore.reset();
+    settingsStore.reset();
+    endpointStore.reset();
+    settingsStore.set({ ...DEFAULT_SETTINGS, region: undefined });
+    endpointStore.addEndpoint('https://example.com');
+    engine = new MeasurementEngine(createMockWorkerFactory());
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    engine.stop();
+    warnSpy.mockRestore();
+  });
+
+  // AC1 — devtools-injected cap that maps to MAX_CAP completes at MAX_CAP
+  // (NaN/Infinity/0/large-positive/non-numeric all clamp to MAX_CAP)
+  it.each([
+    { name: 'large positive', injected: 999_999 },
+    { name: 'NaN', injected: NaN },
+    { name: 'zero (legacy unlimited)', injected: 0 },
+    { name: 'Infinity', injected: Infinity },
+    { name: 'string non-numeric', injected: 'abc' as unknown as number },
+  ])('completes at MAX_CAP when settingsStore.cap is injected with $name', ({ injected }) => {
+    settingsStore.update((s) => ({ ...s, cap: injected }));
+
+    // Set lifecycle to 'running' directly — bypasses engine.start() (which would
+    // call new Worker(...) and throw in jsdom). _dispatchRound's lifecycle guard
+    // at line 329 returns early if lifecycle !== 'running', so this is required.
+    measurementStore.setLifecycle('running');
+
+    // Drive the dispatch loop manually. _dispatchRound increments roundCounter
+    // (line 381) only AFTER the cap check (line 334). So we call it MAX_CAP + 1
+    // times; the call where roundCounter === MAX_CAP sees the cap check fire and
+    // transitions to 'completed'.
+    for (let i = 0; i < MAX_CAP + 1; i++) {
+      engine._dispatchRound();
+      if (get(measurementStore).lifecycle === 'completed') break;
+    }
+
+    expect(get(measurementStore).lifecycle).toBe('completed');
+    expect(get(measurementStore).roundCounter).toBe(MAX_CAP);
+
+    // Regression detector: warn must fire because cap !== effectiveCap for every
+    // value in this parameter set (all are outside [1, MAX_CAP]).
+    // NaN triggers the warn because `NaN !== anything` is always true, including
+    // `NaN !== MAX_CAP`. This is the highest-risk case — clampCap returning NaN
+    // would silently disable the cap check, and this assertion catches that.
+    expect(warnSpy).toHaveBeenCalled();
+    expect(warnSpy.mock.calls[0]?.[0]).toContain('settings.cap');
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(String(injected));
+  });
+
+  // AC1 — negative injection clamps to 1 (minimum), completes at round 1
+  it('completes at round 1 when settingsStore.cap is injected with negative', () => {
+    settingsStore.update((s) => ({ ...s, cap: -1 }));
+    measurementStore.setLifecycle('running');
+
+    for (let i = 0; i < 5; i++) {
+      engine._dispatchRound();
+      if (get(measurementStore).lifecycle === 'completed') break;
+    }
+
+    expect(get(measurementStore).lifecycle).toBe('completed');
+    expect(get(measurementStore).roundCounter).toBe(1); // clampCap(-1) = 1
+    expect(warnSpy).toHaveBeenCalled();
+    expect(warnSpy.mock.calls[0]?.[0]).toContain('settings.cap');
+  });
+
+  // AC1 negative — valid in-range cap does NOT trigger the warn
+  it('does not warn when cap is in-range', () => {
+    settingsStore.update((s) => ({ ...s, cap: 100 }));
+    measurementStore.setLifecycle('running');
+
+    for (let i = 0; i < 101; i++) {
+      engine._dispatchRound();
+      if (get(measurementStore).lifecycle === 'completed') break;
+    }
+
+    expect(get(measurementStore).lifecycle).toBe('completed');
+    expect(get(measurementStore).roundCounter).toBe(100);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  // AC1 — engine completes at exactly MAX_CAP with DEFAULT_SETTINGS.cap
+  it('completes at exactly MAX_CAP with DEFAULT_SETTINGS.cap (no injection)', () => {
+    // settingsStore was reset to DEFAULT_SETTINGS in beforeEach (cap = MAX_CAP after this PR)
+    measurementStore.setLifecycle('running');
+
+    for (let i = 0; i < MAX_CAP + 1; i++) {
+      engine._dispatchRound();
+      if (get(measurementStore).lifecycle === 'completed') break;
+    }
+
+    expect(get(measurementStore).lifecycle).toBe('completed');
+    expect(get(measurementStore).roundCounter).toBe(MAX_CAP);
+    expect(warnSpy).not.toHaveBeenCalled(); // valid value, no warn
   });
 });

--- a/tests/unit/measurement-engine.test.ts
+++ b/tests/unit/measurement-engine.test.ts
@@ -317,9 +317,15 @@ describe('MeasurementEngine — AC1: cap clamping at engine read', () => {
     // NaN triggers the warn because `NaN !== anything` is always true, including
     // `NaN !== MAX_CAP`. This is the highest-risk case — clampCap returning NaN
     // would silently disable the cap check, and this assertion catches that.
-    expect(warnSpy).toHaveBeenCalled();
-    expect(warnSpy.mock.calls[0]?.[0]).toContain('settings.cap');
-    expect(warnSpy.mock.calls[0]?.[0]).toContain(String(injected));
+    // Rate-limit: engine emits the warn at most once per session (set in start()
+    // and gated by _capWarnEmitted), so we assert exactly one warn even though
+    // the cap check fires every round.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    // Join all args of the first call to tolerate future warn-message
+    // refactors (e.g., splitting the value into a second arg).
+    const firstCallText = (warnSpy.mock.calls[0] ?? []).map(String).join(' ');
+    expect(firstCallText).toContain('settings.cap');
+    expect(firstCallText).toContain(String(injected));
   });
 
   // AC1 — negative injection clamps to 1 (minimum), completes at round 1
@@ -334,8 +340,9 @@ describe('MeasurementEngine — AC1: cap clamping at engine read', () => {
 
     expect(get(measurementStore).lifecycle).toBe('completed');
     expect(get(measurementStore).roundCounter).toBe(1); // clampCap(-1) = 1
-    expect(warnSpy).toHaveBeenCalled();
-    expect(warnSpy.mock.calls[0]?.[0]).toContain('settings.cap');
+    expect(warnSpy).toHaveBeenCalledTimes(1); // rate-limited to once per session
+    const firstCallText = (warnSpy.mock.calls[0] ?? []).map(String).join(' ');
+    expect(firstCallText).toContain('settings.cap');
   });
 
   // AC1 negative — valid in-range cap does NOT trigger the warn

--- a/tests/unit/measurement-engine.test.ts
+++ b/tests/unit/measurement-engine.test.ts
@@ -258,9 +258,9 @@ describe('MeasurementEngine', () => {
 function createMockWorkerFactory(): WorkerFactory {
   return {
     create: () => ({
-      addEventListener: () => {},
-      postMessage: () => {},
-      terminate: () => {},
+      addEventListener: vi.fn(),
+      postMessage: vi.fn(),
+      terminate: vi.fn(),
     }) as unknown as Worker,
   };
 }
@@ -276,7 +276,7 @@ describe('MeasurementEngine — AC1: cap clamping at engine read', () => {
     settingsStore.set({ ...DEFAULT_SETTINGS, region: undefined });
     endpointStore.addEndpoint('https://example.com');
     engine = new MeasurementEngine(createMockWorkerFactory());
-    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
   });
 
   afterEach(() => {

--- a/tests/unit/persistence.test.ts
+++ b/tests/unit/persistence.test.ts
@@ -6,6 +6,7 @@ import {
   clearPersistedSettings,
 } from '../../src/lib/utils/persistence';
 import type { PersistedSettings } from '../../src/lib/types';
+import { MAX_CAP } from '../../src/lib/limits';
 
 const localStorageMock = (() => {
   let store: Record<string, string> = {};
@@ -44,7 +45,7 @@ describe('persistence', () => {
       endpoints: [{ url: 'https://a.example', enabled: true }],
       settings: {
         timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000,
-        cap: 0, corsMode: 'no-cors', healthThreshold: 200,
+        cap: MAX_CAP, corsMode: 'no-cors', healthThreshold: 200,
       },
       ui: {
         expandedCards: ['ep-1'],
@@ -69,7 +70,7 @@ describe('persistence', () => {
     const bad = {
       version: 10,
       endpoints: [],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors', healthThreshold: 120 },
       ui: { expandedCards: [], activeView: 'atlas', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
     };
     localStorageMock.setItem(PRIMARY_KEY, JSON.stringify(bad));
@@ -85,7 +86,7 @@ describe('persistence', () => {
     const v9 = {
       version: 9,
       endpoints: [{ url: 'https://example.com', enabled: true }],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors', healthThreshold: 120 },
       ui: { expandedCards: [], activeView: 'overview', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
     };
     localStorageMock.setItem(PRIMARY_KEY, JSON.stringify(v9));
@@ -111,7 +112,7 @@ describe('persistence', () => {
     const v9 = {
       version: 9,
       endpoints: [],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors', healthThreshold: 120 },
       ui: { expandedCards: [], activeView: 'overview', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
     };
     localStorageMock.setItem(LEGACY_KEY, JSON.stringify(v9));
@@ -127,7 +128,7 @@ describe('persistence', () => {
     const v10: PersistedSettings = {
       version: 10,
       endpoints: [{ url: 'https://example.com', enabled: true }],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors', healthThreshold: 120 },
       ui: { expandedCards: [], activeView: 'overview', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
     };
     localStorageMock.setItem(LEGACY_KEY, JSON.stringify(v10));
@@ -146,7 +147,7 @@ describe('persistence', () => {
     const v10: PersistedSettings = {
       version: 10,
       endpoints: [{ url: 'https://example.com', enabled: true }],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors', healthThreshold: 120 },
       ui: { expandedCards: [], activeView: 'overview', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
     };
     localStorageMock.setItem(LEGACY_KEY, JSON.stringify(v10));
@@ -180,7 +181,7 @@ describe('persistence', () => {
     const v10 = {
       version: 10,
       endpoints: [{ url: 'https://example.com', enabled: true }],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors', healthThreshold: 120 },
       ui: { expandedCards: [], activeView: 'overview', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
     };
     const result = migrateSettings(v10);
@@ -194,7 +195,7 @@ describe('persistence', () => {
     const future = {
       version: 99,
       endpoints: [],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors', healthThreshold: 120 },
       ui: { expandedCards: [], activeView: 'overview' },
     };
     expect(migrateSettings(future)).toBeNull();
@@ -215,7 +216,7 @@ describe('persistence', () => {
     const v9 = {
       version: 9,
       endpoints: [],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors', healthThreshold: 120 },
       ui: { expandedCards: [], activeView: 'overview', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
     };
     expect(migrateSettings(v9)).toBeNull();
@@ -236,7 +237,7 @@ describe('persistence', () => {
     const v10 = {
       version: 10,
       endpoints: [{ url: 'https://example.com', enabled: true }],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors', healthThreshold: 120 },
       ui: { expandedCards: ['ep-1'], activeView: 'diagnose', focusedEndpointId: 'ep-1', liveOptions: { split: true, timeRange: '15m' }, terminalFilters: ['timeout'] },
     };
     const result = migrateSettings(v10);
@@ -255,7 +256,7 @@ describe('persistence', () => {
     const v11 = {
       version: 11,
       endpoints: [{ url: 'https://example.com', enabled: true, nickname: 'My Server' }],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors', healthThreshold: 120 },
       ui: { expandedCards: [], activeView: 'overview', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
     };
     localStorageMock.setItem(PRIMARY_KEY, JSON.stringify(v11));
@@ -270,7 +271,7 @@ describe('persistence', () => {
     const v11 = {
       version: 11,
       endpoints: [{ url: 'https://example.com', enabled: true, nickname: longNick }],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors', healthThreshold: 120 },
       ui: { expandedCards: [], activeView: 'overview', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
     };
     localStorageMock.setItem(PRIMARY_KEY, JSON.stringify(v11));
@@ -284,7 +285,7 @@ describe('persistence', () => {
     const v11 = {
       version: 11,
       endpoints: [{ url: 'https://example.com', enabled: true, nickname: 'bad\u202Enick' }],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors', healthThreshold: 120 },
       ui: { expandedCards: [], activeView: 'overview', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
     };
     localStorageMock.setItem(PRIMARY_KEY, JSON.stringify(v11));
@@ -298,7 +299,7 @@ describe('persistence', () => {
     const v11 = {
       version: 11,
       endpoints: [{ url: 'https://example.com', enabled: true, nickname: 'bad\u0000nick' }],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors', healthThreshold: 120 },
       ui: { expandedCards: [], activeView: 'overview', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
     };
     localStorageMock.setItem(PRIMARY_KEY, JSON.stringify(v11));
@@ -312,7 +313,7 @@ describe('persistence', () => {
     const v11 = {
       version: 11,
       endpoints: [{ url: 'https://example.com', enabled: true, nickname: 'zero\u200Bwidth' }],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors', healthThreshold: 120 },
       ui: { expandedCards: [], activeView: 'overview', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
     };
     localStorageMock.setItem(PRIMARY_KEY, JSON.stringify(v11));
@@ -326,7 +327,7 @@ describe('persistence', () => {
     const v11 = {
       version: 11,
       endpoints: [{ url: 'https://example.com', enabled: true, nickname: 'line\u2028sep' }],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors', healthThreshold: 120 },
       ui: { expandedCards: [], activeView: 'overview', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
     };
     localStorageMock.setItem(PRIMARY_KEY, JSON.stringify(v11));
@@ -340,7 +341,7 @@ describe('persistence', () => {
     const v11 = {
       version: 11,
       endpoints: [{ url: 'https://example.com', enabled: true, nickname: 42 }],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors', healthThreshold: 120 },
       ui: { expandedCards: [], activeView: 'overview', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
     };
     localStorageMock.setItem(PRIMARY_KEY, JSON.stringify(v11));
@@ -354,7 +355,7 @@ describe('persistence', () => {
     const v11 = {
       version: 11,
       endpoints: [{ url: 'https://example.com', enabled: true, nickname: '   ' }],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors', healthThreshold: 120 },
       ui: { expandedCards: [], activeView: 'overview', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
     };
     localStorageMock.setItem(PRIMARY_KEY, JSON.stringify(v11));
@@ -368,7 +369,7 @@ describe('persistence', () => {
     const v9 = {
       version: 9,
       endpoints: [{ url: 'https://example.com', enabled: true }],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors', healthThreshold: 120 },
       ui: { expandedCards: [], activeView: 'overview', focusedEndpointId: null, liveOptions: { split: false, timeRange: '5m' }, terminalFilters: [] },
     };
     localStorageMock.setItem(PRIMARY_KEY, JSON.stringify(v9));
@@ -400,4 +401,82 @@ describe('persistence', () => {
       localStorageMock.removeItem = originalRemove;
     }
   });
+});
+
+describe('persistence — cap clamping at parse boundary (AC2)', () => {
+  // Values that survive JSON round-trip: use localStorage path
+  it.each([
+    { label: 'cap: 0 (legacy unlimited)', stored: 0, expected: MAX_CAP },
+    { label: 'cap: -1 (negative)', stored: -1, expected: 1 },
+    { label: 'cap: 99_999 (way above MAX_CAP)', stored: 99_999, expected: MAX_CAP },
+    { label: 'cap: "abc" (string)', stored: 'abc', expected: MAX_CAP },
+  ] as { label: string; stored: unknown; expected: number }[])(
+    '$label → clamps to expected',
+    ({ stored, expected }) => {
+      const payload = {
+        version: 11,
+        endpoints: [],
+        settings: {
+          timeout: 5000,
+          delay: 0,
+          burstRounds: 50,
+          monitorDelay: 1000,
+          cap: stored,
+          corsMode: 'no-cors',
+          healthThreshold: 120,
+        },
+        ui: {
+          expandedCards: [],
+          activeView: 'overview',
+          focusedEndpointId: null,
+          liveOptions: { split: false, timeRange: '5m' },
+          terminalFilters: [],
+        },
+      };
+      localStorageMock.setItem(PRIMARY_KEY, JSON.stringify(payload));
+      const result = loadPersistedSettings();
+      expect(result).not.toBeNull();
+      expect(result?.settings.cap).toBe(expected);
+      expect(result?.settings.cap).toBeGreaterThanOrEqual(1);
+      expect(result?.settings.cap).toBeLessThanOrEqual(MAX_CAP);
+    }
+  );
+
+  // Values that do NOT survive JSON serialization (NaN/Infinity → null via JSON.stringify):
+  // Bypass localStorage and call migrateSettings directly with in-memory record.
+  // The AC's intent is to verify clamping; the JSON medium is irrelevant.
+  it.each([
+    { label: 'NaN (would disable engine check if returned)', cap: NaN },
+    { label: 'Infinity', cap: Infinity },
+    { label: '-Infinity', cap: -Infinity },
+  ] as { label: string; cap: number }[])(
+    'migrateSettings clamps $label to MAX_CAP (bypasses JSON to test non-serializable values)',
+    ({ cap }) => {
+      // migrateSettings is exported and accepts unknown; inject non-serializable cap directly
+      const record = {
+        version: 11,
+        endpoints: [],
+        settings: {
+          timeout: 5000,
+          delay: 0,
+          burstRounds: 50,
+          monitorDelay: 1000,
+          cap,  // NaN / Infinity / -Infinity — not JSON-serializable
+          corsMode: 'no-cors',
+          healthThreshold: 120,
+        },
+        ui: {
+          expandedCards: [],
+          activeView: 'overview',
+          focusedEndpointId: null,
+          liveOptions: { split: false, timeRange: '5m' },
+          terminalFilters: [],
+        },
+      };
+      const result = migrateSettings(record);
+      expect(result).not.toBeNull();
+      expect(result?.settings.cap).toBe(MAX_CAP);
+      expect(Number.isFinite(result?.settings.cap)).toBe(true);
+    }
+  );
 });

--- a/tests/unit/share-manager.test.ts
+++ b/tests/unit/share-manager.test.ts
@@ -7,6 +7,7 @@ import {
   truncatePayload,
 } from '../../src/lib/share/share-manager';
 import type { SharePayload } from '../../src/lib/types';
+import { MAX_CAP } from '../../src/lib/limits';
 
 // Mock window.location for URL-based tests
 Object.defineProperty(global, 'window', {
@@ -25,7 +26,7 @@ describe('share-manager', () => {
     v: 1,
     mode: 'config',
     endpoints: [{ url: 'https://example.com', enabled: true }],
-    settings: { timeout: 5000, delay: 1000, cap: 0, corsMode: 'no-cors' },
+    settings: { timeout: 5000, delay: 1000, cap: MAX_CAP, corsMode: 'no-cors' },
   };
 
   const resultsPayload: SharePayload = {
@@ -35,7 +36,7 @@ describe('share-manager', () => {
       { url: 'https://google.com', enabled: true },
       { url: 'https://1.1.1.1', enabled: true },
     ],
-    settings: { timeout: 5000, delay: 1000, cap: 0, corsMode: 'no-cors' },
+    settings: { timeout: 5000, delay: 1000, cap: MAX_CAP, corsMode: 'no-cors' },
     results: [
       {
         samples: Array.from({ length: 50 }, (_, i) => ({
@@ -131,7 +132,7 @@ describe('share-manager', () => {
       return LZString.compressToEncodedURIComponent(JSON.stringify(data));
     }
 
-    const validSettings = { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors' };
+    const validSettings = { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'no-cors' };
 
     // AC #1 — URL scheme enforcement
     it('rejects javascript: URLs', async () => {
@@ -213,7 +214,7 @@ describe('share-manager', () => {
       const encoded = await manualEncode({
         v: 1, mode: 'config',
         endpoints: [{ url: 'https://example.com', enabled: true }],
-        settings: { timeout: Infinity, delay: 0, cap: 0, corsMode: 'no-cors' },
+        settings: { timeout: Infinity, delay: 0, cap: MAX_CAP, corsMode: 'no-cors' },
       });
       expect(decodeSharePayload(encoded)).toBeNull();
     });
@@ -222,7 +223,7 @@ describe('share-manager', () => {
       const encoded = await manualEncode({
         v: 1, mode: 'config',
         endpoints: [{ url: 'https://example.com', enabled: true }],
-        settings: { timeout: 5000, delay: -1, cap: 0, corsMode: 'no-cors' },
+        settings: { timeout: 5000, delay: -1, cap: MAX_CAP, corsMode: 'no-cors' },
       });
       expect(decodeSharePayload(encoded)).toBeNull();
     });
@@ -241,7 +242,7 @@ describe('share-manager', () => {
       const encoded = await manualEncode({
         v: 1, mode: 'config',
         endpoints: [{ url: 'https://example.com', enabled: true }],
-        settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors', burstRounds: Infinity },
+        settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'no-cors', burstRounds: Infinity },
       });
       expect(decodeSharePayload(encoded)).toBeNull();
     });
@@ -250,7 +251,7 @@ describe('share-manager', () => {
       const encoded = await manualEncode({
         v: 1, mode: 'config',
         endpoints: [{ url: 'https://example.com', enabled: true }],
-        settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors', monitorDelay: -100 },
+        settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'no-cors', monitorDelay: -100 },
       });
       expect(decodeSharePayload(encoded)).toBeNull();
     });
@@ -259,7 +260,7 @@ describe('share-manager', () => {
       const encoded = await manualEncode({
         v: 1, mode: 'config',
         endpoints: [{ url: 'https://example.com', enabled: true }],
-        settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors', burstRounds: 50, monitorDelay: 3000 },
+        settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'no-cors', burstRounds: 50, monitorDelay: 3000 },
       });
       expect(decodeSharePayload(encoded)).not.toBeNull();
     });
@@ -268,7 +269,7 @@ describe('share-manager', () => {
       const encoded = await manualEncode({
         v: 1, mode: 'config',
         endpoints: [{ url: 'https://example.com', enabled: true }],
-        settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors' },
+        settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'no-cors' },
       });
       expect(decodeSharePayload(encoded)).not.toBeNull();
     });
@@ -371,7 +372,7 @@ describe('share-manager', () => {
       const encoded = await manualEncode({
         v: 1, mode: 'config',
         endpoints: [{ url: 'https://example.com', enabled: true }],
-        settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'same-origin' },
+        settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'same-origin' },
       });
       expect(decodeSharePayload(encoded)).toBeNull();
     });
@@ -380,7 +381,7 @@ describe('share-manager', () => {
       const encoded = await manualEncode({
         v: 1, mode: 'config',
         endpoints: [{ url: 'https://example.com', enabled: true }],
-        settings: { timeout: 5000, delay: 0, cap: 0 },
+        settings: { timeout: 5000, delay: 0, cap: MAX_CAP },
       });
       expect(decodeSharePayload(encoded)).toBeNull();
     });
@@ -389,7 +390,26 @@ describe('share-manager', () => {
       const encoded = await manualEncode({
         v: 1, mode: 'config',
         endpoints: [{ url: 'https://example.com', enabled: true }],
-        settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'cors' },
+        settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'cors' },
+      });
+      expect(decodeSharePayload(encoded)).not.toBeNull();
+    });
+
+    // AC4 — cap > MAX_CAP rejection (round-cap-hardening)
+    it('rejects cap > MAX_CAP (3601)', async () => {
+      const encoded = await manualEncode({
+        v: 1, mode: 'config',
+        endpoints: [{ url: 'https://example.com', enabled: true }],
+        settings: { timeout: 5000, delay: 0, cap: MAX_CAP + 1, corsMode: 'no-cors' },
+      });
+      expect(decodeSharePayload(encoded)).toBeNull();
+    });
+
+    it('accepts cap === MAX_CAP (3600) as boundary value', async () => {
+      const encoded = await manualEncode({
+        v: 1, mode: 'config',
+        endpoints: [{ url: 'https://example.com', enabled: true }],
+        settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'no-cors' },
       });
       expect(decodeSharePayload(encoded)).not.toBeNull();
     });
@@ -399,7 +419,7 @@ describe('share-manager', () => {
       const payload: SharePayload = {
         v: 1, mode: 'results',
         endpoints: [{ url: 'https://example.com', enabled: true }],
-        settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors' },
+        settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'no-cors' },
         results: [{ samples: [{ round: 1, latency: 50, status: 'ok' as const }] }],
       };
       const truncated = truncatePayload(payload, 1);

--- a/tests/unit/share/hash-router.test.ts
+++ b/tests/unit/share/hash-router.test.ts
@@ -29,6 +29,7 @@ import { measurementStore } from '../../../src/lib/stores/measurements';
 import { uiStore } from '../../../src/lib/stores/ui';
 import { DEFAULT_SETTINGS } from '../../../src/lib/types';
 import type { SharePayload } from '../../../src/lib/types';
+import { MAX_CAP } from '../../../src/lib/limits';
 
 // Each field is deliberately distinct from DEFAULT_SETTINGS so the cadence-
 // strip invariant fails closed: if a future change accidentally writes any
@@ -40,7 +41,7 @@ const MALICIOUS_CADENCE = {
   delay: 9999,
   burstRounds: 500,
   monitorDelay: 1,
-  cap: 9999,
+  cap: 3000,  // in-range: passes schema validation → exercises apply-drops invariant (PR #81)
   corsMode: 'cors' as const,
 };
 
@@ -79,6 +80,48 @@ beforeEach(() => {
   settingsStore.reset();
   measurementStore.reset();
   uiStore.reset();
+});
+
+describe('hash-router: share-payload schema rejects cap > MAX_CAP', () => {
+  // AC4: schema-reject test — cap=3601 must be rejected by validateSharePayload
+  // (This is distinct from the apply-drops test below, which uses cap=3000.
+  // Both must exist; collapsing them loses coverage of the PR #81 invariant.)
+  it('decodeSharePayload returns null for cap > MAX_CAP', async () => {
+    const { decodeSharePayload } = await import('../../../src/lib/share/share-manager');
+    const { default: LZString } = await import('lz-string');
+    const malicious = {
+      v: 1,
+      mode: 'config',
+      endpoints: [{ url: 'https://attacker.example.com', enabled: true }],
+      settings: {
+        timeout: 5000,
+        delay: 0,
+        cap: MAX_CAP + 1, // 3601 — above MAX_CAP, must be rejected
+        corsMode: 'no-cors',
+      },
+    };
+    const encoded = LZString.compressToEncodedURIComponent(JSON.stringify(malicious));
+    // AC4: validateSharePayload returns null for cap > MAX_CAP
+    expect(decodeSharePayload(encoded)).toBeNull();
+  });
+
+  it('decodeSharePayload accepts cap === MAX_CAP (boundary)', async () => {
+    const { decodeSharePayload } = await import('../../../src/lib/share/share-manager');
+    const { default: LZString } = await import('lz-string');
+    const atBoundary = {
+      v: 1,
+      mode: 'config',
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: {
+        timeout: 5000,
+        delay: 0,
+        cap: MAX_CAP, // 3600 — at boundary, must be accepted
+        corsMode: 'no-cors',
+      },
+    };
+    const encoded = LZString.compressToEncodedURIComponent(JSON.stringify(atBoundary));
+    expect(decodeSharePayload(encoded)).not.toBeNull();
+  });
 });
 
 describe('hash-router: cadence write invariant', () => {
@@ -235,7 +278,7 @@ describe('hash-router: results-mode invariants', () => {
       v: 1,
       mode: 'results',
       endpoints: [{ url: 'https://attacker.example.com', enabled: true }],
-      settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors' },
+      settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'no-cors' },
       // results omitted
     };
     const encoded = encodeSharePayload(malformed as never);

--- a/tests/unit/share/share-payload-rejects-unknown-keys.test.ts
+++ b/tests/unit/share/share-payload-rejects-unknown-keys.test.ts
@@ -16,6 +16,7 @@ import {
   decodeSharePayload,
 } from '../../../src/lib/share/share-manager';
 import type { SharePayload } from '../../../src/lib/types';
+import { MAX_CAP } from '../../../src/lib/limits';
 
 // ── Per-entry rejection ────────────────────────────────────────────────────
 
@@ -27,7 +28,7 @@ describe('validateSharePayload: per-entry unknown key rejection', () => {
       endpoints: [
         { url: 'https://example.com', enabled: true, nickname: 'My Server' },
       ],
-      settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors' as const },
+      settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'no-cors' as const },
     };
     const encoded = encodeSharePayload(payload as never);
     expect(decodeSharePayload(encoded)).toBeNull();
@@ -40,7 +41,7 @@ describe('validateSharePayload: per-entry unknown key rejection', () => {
       endpoints: [
         { url: 'https://example.com', enabled: true, extra: 'injected' },
       ],
-      settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors' as const },
+      settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'no-cors' as const },
     };
     const encoded = encodeSharePayload(payload as never);
     expect(decodeSharePayload(encoded)).toBeNull();
@@ -51,7 +52,7 @@ describe('validateSharePayload: per-entry unknown key rejection', () => {
       v: 1,
       mode: 'config',
       endpoints: [{ url: 'https://example.com', enabled: true }],
-      settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors' },
+      settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'no-cors' },
     };
     const encoded = encodeSharePayload(payload);
     expect(decodeSharePayload(encoded)).not.toBeNull();
@@ -66,7 +67,7 @@ describe('validateSharePayload: top-level unknown key rejection', () => {
       v: 1,
       mode: 'config',
       endpoints: [{ url: 'https://example.com', enabled: true }],
-      settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors' as const },
+      settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'no-cors' as const },
       nicknames: { 'https://example.com': 'My Server' },
     };
     const encoded = encodeSharePayload(payload as never);
@@ -78,7 +79,7 @@ describe('validateSharePayload: top-level unknown key rejection', () => {
       v: 1,
       mode: 'config',
       endpoints: [{ url: 'https://example.com', enabled: true }],
-      settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors' as const },
+      settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'no-cors' as const },
       injected: 'arbitrary',
     };
     const encoded = encodeSharePayload(payload as never);
@@ -90,7 +91,7 @@ describe('validateSharePayload: top-level unknown key rejection', () => {
       v: 1,
       mode: 'config',
       endpoints: [{ url: 'https://example.com', enabled: true }],
-      settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors' },
+      settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'no-cors' },
     };
     const encoded = encodeSharePayload(payload);
     expect(decodeSharePayload(encoded)).not.toBeNull();
@@ -101,7 +102,7 @@ describe('validateSharePayload: top-level unknown key rejection', () => {
       v: 1,
       mode: 'results',
       endpoints: [{ url: 'https://example.com', enabled: true }],
-      settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors' },
+      settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'no-cors' },
       results: [
         {
           samples: [{ round: 0, latency: 42, status: 'ok' }],
@@ -121,7 +122,7 @@ describe('validateSharePayload: PR #81 invariant preserved', () => {
       v: 1,
       mode: 'results',
       endpoints: [{ url: 'https://example.com', enabled: true }],
-      settings: { timeout: 5000, delay: 0, cap: 0, corsMode: 'no-cors' as const },
+      settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'no-cors' as const },
       // results intentionally omitted
     };
     const encoded = encodeSharePayload(payload as never);

--- a/tests/unit/share/to-shared-settings.test.ts
+++ b/tests/unit/share/to-shared-settings.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { toSharedSettings } from '../../../src/lib/share/share-manager';
 import type { Settings } from '../../../src/lib/types';
+import { MAX_CAP } from '../../../src/lib/limits';
 
 describe('toSharedSettings', () => {
   it('strips region from the output', () => {
@@ -9,7 +10,7 @@ describe('toSharedSettings', () => {
       delay: 0,
       burstRounds: 50,
       monitorDelay: 1000,
-      cap: 0,
+      cap: MAX_CAP,
       corsMode: 'no-cors',
       region: 'europe',
     };
@@ -38,7 +39,7 @@ describe('toSharedSettings', () => {
 
   it('output is assignable to SharePayload[settings] shape', () => {
     const settings: Settings = {
-      timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors',
+      timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors',
     };
     const shared = toSharedSettings(settings);
     expect(shared).toHaveProperty('timeout');
@@ -49,7 +50,7 @@ describe('toSharedSettings', () => {
 
   it('works when region is undefined (no region field in source)', () => {
     const settings: Settings = {
-      timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors',
+      timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors',
     };
     const shared = toSharedSettings(settings);
     expect('region' in shared).toBe(false);

--- a/tests/unit/types.test.ts
+++ b/tests/unit/types.test.ts
@@ -16,6 +16,7 @@ import type {
 } from '../../src/lib/types';
 import { DEFAULT_SETTINGS } from '../../src/lib/types';
 import { REGIONAL_DEFAULTS } from '../../src/lib/regional-defaults';
+import { MAX_CAP } from '../../src/lib/limits';
 
 describe('types', () => {
   it('TestLifecycleState is a valid discriminated union', () => {
@@ -70,7 +71,7 @@ describe('types', () => {
       v: 1,
       mode: 'results',
       endpoints: [{ url: 'https://example.com', enabled: true }],
-      settings: { timeout: 5000, delay: 1000, cap: 0, corsMode: 'no-cors' },
+      settings: { timeout: 5000, delay: 1000, cap: MAX_CAP, corsMode: 'no-cors' },
       results: [{
         samples: [{ round: 0, latency: 42, status: 'ok' }],
       }],
@@ -83,7 +84,7 @@ describe('types', () => {
     expect(DEFAULT_SETTINGS.delay).toBe(0);
     expect(DEFAULT_SETTINGS.burstRounds).toBe(50);
     expect(DEFAULT_SETTINGS.monitorDelay).toBe(1000);
-    expect(DEFAULT_SETTINGS.cap).toBe(0);
+    expect(DEFAULT_SETTINGS.cap).toBe(MAX_CAP);
     expect(DEFAULT_SETTINGS.corsMode).toBe('no-cors');
   });
 

--- a/tests/unit/utils/apply-persisted-settings.test.ts
+++ b/tests/unit/utils/apply-persisted-settings.test.ts
@@ -4,6 +4,7 @@ import { applyPersistedSettings } from '../../../src/lib/utils/apply-persisted-s
 import { endpointStore } from '../../../src/lib/stores/endpoints';
 import { settingsStore } from '../../../src/lib/stores/settings';
 import type { PersistedSettings } from '../../../src/lib/types';
+import { MAX_CAP } from '../../../src/lib/limits';
 
 beforeEach(() => {
   // Start each test from a placeholder state to confirm applyPersistedSettings overrides it.
@@ -17,7 +18,7 @@ describe('applyPersistedSettings — G6 label hydration via brandFor', () => {
     const persisted: PersistedSettings = {
       version: 10,
       endpoints: [{ url: 'https://www.google.com', enabled: true }],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors', healthThreshold: 120 },
       ui: { expandedCards: [], activeView: 'overview' },
     };
 
@@ -33,7 +34,7 @@ describe('applyPersistedSettings — G6 label hydration via brandFor', () => {
     const persisted: PersistedSettings = {
       version: 10,
       endpoints: [{ url: 'https://WWW.Google.COM/', enabled: true }],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors', healthThreshold: 120 },
       ui: { expandedCards: [], activeView: 'overview' },
     };
 
@@ -48,7 +49,7 @@ describe('applyPersistedSettings — G6 label hydration via brandFor', () => {
     const persisted: PersistedSettings = {
       version: 10,
       endpoints: [{ url: 'https://unknown-domain.example.com', enabled: true }],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors', healthThreshold: 120 },
       ui: { expandedCards: [], activeView: 'overview' },
     };
 
@@ -67,7 +68,7 @@ describe('applyPersistedSettings — G6 label hydration via brandFor', () => {
     const persisted: PersistedSettings = {
       version: 10,
       endpoints: [{ url: '  https://www.google.com  ', enabled: true }],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', healthThreshold: 120 },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors', healthThreshold: 120 },
       ui: { expandedCards: [], activeView: 'overview' },
     };
 
@@ -85,7 +86,7 @@ describe('applyPersistedSettings — AC2 empty-endpoints contract (§6.2)', () =
     const persisted: PersistedSettings = {
       version: 10,
       endpoints: [],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors' },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors' },
       ui: { expandedCards: [], activeView: 'split' },
     };
 
@@ -102,7 +103,7 @@ describe('applyPersistedSettings — AC2 empty-endpoints contract (§6.2)', () =
         { url: 'https://user-added.example', enabled: true },
         { url: 'https://another.example', enabled: false },
       ],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors' },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors' },
       ui: { expandedCards: [], activeView: 'split' },
     };
 
@@ -120,7 +121,7 @@ describe('applyPersistedSettings — AC2 empty-endpoints contract (§6.2)', () =
     const persisted: PersistedSettings = {
       version: 10,
       endpoints: [],
-      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: 0, corsMode: 'no-cors', region: 'europe' },
+      settings: { timeout: 5000, delay: 0, burstRounds: 50, monitorDelay: 1000, cap: MAX_CAP, corsMode: 'no-cors', region: 'europe' },
       ui: { expandedCards: [], activeView: 'split' },
     };
 


### PR DESCRIPTION
## Summary

- Adds `src/lib/limits.ts` with `MAX_CAP = 3600` and `clampCap(n: unknown): number`
- All four write paths to `settingsStore.cap` (persistence load, SettingsDrawer apply, share-payload validate, DEFAULT_SETTINGS) now clamp to `[1, MAX_CAP]`
- Engine reads `cap` through `clampCap` at each `_dispatchRound`, emits `console.warn` when the value required clamping (regression detector for parse-path bypasses)
- `FooterBar` no longer renders `∞` — `cap` is always finite after hardening
- 60+ test fixtures migrated from `cap: 0` to `cap: MAX_CAP`; `MALICIOUS_CADENCE` test split into schema-reject (cap=3601) and apply-drops (cap=3000) to preserve PR #79/#81 coverage

## Threat model — defended

| Vector | Defense |
|---|---|
| User leaves tab open over weekend | Mandatory cap (DEFAULT_SETTINGS.cap = MAX_CAP) |
| User edits localStorage `{cap: 999_999}` and reloads | `readSettingsField` calls `clampCap` directly (typeof guard removed) |
| Devtools `settingsStore.update(s => ({...s, cap: 999_999 \| NaN \| 0 \| Infinity}))` | Engine `clampCap(cap)` + `console.warn` on `cap !== effectiveCap` (catches NaN because `NaN !== anything === true`) |
| Crafted share-link with `cap > MAX_CAP` reaching a victim | Schema rejection at `share-manager.ts:88` (defense-in-depth on top of PR #81 cadence-drop) |
| Future PR introduces a new write path that bypasses `clampCap` | Engine `clampCap` + `console.warn` is the regression detector |

## Threat model — not defended (stated honestly)

- JS bundle modification (physics — client-side code is user-controllable)
- Multi-tab automation (each tab independent; no shared coordinator without a server)
- Userscript / Selenium clear-and-restart loops (same as bundle modification)
- User clicking "Clear all results" repeatedly (intentional, user-initiated)

Framed per OWASP as **functionality abuse mitigation, not a security boundary**.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 warnings (Svelte ChronographDial `state_referenced_locally` is pre-existing, unrelated)
- [x] `npm test` — **785/785 pass** (was 755 — 30 new tests added)
- [x] AC1: engine parameterized test asserts completion at MAX_CAP for injected cap = 999_999 / NaN / 0 / Infinity / non-numeric
- [x] AC2: persistence parameterized test asserts clamp for cap = 0 / -1 / 99_999 / NaN / Infinity / "abc" (NaN/Infinity tests use exported `migrateSettings` since JSON can't serialize NaN)
- [x] AC3: SettingsDrawer test asserts input has `min="1" max="3600"`, applyCap clamps edge inputs, hint text updated
- [x] AC4: share-manager test asserts `cap=3601 → null`, `cap=MAX_CAP → not null`
- [x] AC5: FooterBar test asserts no `∞` glyph for cap = 1 / 100 / MAX_CAP

Playwright visual: skipped — zero layout changes (only text/input-attribute changes); UI behavior covered by unit tests.

## Migration notes

Existing users (~3 friend testers pre-launch) with `cap: 0` in localStorage will have their next session capped at MAX_CAP (~1 hour at 1/sec cruise). Silent and benign — no banner needed. Schema unchanged (still v11; `cap` is still `number`); no migration version bump.

## Spec / plan / research

- Spec: `docs/superpowers/specs/2026-04-26-round-cap-hardening-design.md`
- Plan: `docs/plans/2026-04-26-round-cap-hardening-plan.md`
- Research bundle: `docs/superpowers/research/2026-04-26-round-cap-hardening-{ccb,acceptance-criteria,brief,approaches,design-validation}.md`
- Retrospective: `docs/superpowers/retrospectives/2026-04-26-round-cap-hardening-retro.md`

(All design artifacts are untracked locally — commit them as a tiny docs-only PR when convenient.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed progress label display to remove infinity symbol (∞) and always show numeric values.
  * Improved cap (round limit) validation with proper clamping of out-of-range values across the app.

* **Improvements**
  * Updated settings UI constraints: cap input now requires minimum of 1 and maximum of 3600 rounds.
  * Changed cap hint text from "0 = unlimited" to show bounded range.
  * Enhanced imported and persisted settings parsing for more robust cap handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->