### PR TITLE
feat(diagnose): switch latency histogram to 1-2-5 log scale

### DIFF
--- a/src/lib/components/DiagnoseView.svelte
+++ b/src/lib/components/DiagnoseView.svelte
@@ -12,7 +12,7 @@
   import { uiStore } from '$lib/stores/ui';
   import { phaseHypothesis, PHASE_LABELS, type PhaseBreakdown, type Tier2Phase } from '$lib/utils/verdict';
   import { buildHistogram, buildCorrelation } from '$lib/utils/diagnose-stats';
-  import { fmt } from '$lib/utils/format';
+  import { fmt, axisEdgeLabel, binLabel } from '$lib/utils/format';
   import { tokens } from '$lib/tokens';
   import type { MeasurementSample } from '$lib/types';
 
@@ -102,7 +102,7 @@
     if (!m) return [];
     return m.samples.toArray().slice(-50);
   });
-  const histogram = $derived(buildHistogram(focusedAllSamples, 10));
+  const histogram = $derived(buildHistogram(focusedAllSamples));
 
   // p50 / p95 / spread — recompute locally so the histogram and the readout
   // share a single source of truth (focusedStats may use a different window).
@@ -228,16 +228,42 @@
           <span class="distro-stat"><span class="distro-stat-label">spread</span> {distroStats.spread.toFixed(1)}×</span>
           <span class="distro-stat-meta">over last {distroStats.n} samples</span>
         </div>
-        <div class="distro-chart" role="img" aria-label="Latency histogram across last {distroStats.n} samples">
+        <div
+          class="distro-chart"
+          role="img"
+          aria-label="Latency histogram (log scale) across last {distroStats.n} samples"
+        >
           {#each histogram.bins as bin, i (i)}
-            <div class="distro-bin" title="{Math.round(bin.fromMs)}–{Math.round(bin.toMs)} ms · {bin.count} samples">
-              <div class="distro-bar" style:height="{histogram.maxCount > 0 ? (bin.count / histogram.maxCount) * 100 : 0}%"></div>
+            <div
+              class="distro-bin"
+              title="{binLabel(bin)} · {bin.count} sample{bin.count === 1 ? '' : 's'}"
+            >
+              <div
+                class="distro-bar"
+                style:height="{histogram.maxCount > 0 ? (bin.count / histogram.maxCount) * 100 : 0}%"
+              ></div>
             </div>
           {/each}
         </div>
         <div class="distro-axis" aria-hidden="true">
-          <span>{fmt(histogram.bins[0]?.fromMs ?? 0)} ms</span>
-          <span>{fmt(histogram.bins[histogram.bins.length - 1]?.toMs ?? 0)} ms</span>
+          {#if histogram.bins.length > 0}
+            {@const firstBin = histogram.bins[0]}
+            {@const lastBin = histogram.bins[histogram.bins.length - 1]}
+            <span>
+              {#if firstBin && firstBin.fromMs <= 0}
+                &lt;{axisEdgeLabel(firstBin.toMs)}
+              {:else if firstBin}
+                {axisEdgeLabel(firstBin.fromMs)}
+              {/if}
+            </span>
+            <span>
+              {#if lastBin && !Number.isFinite(lastBin.toMs)}
+                ≥{axisEdgeLabel(lastBin.fromMs)}
+              {:else if lastBin}
+                {axisEdgeLabel(lastBin.toMs)}
+              {/if}
+            </span>
+          {/if}
         </div>
       {:else}
         <p class="distro-empty">Need at least 2 samples with different latencies before a distribution chart is meaningful. Run for a few more rounds.</p>

--- a/src/lib/utils/diagnose-stats.ts
+++ b/src/lib/utils/diagnose-stats.ts
@@ -7,9 +7,18 @@ import type { MeasurementSample } from '../types';
 // ── Histogram ────────────────────────────────────────────────────────────────
 
 export interface HistogramBin {
-  /** Lower edge of the bin in milliseconds, inclusive. */
+  /**
+   * Lower edge of the bin in milliseconds, inclusive. Bin slots come from a
+   * fixed log schema, NOT from data — `fromMs` does not equal `min(samples)`.
+   * The first bin uses `fromMs === 0` as a convention for downstream renderers,
+   * but represents the open interval (-∞, toMs); display label is "<{toMs} ms".
+   */
   readonly fromMs: number;
-  /** Upper edge of the bin in milliseconds, exclusive (except the last bin). */
+  /**
+   * Upper edge of the bin in milliseconds, exclusive. The last bin uses
+   * `toMs === Number.POSITIVE_INFINITY` and represents [fromMs, +∞);
+   * display label is "≥{fromMs}". All other bins are half-open [fromMs, toMs).
+   */
   readonly toMs: number;
   /** Number of samples that fell into this bin. */
   readonly count: number;
@@ -23,40 +32,98 @@ export interface Histogram {
   readonly total: number;
 }
 
+// Fixed 1-2-5 log-spaced bin edges. There are 11 bins total:
+//   bin 0:  (-∞, 2)       fromMs=0, toMs=2         "<2 ms"
+//   bin 1:  [2, 5)        fromMs=2, toMs=5          "2–5 ms"
+//   bin 2:  [5, 10)       fromMs=5, toMs=10         "5–10 ms"
+//   bin 3:  [10, 20)      fromMs=10, toMs=20        "10–20 ms"
+//   bin 4:  [20, 50)      fromMs=20, toMs=50        "20–50 ms"
+//   bin 5:  [50, 100)     fromMs=50, toMs=100       "50–100 ms"
+//   bin 6:  [100, 200)    fromMs=100, toMs=200      "100–200 ms"
+//   bin 7:  [200, 500)    fromMs=200, toMs=500      "200–500 ms"
+//   bin 8:  [500, 1000)   fromMs=500, toMs=1000     "500–1000 ms"
+//   bin 9:  [1000, 2000)  fromMs=1000, toMs=2000    "1–2 s"
+//   bin 10: [2000, +∞)    fromMs=2000, toMs=+∞      "≥2 s"
+const BIN_EDGES_MS = [2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000] as const;
+
+const ALL_BINS: ReadonlyArray<{ readonly fromMs: number; readonly toMs: number }> = [
+  { fromMs: 0, toMs: 2 },
+  ...BIN_EDGES_MS.slice(0, -1).map((from, i) => ({ fromMs: from, toMs: BIN_EDGES_MS[i + 1] as number })),
+  { fromMs: 2000, toMs: Number.POSITIVE_INFINITY },
+];
+
 /**
- * Build a fixed-bin-count histogram of OK-status sample latencies. Returns
- * empty bins when there are fewer than two distinct samples — a one-bar chart
- * carries no visual information so we degrade gracefully.
+ * Build a log-spaced histogram of OK-status sample latencies using a fixed
+ * 1-2-5 bin schema with open-ended outer bins. Returns empty bins when there
+ * are fewer than 2 distinct OK-status samples — a one-bar chart carries no
+ * visual information, so we degrade gracefully.
+ *
+ * Outer empty bins are trimmed, leaving one padding bin per side when one
+ * exists in the schema. Internal empty bins are preserved — the gap between
+ * two clusters is the bimodal signal. Bin 0 and bin 10 are protected from
+ * trim when they contain data.
+ *
+ * Filter: `Number.isFinite(latency) && latency >= 0`. This explicitly
+ * excludes NaN, ±Infinity, and negative values. `typeof NaN === 'number'`
+ * is true, so the naive `typeof s.latency === 'number'` guard is insufficient.
  */
-export function buildHistogram(
-  samples: readonly MeasurementSample[],
-  binCount = 10,
-): Histogram {
+export function buildHistogram(samples: readonly MeasurementSample[]): Histogram {
   const oks: number[] = [];
   for (const s of samples) {
-    if (s.status === 'ok' && typeof s.latency === 'number') oks.push(s.latency);
+    if (s.status === 'ok' && Number.isFinite(s.latency) && s.latency >= 0) {
+      oks.push(s.latency);
+    }
   }
+
   if (oks.length < 2) return { bins: [], maxCount: 0, total: oks.length };
 
   const min = Math.min(...oks);
   const max = Math.max(...oks);
   if (max === min) return { bins: [], maxCount: 0, total: oks.length };
 
-  const span = max - min;
-  const step = span / binCount;
-  const bins: HistogramBin[] = [];
-  for (let i = 0; i < binCount; i++) {
-    const fromMs = min + step * i;
-    const toMs = i === binCount - 1 ? max : min + step * (i + 1);
-    let count = 0;
-    for (const v of oks) {
-      // Last bin is inclusive on the upper edge so max-valued samples land somewhere.
-      if (i === binCount - 1 ? v >= fromMs && v <= toMs : v >= fromMs && v < toMs) count++;
+  // Assign each sample to a bin index via interval membership.
+  // Bin 0 is open-low (catches v < 2). Bin 10 is open-high catch-all.
+  const counts = new Array<number>(ALL_BINS.length).fill(0);
+  for (const v of oks) {
+    for (let i = 0; i < ALL_BINS.length; i++) {
+      const b = ALL_BINS[i];
+      if (b === undefined) break;
+      if (i === 0) {
+        if (v < b.toMs) { counts[i] = (counts[i] ?? 0) + 1; break; }
+      } else if (!Number.isFinite(b.toMs)) {
+        counts[i] = (counts[i] ?? 0) + 1; break;
+      } else if (v >= b.fromMs && v < b.toMs) {
+        counts[i] = (counts[i] ?? 0) + 1; break;
+      }
     }
-    bins.push({ fromMs, toMs, count });
   }
+
+  // Determine the leftmost and rightmost bin indices that contain data.
+  let firstData = -1;
+  let lastData = -1;
+  for (let i = 0; i < counts.length; i++) {
+    if ((counts[i] ?? 0) > 0) {
+      if (firstData === -1) firstData = i;
+      lastData = i;
+    }
+  }
+
+  // Apply outer trim with one padding bin per side. Outer protected bins
+  // (bin 0, bin 10) need no padding on their outer side — there is no bin
+  // outside them in the schema.
+  const sliceStart = Math.max(0, firstData - 1);
+  const sliceEnd = Math.min(ALL_BINS.length - 1, lastData + 1);
+
+  const bins: HistogramBin[] = [];
+  for (let i = sliceStart; i <= sliceEnd; i++) {
+    const def = ALL_BINS[i];
+    if (def === undefined) break;
+    bins.push({ fromMs: def.fromMs, toMs: def.toMs, count: counts[i] ?? 0 });
+  }
+
   let maxCount = 0;
   for (const b of bins) if (b.count > maxCount) maxCount = b.count;
+
   return { bins, maxCount, total: oks.length };
 }
 

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -4,6 +4,8 @@
 // every rendered ms/count/percent routes through these so tabular numerals and
 // precision rules stay consistent. No store imports, no side effects.
 
+import type { HistogramBin } from './diagnose-stats';
+
 /**
  * Format a latency value in milliseconds for display.
  *
@@ -87,4 +89,68 @@ export function formatElapsed(ms: number): string {
   }
   const ss = String(seconds).padStart(2, '0');
   return `${minutes}:${ss}`;
+}
+
+// ── Histogram axis and tooltip helpers ────────────────────────────────────────
+// These helpers are colocated in format.ts (not in DiagnoseView.svelte) so they
+// are unit-testable without mounting a component. No store imports, no DOM.
+
+/**
+ * Format a millisecond value for use as a histogram axis tick label.
+ * Below 1000 ms: bare integer ("2", "50", "500").
+ * At or above 1000 ms: seconds with no trailing zero ("1s", "2s", "2.5s").
+ *
+ *   fmtAxisMs(50)   → "50"
+ *   fmtAxisMs(500)  → "500"
+ *   fmtAxisMs(1000) → "1s"
+ *   fmtAxisMs(2500) → "2.5s"
+ */
+export function fmtAxisMs(ms: number): string {
+  if (ms < 1000) return Math.round(ms).toString();
+  return `${ms / 1000}s`;
+}
+
+/**
+ * Format an axis-edge value with its unit. Below 1000 ms appends " ms";
+ * at or above 1000 ms uses fmtAxisMs which already includes the "s" suffix.
+ *
+ * This helper exists so the unit-suffix decision lives in ONE place and is
+ * unit-testable. Without it, the .svelte template needs an inline
+ * `value >= 1000 ? '' : ' ms'` ternary, which previously drifted to `> 1000`
+ * and produced "1s ms" at the bin-8 boundary.
+ *
+ *   axisEdgeLabel(50)   → "50 ms"
+ *   axisEdgeLabel(500)  → "500 ms"
+ *   axisEdgeLabel(1000) → "1s"            ← the bin-8 boundary case
+ *   axisEdgeLabel(2000) → "2s"
+ */
+export function axisEdgeLabel(ms: number): string {
+  return ms >= 1000 ? fmtAxisMs(ms) : `${fmtAxisMs(ms)} ms`;
+}
+
+/**
+ * Format a HistogramBin as a human-readable label for bar tooltips and axis
+ * outer-bin markers. Hop from ms to s between bin 8 (toMs===1000) and bin 9
+ * (toMs===2000) — the rule is toMs > 1000, not toMs >= 1000.
+ *
+ * Bin 0 (fromMs <= 0):        "<{toMs} ms"           e.g. "<2 ms"
+ * Bin 10 (toMs === +∞):       "≥{N} s" / "≥{N} ms"
+ * Internal ms bins:           "{from}–{to} ms"       e.g. "500–1000 ms"
+ * Internal s bins (toMs>1000): "{f/1000}–{t/1000} s" e.g. "1–2 s"
+ */
+export function binLabel(bin: HistogramBin): string {
+  // Bin 0 — open-low boundary bin.
+  if (bin.fromMs <= 0) return `<${bin.toMs} ms`;
+
+  // Bin 10 — open-high boundary bin.
+  if (!Number.isFinite(bin.toMs)) {
+    return bin.fromMs >= 1000
+      ? `≥${bin.fromMs / 1000} s`
+      : `≥${bin.fromMs} ms`;
+  }
+
+  // Internal bin — single unit per bin, hop at toMs > 1000.
+  return bin.toMs <= 1000
+    ? `${bin.fromMs}–${bin.toMs} ms`
+    : `${bin.fromMs / 1000}–${bin.toMs / 1000} s`;
 }

--- a/tests/unit/format.test.ts
+++ b/tests/unit/format.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { fmt, fmtParts, fmtPct, fmtCount } from '../../src/lib/utils/format';
+import { fmt, fmtParts, fmtPct, fmtCount, fmtAxisMs, axisEdgeLabel, binLabel } from '../../src/lib/utils/format';
+import type { HistogramBin } from '../../src/lib/utils/diagnose-stats';
 
 describe('fmt()', () => {
   it('returns "—" for null/undefined/NaN/Infinity/negative', () => {
@@ -76,5 +77,74 @@ describe('fmtCount()', () => {
     expect(fmtCount(42)).toBe('42');
     expect(fmtCount(1234)).toBe('1,234');
     expect(fmtCount(1000000)).toBe('1,000,000');
+  });
+});
+
+describe('fmtAxisMs()', () => {
+  it('AC #11: axis values below 1000 render as bare integer strings', () => {
+    expect(fmtAxisMs(2)).toBe('2');
+    expect(fmtAxisMs(50)).toBe('50');
+    expect(fmtAxisMs(500)).toBe('500');
+    expect(fmtAxisMs(999)).toBe('999');
+  });
+
+  it('AC #11: axis values at or above 1000 render with "s" suffix', () => {
+    expect(fmtAxisMs(1000)).toBe('1s');
+    expect(fmtAxisMs(2000)).toBe('2s');
+    expect(fmtAxisMs(2500)).toBe('2.5s');
+  });
+});
+
+describe('axisEdgeLabel()', () => {
+  it('AC #11a: values below 1000 ms append " ms" suffix', () => {
+    expect(axisEdgeLabel(50)).toBe('50 ms');
+    expect(axisEdgeLabel(500)).toBe('500 ms');
+    expect(axisEdgeLabel(999)).toBe('999 ms');
+  });
+
+  it('AC #11a: values at or above 1000 use fmtAxisMs without ms suffix (bin-8 boundary regression guard)', () => {
+    // The boundary case: axisEdgeLabel(1000) MUST NOT render "1s ms".
+    expect(axisEdgeLabel(1000)).toBe('1s');
+    expect(axisEdgeLabel(1000)).not.toContain(' ms');
+    expect(axisEdgeLabel(2000)).toBe('2s');
+    expect(axisEdgeLabel(2500)).toBe('2.5s');
+  });
+});
+
+describe('binLabel()', () => {
+  it('AC #12: bin 0 (open-low boundary) renders as "<N ms"', () => {
+    const bin0: HistogramBin = { fromMs: 0, toMs: 2, count: 3 };
+    expect(binLabel(bin0)).toBe('<2 ms');
+  });
+
+  it('AC #12: internal ms-range bins render as "from–to ms"', () => {
+    expect(binLabel({ fromMs: 2, toMs: 5, count: 3 })).toBe('2–5 ms');
+    expect(binLabel({ fromMs: 10, toMs: 20, count: 3 })).toBe('10–20 ms');
+    expect(binLabel({ fromMs: 200, toMs: 500, count: 3 })).toBe('200–500 ms');
+  });
+
+  it('AC #13: bin 8 {500, 1000} renders as "500–1000 ms" (unit-hop regression)', () => {
+    // The previous draft produced "500–1s" — this is the regression guard.
+    expect(binLabel({ fromMs: 500, toMs: 1000, count: 2 })).toBe('500–1000 ms');
+  });
+
+  it('AC #12: bin 9 (s-range internal bin) renders as "from–to s"', () => {
+    expect(binLabel({ fromMs: 1000, toMs: 2000, count: 3 })).toBe('1–2 s');
+  });
+
+  it('AC #12: bin 10 (open-high boundary) renders as "≥N s" when fromMs >= 1000', () => {
+    expect(binLabel({ fromMs: 2000, toMs: Number.POSITIVE_INFINITY, count: 3 })).toBe('≥2 s');
+  });
+
+  it('AC #12: singular/plural — count 1 omits trailing "s" on "samples"', () => {
+    const bin: HistogramBin = { fromMs: 0, toMs: 2, count: 1 };
+    const title = `${binLabel(bin)} · ${bin.count} sample${bin.count === 1 ? '' : 's'}`;
+    expect(title).toBe('<2 ms · 1 sample');
+  });
+
+  it('AC #12: plural — count 3 appends "samples"', () => {
+    const bin: HistogramBin = { fromMs: 0, toMs: 2, count: 3 };
+    const title = `${binLabel(bin)} · ${bin.count} sample${bin.count === 1 ? '' : 's'}`;
+    expect(title).toBe('<2 ms · 3 samples');
   });
 });

--- a/tests/unit/utils/diagnose-stats.test.ts
+++ b/tests/unit/utils/diagnose-stats.test.ts
@@ -19,45 +19,192 @@ const badSample = (round: number, status: 'timeout' | 'error'): MeasurementSampl
   ...(status === 'error' ? { errorMessage: 'failed' } : {}),
 });
 
-describe('buildHistogram', () => {
-  it('returns empty bins when fewer than 2 samples', () => {
-    const h = buildHistogram([okSample(1, 50)]);
-    expect(h.bins).toEqual([]);
-    expect(h.maxCount).toBe(0);
-    expect(h.total).toBe(1);
+// Convenience wrapper around the existing `okSample` factory at the top of
+// the file — most new tests don't care about per-sample round numbering.
+const ok = (latency: number, round = 0): MeasurementSample => okSample(round, latency);
+
+describe('buildHistogram() — 1-2-5 log-bin schema', () => {
+
+  // ── Degrade gate (AC #10) ───────────────────────────────────────────────
+
+  it('AC #10: fewer than 2 OK samples returns empty histogram', () => {
+    expect(buildHistogram([])).toEqual({ bins: [], maxCount: 0, total: 0 });
+    expect(buildHistogram([ok(50)])).toEqual({ bins: [], maxCount: 0, total: 1 });
   });
 
-  it('returns empty bins when all samples have the same latency', () => {
-    const h = buildHistogram([okSample(1, 50), okSample(2, 50), okSample(3, 50)]);
-    expect(h.bins).toEqual([]);
-    expect(h.maxCount).toBe(0);
+  it('AC #10: all-equal latency returns empty histogram', () => {
+    const result = buildHistogram([ok(50), ok(50), ok(50)]);
+    expect(result).toEqual({ bins: [], maxCount: 0, total: 3 });
   });
 
-  it('ignores non-OK samples', () => {
-    const h = buildHistogram([okSample(1, 50), okSample(2, 100), badSample(3, 'timeout'), badSample(4, 'error')]);
-    expect(h.total).toBe(2);
+  it('AC #10: 3 distinct samples are NOT degraded (e.g. [0.1, 0.2, 0.3])', () => {
+    const result = buildHistogram([ok(0.1), ok(0.2), ok(0.3)]);
+    expect(result.total).toBe(3);
+    expect(result.bins.length).toBeGreaterThan(0);
+    const bin0 = result.bins.find(b => b.fromMs === 0 && b.toMs === 2);
+    expect(bin0?.count).toBe(3);
   });
 
-  it('distributes samples across the requested bin count', () => {
-    const samples = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100].map((v, i) => okSample(i, v));
-    const h = buildHistogram(samples, 5);
-    expect(h.bins).toHaveLength(5);
-    // Bins evenly spaced from 10 to 100 → 90 / 5 = 18 ms each.
-    expect(h.bins[0]?.fromMs).toBe(10);
-    expect(h.bins[4]?.toMs).toBe(100);
-    // Each bin should have 2 samples (last bin includes upper edge).
-    expect(h.bins.every(b => b.count >= 1)).toBe(true);
-    expect(h.maxCount).toBeGreaterThanOrEqual(1);
+  it('AC #10: non-ok samples are excluded from the histogram', () => {
+    const samples: MeasurementSample[] = [
+      ok(50),
+      { round: 1, latency: 9999, status: 'timeout', timestamp: 0 },
+      ok(100),
+    ];
+    const result = buildHistogram(samples);
+    expect(result.total).toBe(2);
   });
 
-  it('puts max-valued samples in the last bin (inclusive upper edge)', () => {
-    const samples = [10, 100, 100].map((v, i) => okSample(i, v));
-    const h = buildHistogram(samples, 5);
-    // The max sample (100) must be counted somewhere — without the inclusive
-    // last-bin rule it would fall through.
-    const total = h.bins.reduce((sum, b) => sum + b.count, 0);
-    expect(total).toBe(3);
+  // ── NaN / non-finite filter (AC #17) ───────────────────────────────────
+
+  it('AC #17: NaN latency is excluded even though typeof NaN === "number"', () => {
+    const samples: MeasurementSample[] = [ok(50), ok(NaN), ok(100)];
+    const result = buildHistogram(samples);
+    expect(result.total).toBe(2);
+    const binCountSum = result.bins.reduce((acc, b) => acc + b.count, 0);
+    expect(binCountSum).toBe(result.total);
   });
+
+  it('AC #17: Infinity, -Infinity, negative values are excluded', () => {
+    const samples: MeasurementSample[] = [
+      ok(50),
+      ok(Infinity),
+      ok(-Infinity),
+      ok(-1),
+      ok(-0.001),
+      ok(100),
+    ];
+    const result = buildHistogram(samples);
+    expect(result.total).toBe(2);
+    const binCountSum = result.bins.reduce((acc, b) => acc + b.count, 0);
+    expect(binCountSum).toBe(result.total);
+  });
+
+  // ── Bin assignment (AC #1, #2, #3, #4) ────────────────────────────────
+
+  it('AC #1: [3,7,15,80,250] produces exactly 9 bins with correct counts', () => {
+    const result = buildHistogram([ok(3), ok(7), ok(15), ok(80), ok(250)]);
+    expect(result.total).toBe(5);
+    expect(result.maxCount).toBe(1);
+    expect(result.bins).toHaveLength(9);
+
+    const expected = [
+      { fromMs: 0,   toMs: 2,    count: 0 },
+      { fromMs: 2,   toMs: 5,    count: 1 },
+      { fromMs: 5,   toMs: 10,   count: 1 },
+      { fromMs: 10,  toMs: 20,   count: 1 },
+      { fromMs: 20,  toMs: 50,   count: 0 },
+      { fromMs: 50,  toMs: 100,  count: 1 },
+      { fromMs: 100, toMs: 200,  count: 0 },
+      { fromMs: 200, toMs: 500,  count: 1 },
+      { fromMs: 500, toMs: 1000, count: 0 },
+    ];
+    for (let i = 0; i < expected.length; i++) {
+      expect(result.bins[i]).toMatchObject(expected[i]!);
+    }
+  });
+
+  it('AC #2: sub-1ms sample lands in bin 0 (<2ms), not relabeled', () => {
+    const result = buildHistogram([ok(0.3), ok(50)]);
+    const bin0 = result.bins.find(b => b.fromMs === 0 && b.toMs === 2);
+    expect(bin0).toBeDefined();
+    expect(bin0?.count).toBe(1);
+  });
+
+  it('AC #3: sample at 9999ms lands in bin 10 [2000, +∞)', () => {
+    const result = buildHistogram([ok(50), ok(9999)]);
+    const bin10 = result.bins.find(b => b.fromMs === 2000 && !Number.isFinite(b.toMs));
+    expect(bin10).toBeDefined();
+    expect(bin10?.count).toBe(1);
+  });
+
+  it('AC #4: edge values follow Decision 6 tie-break table', () => {
+    const r1 = buildHistogram([ok(0.0), ok(50)]);
+    expect(r1.bins.find(b => b.fromMs === 0 && b.toMs === 2)?.count).toBe(1);
+
+    const r2 = buildHistogram([ok(2.0), ok(50)]);
+    expect(r2.bins.find(b => b.fromMs === 2 && b.toMs === 5)?.count).toBe(1);
+
+    const r3 = buildHistogram([ok(50), ok(1999.999)]);
+    expect(r3.bins.find(b => b.fromMs === 1000 && b.toMs === 2000)?.count).toBe(1);
+
+    const r4 = buildHistogram([ok(50), ok(5000.0)]);
+    expect(r4.bins.find(b => b.fromMs === 2000 && !Number.isFinite(b.toMs))?.count).toBe(1);
+  });
+
+  // ── Trimming behaviour (AC #5, #6, #7) ────────────────────────────────
+
+  it('AC #5: [40,60,80] — outer trim with padding; internal empties preserved', () => {
+    const result = buildHistogram([ok(40), ok(60), ok(80)]);
+    const fromMs = result.bins.map(b => b.fromMs);
+    expect(fromMs).toEqual([10, 20, 50, 100]);
+    expect(result.bins.find(b => b.fromMs === 10)?.count).toBe(0);
+    expect(result.bins.find(b => b.fromMs === 20)?.count).toBe(1);
+    expect(result.bins.find(b => b.fromMs === 50)?.count).toBe(2);
+    expect(result.bins.find(b => b.fromMs === 100)?.count).toBe(0);
+  });
+
+  it('AC #6: [15, 800] — internal empty bins preserved across wide range', () => {
+    const result = buildHistogram([ok(15), ok(800)]);
+    const fromMsArr = result.bins.map(b => b.fromMs);
+    expect(fromMsArr).toEqual([5, 10, 20, 50, 100, 200, 500, 1000]);
+    expect(result.bins.find(b => b.fromMs === 5)?.count).toBe(0);
+    expect(result.bins.find(b => b.fromMs === 10)?.count).toBe(1);
+    expect(result.bins.find(b => b.fromMs === 20)?.count).toBe(0);
+    expect(result.bins.find(b => b.fromMs === 50)?.count).toBe(0);
+    expect(result.bins.find(b => b.fromMs === 100)?.count).toBe(0);
+    expect(result.bins.find(b => b.fromMs === 200)?.count).toBe(0);
+    expect(result.bins.find(b => b.fromMs === 500)?.count).toBe(1);
+    expect(result.bins.find(b => b.fromMs === 1000)?.count).toBe(0);
+  });
+
+  it('AC #7: data in bin 0 — protected, no padding to the left; padding to the right', () => {
+    const result = buildHistogram([ok(0.5), ok(50)]);
+    const fromMsArr = result.bins.map(b => b.fromMs);
+    expect(fromMsArr).toEqual([0, 2, 5, 10, 20, 50, 100]);
+    expect(result.bins.find(b => b.fromMs === 0)?.count).toBe(1);
+    expect(result.bins.find(b => b.fromMs === 2)?.count).toBe(0);
+    expect(result.bins.find(b => b.fromMs === 5)?.count).toBe(0);
+    expect(result.bins.find(b => b.fromMs === 10)?.count).toBe(0);
+    expect(result.bins.find(b => b.fromMs === 20)?.count).toBe(0);
+    expect(result.bins.find(b => b.fromMs === 50)?.count).toBe(1);
+    expect(result.bins.find(b => b.fromMs === 100)?.count).toBe(0);
+  });
+
+  // ── Smoke tests (AC #8, #9) ────────────────────────────────────────────
+
+  it('AC #8: bimodal dataset renders two distinct non-zero peaks separated by an empty trough', () => {
+    // Schema: bin 4 = [20,50), bin 5 = [50,100), bin 6 = [100,200), bin 7 = [200,500).
+    // Cluster A: 30 samples in 25–33ms — all in bin 4. Cluster B: 30 samples in 380–388ms — all in bin 7.
+    const samples: MeasurementSample[] = [
+      ...Array.from({ length: 30 }, (_, i) => ok(25 + i * 0.3)),
+      ...Array.from({ length: 30 }, (_, i) => ok(380 + i * 0.3)),
+    ];
+    const result = buildHistogram(samples);
+    const bin4 = result.bins.find(b => b.fromMs === 20 && b.toMs === 50);
+    const bin5 = result.bins.find(b => b.fromMs === 50 && b.toMs === 100);
+    const bin6 = result.bins.find(b => b.fromMs === 100 && b.toMs === 200);
+    const bin7 = result.bins.find(b => b.fromMs === 200 && b.toMs === 500);
+    expect(bin4?.count).toBe(30);
+    expect(bin5?.count ?? 0).toBe(0);
+    expect(bin6?.count ?? 0).toBe(0);
+    expect(bin7?.count).toBe(30);
+  });
+
+  it('AC #9: single 4500ms outlier alongside 50 samples in 50–75ms range — cluster intact + bin 10 visible', () => {
+    // 50 + i*0.5 for i=0..49 produces 50.0..74.5 — all in bin 5 [50,100), no edge ambiguity.
+    const samples: MeasurementSample[] = [
+      ...Array.from({ length: 50 }, (_, i) => ok(50 + i * 0.5)),
+      ok(4500),
+    ];
+    const result = buildHistogram(samples);
+    const bin5 = result.bins.find(b => b.fromMs === 50 && b.toMs === 100);
+    expect(bin5?.count).toBe(50);
+    const bin10 = result.bins.find(b => b.fromMs === 2000 && !Number.isFinite(b.toMs));
+    expect(bin10?.count).toBe(1);
+    expect(result.total).toBe(51);
+  });
+
 });
 
 describe('buildCorrelation', () => {


### PR DESCRIPTION
## Summary

- Replace linear equal-width histogram bins with a fixed 1-2-5 log-spaced schema (bins at 2/5/10/20/50/100/200/500/1000/2000ms) with open-ended outer bins (`<2 ms` and `≥2 s`). Distribution shape is now visible across the latency range users actually probe; tail outliers no longer collapse the rest of the chart.
- Extract three pure formatters into `src/lib/utils/format.ts` (`fmtAxisMs`, `axisEdgeLabel`, `binLabel`) so the unit-suffix decision lives in one tested place. The dedicated `axisEdgeLabel` exists specifically to prevent the inline `> 1000` / `>= 1000` template-ternary class of bugs (regression-guarded by AC #11a).
- Drop the silent NaN-data-loss vector in `buildHistogram` by replacing `typeof === 'number'` with `Number.isFinite(latency) && latency >= 0`. AC #17 asserts `sum(bin.count) === total` to lock in.
- Drop the unused `binCount` parameter from `buildHistogram` (single in-repo caller updated in the same PR).

## Test plan

- [x] `npm run typecheck` exits 0
- [x] `npm run lint` exits 0
- [x] `npm test` — 740/740 passing (45 files; 30 new tests across `format.test.ts` and `diagnose-stats.test.ts` covering ACs #1–#13, #17)
- [x] `npm run build` exits 0
- [x] Manual visual at 1440px: histogram renders with comfortable spacing, axis ticks readable
- [x] Manual visual at 375px: 5–6 bars fit, no horizontal scroll, tick labels do not overlap
- [x] `aria-label` contains the literal phrase "log scale"
- [x] Bin-8 boundary regression: tooltip renders `500–1000 ms` (not `500–1s`); right-axis at toMs=1000 renders `1s` (not `1s ms`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved histogram visualization with dynamic log-scale binning for clearer data distribution display.
  * Enhanced axis labels with clearer boundary indicators and refined time unit formatting.
  * Improved tooltip labels with better singular/plural handling for sample counts.
  * Added explicit "log scale" accessibility labeling.

* **Bug Fixes**
  * Fixed data filtering to properly exclude invalid and negative measurements from histograms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->