### PR TITLE
Open shared results as diagnostic reports

### DIFF
--- a/src/lib/components/App.svelte
+++ b/src/lib/components/App.svelte
@@ -230,7 +230,7 @@
 <div id="chronoscope-root">
   {#if $uiStore.pendingShare}
     <ConfigStagingBanner />
-  {:else if $uiStore.isSharedView}
+  {:else if $uiStore.isSharedView && !$uiStore.sharedReportMode}
     <SharedResultsBanner />
   {/if}
   <Layout onStart={handleStart} onStop={handleStop} />

--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -17,6 +17,7 @@
   import OverviewView from './OverviewView.svelte';
   import LiveView from './LiveView.svelte';
   import DiagnoseView from './DiagnoseView.svelte';
+  import ReportView from './ReportView.svelte';
   import FooterBar from './FooterBar.svelte';
 
   let { onStart, onStop }: {
@@ -34,6 +35,7 @@
   }
 
   const activeView = $derived($uiStore.activeView);
+  const sharedReportMode = $derived($uiStore.isSharedView && $uiStore.sharedReportMode);
 
   onMount(() => {
     unsubLifecycle = measurementStore.subscribe((state) => {
@@ -65,32 +67,38 @@
 >
   <Topbar {onStart} {onStop} />
 
-  <div class="shell-body">
-    <EndpointRail />
+  {#if sharedReportMode}
+    <main id="main-content" class="shell-main report-main" tabindex="-1">
+      <ReportView />
+    </main>
+  {:else}
+    <div class="shell-body">
+      <EndpointRail />
 
-    <div class="shell-main-wrap">
-      <ViewSwitcher />
+      <div class="shell-main-wrap">
+        <ViewSwitcher />
 
-      <main id="main-content" class="shell-main" tabindex="-1">
-        {#if activeView === 'live'}
-          <LiveView />
-        {:else if activeView === 'diagnose'}
-          <DiagnoseView />
-        {:else}
-          <!--
-            Fallback: overview renders here as the default. 'strata' and
-            'terminal' are still in the ActiveView union (disabled tabs in
-            ViewSwitcher, tracked by issues #50 and #51) — if either leaks
-            in via a hand-edited payload or future dev tooling, we show the
-            Overview rather than a blank stub. ViewSwitcher's disabled-state
-            guard prevents production paths from reaching this branch for
-            those two views.
-          -->
-          <OverviewView />
-        {/if}
-      </main>
+        <main id="main-content" class="shell-main" tabindex="-1">
+          {#if activeView === 'live'}
+            <LiveView />
+          {:else if activeView === 'diagnose'}
+            <DiagnoseView />
+          {:else}
+            <!--
+              Fallback: overview renders here as the default. 'strata' and
+              'terminal' are still in the ActiveView union (disabled tabs in
+              ViewSwitcher, tracked by issues #50 and #51) — if either leaks
+              in via a hand-edited payload or future dev tooling, we show the
+              Overview rather than a blank stub. ViewSwitcher's disabled-state
+              guard prevents production paths from reaching this branch for
+              those two views.
+            -->
+            <OverviewView />
+          {/if}
+        </main>
+      </div>
     </div>
-  </div>
+  {/if}
 
   <FooterBar />
 </div>
@@ -160,6 +168,10 @@
     min-height: 0;
   }
   .shell-main:focus { outline: none; }
+  .report-main {
+    flex: 1;
+    min-height: 0;
+  }
 
   .sr-only {
     position: absolute; width: 1px; height: 1px;

--- a/src/lib/components/ReportView.svelte
+++ b/src/lib/components/ReportView.svelte
@@ -1,0 +1,549 @@
+<!-- src/lib/components/ReportView.svelte -->
+<!-- Read-only diagnostic report for shared result links.                      -->
+<script lang="ts">
+  import { get } from 'svelte/store';
+  import { endpointStore } from '$lib/stores/endpoints';
+  import { measurementStore } from '$lib/stores/measurements';
+  import { settingsStore } from '$lib/stores/settings';
+  import { statisticsStore } from '$lib/stores/statistics';
+  import { uiStore } from '$lib/stores/ui';
+  import { buildShareURL } from '$lib/share/share-manager';
+  import { buildResultsSharePayload } from '$lib/share/share-payload-builder';
+  import { buildDiagnosticReport, formatReportMetric } from '$lib/utils/diagnostic-report';
+  import { tokens } from '$lib/tokens';
+
+  const endpoints = $derived($endpointStore);
+  const measurements = $derived($measurementStore);
+  const settings = $derived($settingsStore);
+  const stats = $derived($statisticsStore);
+  const context = $derived($uiStore.sharedReportContext);
+
+  const report = $derived(buildDiagnosticReport({
+    endpoints,
+    stats,
+    measurements,
+    settings,
+    context,
+  }));
+  const additionalLimitations = $derived(
+    report.diagnosis.limitations.filter((limit) => limit.id !== 'timing-visibility'),
+  );
+
+  let copiedSummary = $state(false);
+  let copiedLink = $state(false);
+
+  function copyText(text: string, onDone: () => void): void {
+    if (!navigator.clipboard) return;
+    void navigator.clipboard.writeText(text).then(() => {
+      onDone();
+      setTimeout(() => {
+        copiedSummary = false;
+        copiedLink = false;
+      }, 1800);
+    });
+  }
+
+  function handleCopySummary(): void {
+    copyText(report.copySummary, () => {
+      copiedSummary = true;
+    });
+  }
+
+  function handleCopyLink(): void {
+    const settingsForReport = {
+      ...get(settingsStore),
+      healthThreshold: report.threshold,
+      corsMode: report.corsMode,
+    };
+    const built = buildResultsSharePayload(
+      get(endpointStore),
+      settingsForReport,
+      get(measurementStore),
+      undefined,
+      Date.now(),
+      {
+        createdAt: report.createdAt ?? Date.now(),
+        healthThreshold: report.threshold,
+        corsMode: report.corsMode,
+        roundCount: report.roundCount,
+        totalSampleCount: report.totalSampleCount,
+        truncated: report.truncated,
+      },
+    );
+    copyText(buildShareURL(built.payload), () => {
+      copiedLink = true;
+    });
+  }
+
+  function handleInteractive(): void {
+    uiStore.setSharedReportMode(false);
+    const target = report.diagnosis.verdict.worstEpId;
+    if (target) {
+      uiStore.setFocusedEndpoint(target);
+      uiStore.setActiveView('diagnose');
+    } else {
+      uiStore.setActiveView('overview');
+    }
+  }
+
+  function handleRunOwn(): void {
+    uiStore.clearSharedView();
+    measurementStore.reset();
+  }
+</script>
+
+<section
+  class="report"
+  aria-label="Diagnostic report"
+  style:--accent-cyan={tokens.color.accent.cyan}
+  style:--accent-green={tokens.color.accent.green}
+  style:--accent-amber={tokens.color.accent.amber}
+  style:--accent-pink={tokens.color.accent.pink}
+>
+  <header class="report-hero">
+    <div class="report-kicker">Shared diagnostic report</div>
+    <div class="report-title-row">
+      <h1>{report.diagnosis.verdict.headline}</h1>
+      <span
+        class="confidence"
+        class:low={report.diagnosis.confidence === 'low'}
+        class:medium={report.diagnosis.confidence === 'medium'}
+        class:high={report.diagnosis.confidence === 'high'}
+        title={report.diagnosis.confidenceReason}
+      >{report.diagnosis.confidenceLabel}</span>
+    </div>
+    <p class="report-lede">{report.diagnosis.explanation}</p>
+
+    <div class="report-actions" aria-label="Report actions">
+      <button type="button" class="action action-primary" onclick={handleInteractive}>
+        Open Interactive Analysis
+      </button>
+      <button type="button" class="action" onclick={handleCopySummary}>
+        {copiedSummary ? 'Summary Copied' : 'Copy Summary'}
+      </button>
+      <button type="button" class="action" onclick={handleCopyLink}>
+        {copiedLink ? 'Link Copied' : 'Copy Report Link'}
+      </button>
+      <button type="button" class="action" onclick={handleRunOwn}>
+        Run Your Own Test
+      </button>
+    </div>
+  </header>
+
+  <section class="report-strip" aria-label="Report metadata">
+    <div>
+      <span class="metric-label">Created</span>
+      <strong>{report.createdLabel}</strong>
+    </div>
+    <div>
+      <span class="metric-label">Threshold</span>
+      <strong>{Math.round(report.threshold)} ms</strong>
+      <span class="metric-note">{report.thresholdSource === 'shared' ? 'from sender' : 'local default'}</span>
+    </div>
+    <div>
+      <span class="metric-label">Samples</span>
+      <strong>{report.keptSampleCount}</strong>
+      <span class="metric-note">{report.truncated ? `trimmed from ${report.totalSampleCount}` : `${report.roundCount} rounds`}</span>
+    </div>
+    <div>
+      <span class="metric-label">Timing mode</span>
+      <strong>{report.corsMode}</strong>
+      <span class="metric-note">{report.corsModeSource === 'shared' ? 'from sender' : report.corsModeSource === 'payload-settings' ? 'legacy link' : 'local default'}</span>
+    </div>
+  </section>
+
+  <div class="report-grid">
+    <section class="report-panel verdict-panel" aria-label="Verdict evidence">
+      <div class="section-kicker">Verdict evidence</div>
+      <div class="evidence-grid">
+        {#each report.diagnosis.evidence as item (item.label)}
+          <div class="evidence-item">
+            <span>{item.label}</span>
+            <strong>{item.value}</strong>
+            {#if item.detail}
+              <small>{item.detail}</small>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    </section>
+
+    <section class="report-panel" aria-label="Browser visibility">
+      <div class="section-kicker">Browser visibility</div>
+      <h2>{report.diagnosis.timingVisibility.headline}</h2>
+      <p>{report.diagnosis.timingVisibility.detail}</p>
+      {#if report.diagnosis.timingVisibility.action}
+        <p class="guidance">{report.diagnosis.timingVisibility.action}</p>
+      {/if}
+      {#if additionalLimitations.length > 0}
+        <div class="limitations">
+          {#each additionalLimitations as limit (limit.id)}
+            <div class="limitation">
+              <strong>{limit.headline}</strong>
+              <span>{limit.detail}</span>
+              {#if limit.action}
+                <small>{limit.action}</small>
+              {/if}
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </section>
+  </div>
+
+  <section class="report-panel endpoint-panel" aria-label="Endpoint comparison">
+    <div class="section-kicker">Endpoint comparison</div>
+    <div class="endpoint-table" role="table" aria-label="Endpoint report table">
+      <div class="endpoint-head" role="row">
+        <span role="columnheader">Endpoint</span>
+        <span role="columnheader">Status</span>
+        <span role="columnheader">p50</span>
+        <span role="columnheader">p95</span>
+        <span role="columnheader">Loss</span>
+        <span role="columnheader">Samples</span>
+      </div>
+      {#each report.endpointRows as row (row.endpointId)}
+        <div class="endpoint-row" role="row" class:implicated={row.implicated}>
+          <span class="endpoint-name" role="cell">
+            <i style:background={row.color || tokens.color.endpoint[0]} aria-hidden="true"></i>
+            <span>
+              <strong>{row.label}</strong>
+              <small>{row.url}</small>
+            </span>
+          </span>
+          <span role="cell" class="status-pill" class:ok={row.status === 'ok'} class:slow={row.status === 'slow'} class:loss={row.status === 'loss'} class:muted={row.status === 'unready' || row.status === 'disabled'}>
+            {row.implicated ? 'likely source' : row.status}
+          </span>
+          <span role="cell">{formatReportMetric(row.p50)}</span>
+          <span role="cell">{formatReportMetric(row.p95)}</span>
+          <span role="cell">{formatReportMetric(row.lossPercent, '%')}</span>
+          <span role="cell">{row.okCount}/{row.sampleCount}</span>
+        </div>
+      {/each}
+    </div>
+  </section>
+
+  <section class="next-steps" aria-label="Recommended next steps">
+    <div class="section-kicker">Recommended next steps</div>
+    <ol>
+      {#each report.diagnosis.nextSteps as step, i (`${i}-${step}`)}
+        <li>{step}</li>
+      {/each}
+    </ol>
+  </section>
+</section>
+
+<style>
+  .report {
+    width: 100%;
+    max-width: min(1120px, calc(100vw - 32px));
+    margin: 0 auto;
+    padding: 22px 0 32px;
+    color: var(--t1);
+    font-family: var(--sans);
+  }
+
+  .report-hero {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    padding: 4px 0 18px;
+    border-bottom: 1px solid var(--border-mid);
+  }
+
+  .report-kicker,
+  .section-kicker,
+  .metric-label,
+  .metric-note {
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    color: var(--t3);
+    letter-spacing: var(--tr-label);
+    text-transform: uppercase;
+  }
+
+  .report-title-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+  }
+
+  h1 {
+    margin: 0;
+    max-width: 820px;
+    font-size: 44px;
+    line-height: 1.02;
+    letter-spacing: 0;
+  }
+
+  h2 {
+    margin: 8px 0 0;
+    font-size: var(--ts-xl);
+    letter-spacing: 0;
+  }
+
+  .report-lede {
+    margin: 0;
+    max-width: 820px;
+    color: var(--t2);
+    font-size: var(--ts-lg);
+    line-height: 1.55;
+  }
+
+  .confidence,
+  .status-pill {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 28px;
+    padding: 0 10px;
+    border-radius: 999px;
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+  .confidence.low { color: var(--accent-amber); border: 1px solid rgba(251,191,36,.34); background: rgba(251,191,36,.08); }
+  .confidence.medium { color: var(--accent-cyan); border: 1px solid rgba(103,232,249,.32); background: rgba(103,232,249,.08); }
+  .confidence.high { color: var(--accent-green); border: 1px solid rgba(74,222,128,.34); background: rgba(74,222,128,.08); }
+
+  .report-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .action {
+    min-height: 44px;
+    border-radius: 8px;
+    border: 1px solid var(--border-mid);
+    background: rgba(255,255,255,.025);
+    color: var(--t2);
+    padding: 0 13px;
+    font-family: var(--sans);
+    font-size: var(--ts-sm);
+    cursor: pointer;
+  }
+  .action:hover {
+    color: var(--t1);
+    border-color: var(--border-bright);
+  }
+  .action-primary {
+    color: var(--accent-cyan);
+    border-color: rgba(103,232,249,.35);
+    background: rgba(103,232,249,.08);
+  }
+
+  .report-strip {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1px;
+    margin: 18px 0;
+    border: 1px solid var(--border-mid);
+    border-radius: 8px;
+    overflow: hidden;
+    background: var(--border-mid);
+  }
+  .report-strip > div {
+    min-width: 0;
+    padding: 13px 14px;
+    background: rgba(12,10,20,.68);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .report-strip strong {
+    font-size: var(--ts-lg);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .report-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 18px;
+    margin-bottom: 18px;
+  }
+
+  .report-panel,
+  .next-steps {
+    border: 1px solid var(--border-mid);
+    border-radius: 8px;
+    background: rgba(12,10,20,.58);
+    padding: 16px;
+  }
+
+  .evidence-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+    margin-top: 12px;
+  }
+  .evidence-item {
+    min-width: 0;
+    padding: 11px;
+    border-radius: 7px;
+    background: rgba(255,255,255,.035);
+    border: 1px solid rgba(255,255,255,.055);
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+  .evidence-item span,
+  .evidence-item small,
+  .limitations small,
+  .endpoint-name small {
+    color: var(--t3);
+  }
+  .evidence-item strong {
+    font-size: var(--ts-xl);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .report-panel p {
+    color: var(--t2);
+    line-height: 1.5;
+  }
+  .guidance {
+    padding-left: 10px;
+    border-left: 2px solid var(--accent-cyan);
+  }
+  .limitations {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 12px;
+  }
+  .limitation {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    padding: 10px;
+    border-radius: 7px;
+    background: rgba(251,191,36,.06);
+    border: 1px solid rgba(251,191,36,.16);
+  }
+  .limitation span {
+    color: var(--t2);
+  }
+
+  .endpoint-panel {
+    margin-bottom: 18px;
+  }
+  .endpoint-table {
+    margin-top: 12px;
+    display: flex;
+    flex-direction: column;
+    border: 1px solid rgba(255,255,255,.06);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .endpoint-head,
+  .endpoint-row {
+    display: grid;
+    grid-template-columns: minmax(220px, 1.7fr) .8fr .55fr .55fr .55fr .55fr;
+    gap: 10px;
+    align-items: center;
+    min-width: 0;
+  }
+  .endpoint-head {
+    padding: 10px 12px;
+    background: rgba(255,255,255,.035);
+    color: var(--t3);
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    text-transform: uppercase;
+  }
+  .endpoint-row {
+    padding: 12px;
+    border-top: 1px solid rgba(255,255,255,.055);
+    color: var(--t2);
+    font-variant-numeric: tabular-nums;
+  }
+  .endpoint-row.implicated {
+    background: rgba(249,168,212,.055);
+  }
+  .endpoint-name {
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .endpoint-name i {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .endpoint-name span {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .endpoint-name strong,
+  .endpoint-name small {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .status-pill {
+    justify-self: start;
+    min-height: 24px;
+    padding: 0 8px;
+    border: 1px solid rgba(255,255,255,.12);
+    color: var(--t3);
+    background: rgba(255,255,255,.035);
+  }
+  .status-pill.ok { color: var(--accent-green); border-color: rgba(74,222,128,.25); background: rgba(74,222,128,.07); }
+  .status-pill.slow,
+  .endpoint-row.implicated .status-pill { color: var(--accent-pink); border-color: rgba(249,168,212,.28); background: rgba(249,168,212,.08); }
+  .status-pill.loss { color: var(--accent-amber); border-color: rgba(251,191,36,.28); background: rgba(251,191,36,.08); }
+  .status-pill.muted { opacity: .75; }
+
+  .next-steps ol {
+    margin: 12px 0 0;
+    padding-left: 22px;
+    color: var(--t2);
+    line-height: 1.6;
+  }
+  .next-steps li + li {
+    margin-top: 6px;
+  }
+
+  @media (max-width: 900px) {
+    .report {
+      max-width: calc(100vw - 24px);
+      padding-top: 16px;
+    }
+    .report-title-row {
+      flex-direction: column;
+    }
+    .report-strip,
+    .report-grid {
+      grid-template-columns: 1fr;
+    }
+    .evidence-grid {
+      grid-template-columns: 1fr;
+    }
+    .endpoint-table {
+      overflow-x: auto;
+    }
+    .endpoint-head,
+    .endpoint-row {
+      min-width: 760px;
+    }
+  }
+
+  @media (max-width: 520px) {
+    .report-actions {
+      flex-direction: column;
+    }
+    .action {
+      width: 100%;
+    }
+    h1 {
+      font-size: 32px;
+    }
+  }
+</style>

--- a/src/lib/components/SharePopover.svelte
+++ b/src/lib/components/SharePopover.svelte
@@ -8,11 +8,14 @@
   import { endpointStore } from '$lib/stores/endpoints';
   import { settingsStore } from '$lib/stores/settings';
   import { measurementStore } from '$lib/stores/measurements';
-  import { buildShareURL, estimateShareSize, truncatePayload, toSharedSettings } from '$lib/share/share-manager';
+  import { buildShareURL } from '$lib/share/share-manager';
+  import {
+    buildConfigSharePayload,
+    buildResultsSharePayload,
+    MAX_SHARE_URL_CHARS,
+  } from '$lib/share/share-payload-builder';
   import { tokens } from '$lib/tokens';
   import type { SharePayload } from '$lib/types';
-
-  const MAX_URL_CHARS = 8000;
 
   let popoverEl: HTMLDivElement;
   let copiedConfig = $state(false);
@@ -26,52 +29,21 @@
   );
 
   let configPayload = $derived(buildConfigPayload());
-  let resultsPayload = $derived(hasResults ? buildResultsPayload() : null);
-  let resultsSize = $derived(resultsPayload ? estimateShareSize(resultsPayload) : 0);
-  let resultsTruncated = $derived(resultsSize > MAX_URL_CHARS);
+  let builtResults = $derived(hasResults ? buildResultsPayload() : null);
+  let resultsPayload = $derived(builtResults?.payload ?? null);
+  let resultsTruncated = $derived(builtResults?.truncated ?? false);
 
   function buildConfigPayload(): SharePayload {
-    const endpoints = get(endpointStore);
-    const settings = get(settingsStore);
-    return {
-      v: 1,
-      mode: 'config',
-      endpoints: endpoints.map(ep => ({ url: ep.url, enabled: ep.enabled })),
-      settings: toSharedSettings(settings),
-    };
+    return buildConfigSharePayload(get(endpointStore), get(settingsStore));
   }
 
-  function buildResultsPayload(): SharePayload {
-    const endpoints = get(endpointStore);
-    const settings = get(settingsStore);
-    const mstate = get(measurementStore);
-
-    const results = endpoints.map(ep => {
-      const epState = mstate.endpoints[ep.id];
-      return {
-        samples: (epState?.samples ?? []).map(s => ({
-          round: s.round,
-          latency: s.latency,
-          status: s.status,
-          ...(s.tier2 ? { tier2: s.tier2 } : {}),
-        })),
-      };
-    });
-
-    const payload: SharePayload = {
-      v: 1,
-      mode: 'results',
-      endpoints: endpoints.map(ep => ({ url: ep.url, enabled: ep.enabled })),
-      settings: toSharedSettings(settings),
-      results,
-    };
-
-    // Auto-truncate if too large
-    if (estimateShareSize(payload) > MAX_URL_CHARS) {
-      return truncatePayload(payload, MAX_URL_CHARS);
-    }
-
-    return payload;
+  function buildResultsPayload() {
+    return buildResultsSharePayload(
+      get(endpointStore),
+      get(settingsStore),
+      get(measurementStore),
+      MAX_SHARE_URL_CHARS,
+    );
   }
 
   async function handleCopyConfig(): Promise<void> {

--- a/src/lib/components/SharedResultsBanner.svelte
+++ b/src/lib/components/SharedResultsBanner.svelte
@@ -5,6 +5,12 @@
   import { uiStore } from '$lib/stores/ui';
   import { measurementStore } from '$lib/stores/measurements';
 
+  const reportMode = $derived($uiStore.sharedReportMode);
+
+  function handleToggleReport(): void {
+    uiStore.setSharedReportMode(!reportMode);
+  }
+
   function handleRunAgain(): void {
     uiStore.clearSharedView();
     measurementStore.reset();
@@ -18,15 +24,24 @@
 >
   <div class="banner-content">
     <span class="banner-icon" aria-hidden="true">↗</span>
-    <span class="banner-text">Shared results — read only. Run your own test to measure from your location.</span>
+    <span class="banner-text">Shared diagnostic report — read only. Run your own test to measure from your location.</span>
   </div>
-  <button
-    type="button"
-    class="btn-run-again"
-    onclick={handleRunAgain}
-  >
-    Run Your Own Test
-  </button>
+  <div class="banner-actions">
+    <button
+      type="button"
+      class="btn-banner"
+      onclick={handleToggleReport}
+    >
+      {reportMode ? 'Open Interactive Analysis' : 'View Report'}
+    </button>
+    <button
+      type="button"
+      class="btn-banner btn-run-again"
+      onclick={handleRunAgain}
+    >
+      Run Your Own Test
+    </button>
+  </div>
 </div>
 
 <style>
@@ -71,7 +86,14 @@
     text-overflow: ellipsis;
   }
 
-  .btn-run-again {
+  .banner-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    flex-shrink: 0;
+  }
+
+  .btn-banner {
     flex-shrink: 0;
     padding: var(--spacing-xs) var(--spacing-sm);
     border: 1px solid var(--accent-cyan);
@@ -89,7 +111,7 @@
     align-items: center;
   }
 
-  .btn-run-again:hover {
+  .btn-banner:hover {
     background: var(--accent-cyan);
     color: var(--bg-base);
   }
@@ -99,6 +121,11 @@
     .shared-banner {
       flex-direction: column;
       align-items: flex-start;
+    }
+
+    .banner-actions {
+      width: 100%;
+      flex-wrap: wrap;
     }
 
     .banner-text {

--- a/src/lib/share/hash-router.ts
+++ b/src/lib/share/hash-router.ts
@@ -19,7 +19,13 @@ import { parseShareURL } from './share-manager';
 import { endpointStore, MAX_ENDPOINTS } from '../stores/endpoints';
 import { measurementStore } from '../stores/measurements';
 import { uiStore } from '../stores/ui';
-import type { SharePayload, MeasurementSample, SampleStatus, Endpoint } from '../types';
+import type {
+  SharePayload,
+  MeasurementSample,
+  SampleStatus,
+  Endpoint,
+  SharedReportContext,
+} from '../types';
 import { tokens } from '../tokens';
 import { get } from 'svelte/store';
 import { displayLabel } from '../endpoint/displayLabel';
@@ -76,6 +82,51 @@ function buildEndpoints(
   }));
 }
 
+function countResultSamples(results: NonNullable<SharePayload['results']>): number {
+  let count = 0;
+  for (const result of results) count += result.samples.length;
+  return count;
+}
+
+function inferRoundCount(results: NonNullable<SharePayload['results']>): number {
+  let maxRound = 0;
+  for (const result of results) {
+    for (const sample of result.samples) {
+      if (sample.round > maxRound) maxRound = sample.round;
+    }
+  }
+  return maxRound;
+}
+
+function buildSharedReportContext(payload: SharePayload): SharedReportContext | null {
+  if (payload.mode !== 'results' || !payload.results) return null;
+
+  const keptSampleCount = countResultSamples(payload.results);
+  if (payload.v === 2 && payload.report) {
+    return {
+      createdAt: payload.report.createdAt,
+      healthThreshold: payload.report.healthThreshold,
+      corsMode: payload.report.corsMode,
+      roundCount: payload.report.roundCount,
+      totalSampleCount: payload.report.totalSampleCount,
+      keptSampleCount: payload.report.keptSampleCount,
+      truncated: payload.report.truncated,
+      sourceVersion: 2,
+    };
+  }
+
+  return {
+    createdAt: null,
+    healthThreshold: null,
+    corsMode: payload.settings.corsMode,
+    roundCount: inferRoundCount(payload.results),
+    totalSampleCount: keptSampleCount,
+    keptSampleCount,
+    truncated: false,
+    sourceVersion: 1,
+  };
+}
+
 /**
  * Apply a decoded SharePayload.
  *
@@ -99,6 +150,8 @@ export function applySharePayload(payload: SharePayload): string[] {
       mode: 'config',
       endpoints: uniqueEndpoints(payload.endpoints),
     });
+    uiStore.setSharedReportMode(false);
+    uiStore.setSharedReportContext(null);
     return [];
   }
 
@@ -172,9 +225,13 @@ export function applySharePayload(payload: SharePayload): string[] {
 
     measurementStore.loadSnapshot(snapshot);
 
+    uiStore.setSharedReportContext(buildSharedReportContext(payload));
     uiStore.setSharedView(true);
+    uiStore.setSharedReportMode(true);
   } else {
     uiStore.setSharedView(false);
+    uiStore.setSharedReportMode(false);
+    uiStore.setSharedReportContext(null);
   }
 
   return ids;

--- a/src/lib/share/hash-router.ts
+++ b/src/lib/share/hash-router.ts
@@ -88,7 +88,7 @@ function countResultSamples(results: NonNullable<SharePayload['results']>): numb
   return count;
 }
 
-function inferRoundCount(results: NonNullable<SharePayload['results']>): number {
+function inferRoundCounter(results: NonNullable<SharePayload['results']>): number {
   let maxRound = 0;
   for (const result of results) {
     for (const sample of result.samples) {
@@ -119,7 +119,7 @@ function buildSharedReportContext(payload: SharePayload): SharedReportContext | 
     createdAt: null,
     healthThreshold: null,
     corsMode: payload.settings.corsMode,
-    roundCount: inferRoundCount(payload.results),
+    roundCount: inferRoundCounter(payload.results),
     totalSampleCount: keptSampleCount,
     keptSampleCount,
     truncated: false,

--- a/src/lib/share/share-manager.ts
+++ b/src/lib/share/share-manager.ts
@@ -57,7 +57,7 @@ function validateSharePayload(data: unknown): SharePayload | null {
   if (data === null || typeof data !== 'object') return null;
   const obj = data as Record<string, unknown>;
 
-  if (obj['v'] !== 1) return null;
+  if (obj['v'] !== 1 && obj['v'] !== 2) return null;
   if (obj['mode'] !== 'config' && obj['mode'] !== 'results') return null;
   if (!Array.isArray(obj['endpoints'])) return null;
   if ((obj['endpoints'] as unknown[]).length > 50) return null;
@@ -91,8 +91,36 @@ function validateSharePayload(data: unknown): SharePayload | null {
   if (s['monitorDelay'] !== undefined && (!isNonNegativeFiniteNumber(s['monitorDelay']) || (s['monitorDelay'] as number) > 60000)) return null;
   if (s['corsMode'] !== 'no-cors' && s['corsMode'] !== 'cors') return null;
 
-  // Reject unknown top-level keys. Allowlist: v, mode, endpoints, settings, results. Symmetric with per-entry — closes future round-trip footgun.
-  const ALLOWED_TOP_LEVEL = new Set(['v', 'mode', 'endpoints', 'settings', 'results']);
+  if (obj['report'] !== undefined) {
+    if (obj['mode'] !== 'results') return null;
+    if (obj['v'] !== 2) return null;
+    const report = obj['report'];
+    if (report === null || typeof report !== 'object') return null;
+    const r = report as Record<string, unknown>;
+    const allowedReportKeys = new Set([
+      'createdAt',
+      'healthThreshold',
+      'corsMode',
+      'roundCount',
+      'totalSampleCount',
+      'keptSampleCount',
+      'truncated',
+    ]);
+    for (const key of Object.keys(r)) {
+      if (!allowedReportKeys.has(key)) return null;
+    }
+    if (!isNonNegativeFiniteNumber(r['createdAt'])) return null;
+    if (!isNonNegativeFiniteNumber(r['healthThreshold']) || (r['healthThreshold'] as number) > 15000) return null;
+    if (r['corsMode'] !== 'no-cors' && r['corsMode'] !== 'cors') return null;
+    if (!isNonNegativeFiniteNumber(r['roundCount']) || (r['roundCount'] as number) > 1_000_000) return null;
+    if (!isNonNegativeFiniteNumber(r['totalSampleCount']) || (r['totalSampleCount'] as number) > 500_000) return null;
+    if (!isNonNegativeFiniteNumber(r['keptSampleCount']) || (r['keptSampleCount'] as number) > 500_000) return null;
+    if ((r['keptSampleCount'] as number) > (r['totalSampleCount'] as number)) return null;
+    if (typeof r['truncated'] !== 'boolean') return null;
+  }
+
+  // Reject unknown top-level keys. Allowlist: v, mode, endpoints, settings, results, report. Symmetric with per-entry.
+  const ALLOWED_TOP_LEVEL = new Set(['v', 'mode', 'endpoints', 'settings', 'results', 'report']);
   for (const key of Object.keys(obj)) {
     if (!ALLOWED_TOP_LEVEL.has(key)) return null;
   }

--- a/src/lib/share/share-payload-builder.ts
+++ b/src/lib/share/share-payload-builder.ts
@@ -64,15 +64,19 @@ export function buildResultsSharePayload(
   reportMetadata: Partial<ShareReportMetadata> = {},
 ): BuiltResultsSharePayload {
   const results = buildResults(endpoints, measurements);
-  const totalSampleCount = countSamples(results);
+  const keptSampleCount = countSamples(results);
+  const totalSampleCount = Math.max(
+    reportMetadata.totalSampleCount ?? keptSampleCount,
+    keptSampleCount,
+  );
 
   const metadata: ShareReportMetadata = {
     createdAt: reportMetadata.createdAt ?? now,
     healthThreshold: reportMetadata.healthThreshold ?? settings.healthThreshold,
     corsMode: reportMetadata.corsMode ?? settings.corsMode,
     roundCount: reportMetadata.roundCount ?? measurements.roundCounter,
-    totalSampleCount: reportMetadata.totalSampleCount ?? totalSampleCount,
-    keptSampleCount: totalSampleCount,
+    totalSampleCount,
+    keptSampleCount,
     truncated: reportMetadata.truncated ?? false,
   };
 
@@ -94,10 +98,10 @@ export function buildResultsSharePayload(
   }
 
   const truncatedPayload = truncatePayload(basePayload, maxChars);
-  const keptSampleCount = countSamples(truncatedPayload.results ?? []);
+  const truncatedKeptSampleCount = countSamples(truncatedPayload.results ?? []);
   const payload = withReportMetadata(truncatedPayload, {
     ...metadata,
-    keptSampleCount,
+    keptSampleCount: truncatedKeptSampleCount,
     truncated: true,
   });
 

--- a/src/lib/share/share-payload-builder.ts
+++ b/src/lib/share/share-payload-builder.ts
@@ -1,0 +1,109 @@
+// src/lib/share/share-payload-builder.ts
+// Pure builders for config and result share payloads. Keeping this outside the
+// popover lets ReportView copy the exact report link that SharePopover emits.
+
+import type { Endpoint, MeasurementState, Settings, SharePayload, ShareReportMetadata } from '../types';
+import { estimateShareSize, toSharedSettings, truncatePayload } from './share-manager';
+
+export const MAX_SHARE_URL_CHARS = 8000;
+
+export interface BuiltResultsSharePayload {
+  readonly payload: SharePayload;
+  readonly estimatedSize: number;
+  readonly truncated: boolean;
+}
+
+export function buildConfigSharePayload(
+  endpoints: readonly Endpoint[],
+  settings: Settings,
+): SharePayload {
+  return {
+    v: 1,
+    mode: 'config',
+    endpoints: endpoints.map(ep => ({ url: ep.url, enabled: ep.enabled })),
+    settings: toSharedSettings(settings),
+  };
+}
+
+function countSamples(results: NonNullable<SharePayload['results']>): number {
+  let count = 0;
+  for (const result of results) count += result.samples.length;
+  return count;
+}
+
+function buildResults(
+  endpoints: readonly Endpoint[],
+  measurements: MeasurementState,
+): NonNullable<SharePayload['results']> {
+  return endpoints.map(ep => {
+    const epState = measurements.endpoints[ep.id];
+    return {
+      samples: (epState?.samples ?? []).map(s => ({
+        round: s.round,
+        latency: s.latency,
+        status: s.status,
+        ...(s.tier2 ? { tier2: s.tier2 } : {}),
+      })),
+    };
+  });
+}
+
+function withReportMetadata(
+  payload: SharePayload,
+  metadata: ShareReportMetadata,
+): SharePayload {
+  return { ...payload, report: metadata };
+}
+
+export function buildResultsSharePayload(
+  endpoints: readonly Endpoint[],
+  settings: Settings,
+  measurements: MeasurementState,
+  maxChars = MAX_SHARE_URL_CHARS,
+  now = Date.now(),
+  reportMetadata: Partial<ShareReportMetadata> = {},
+): BuiltResultsSharePayload {
+  const results = buildResults(endpoints, measurements);
+  const totalSampleCount = countSamples(results);
+
+  const metadata: ShareReportMetadata = {
+    createdAt: reportMetadata.createdAt ?? now,
+    healthThreshold: reportMetadata.healthThreshold ?? settings.healthThreshold,
+    corsMode: reportMetadata.corsMode ?? settings.corsMode,
+    roundCount: reportMetadata.roundCount ?? measurements.roundCounter,
+    totalSampleCount: reportMetadata.totalSampleCount ?? totalSampleCount,
+    keptSampleCount: totalSampleCount,
+    truncated: reportMetadata.truncated ?? false,
+  };
+
+  const basePayload: SharePayload = {
+    v: 2,
+    mode: 'results',
+    endpoints: endpoints.map(ep => ({ url: ep.url, enabled: ep.enabled })),
+    settings: toSharedSettings(settings),
+    report: metadata,
+    results,
+  };
+
+  if (estimateShareSize(basePayload) <= maxChars) {
+    return {
+      payload: basePayload,
+      estimatedSize: estimateShareSize(basePayload),
+      truncated: false,
+    };
+  }
+
+  const truncatedPayload = truncatePayload(basePayload, maxChars);
+  const keptSampleCount = countSamples(truncatedPayload.results ?? []);
+  const payload = withReportMetadata(truncatedPayload, {
+    ...metadata,
+    keptSampleCount,
+    truncated: true,
+  });
+
+  return {
+    payload,
+    estimatedSize: estimateShareSize(payload),
+    truncated: true,
+  };
+}

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -3,7 +3,7 @@
 // and panel visibility. No side effects; all state is local to this module.
 
 import { writable } from 'svelte/store';
-import type { LiveTimeRange, PendingShare, TerminalEventType, UIState } from '../types';
+import type { LiveTimeRange, PendingShare, SharedReportContext, TerminalEventType, UIState } from '../types';
 
 const initialState = (): UIState => ({
   // 'overview' is the v2 default. Phase 7 migration (v6→v7) collapses any
@@ -15,6 +15,8 @@ const initialState = (): UIState => ({
   showShare: false,
   showKeyboardHelp: false,
   isSharedView: false,
+  sharedReportMode: false,
+  sharedReportContext: null,
   pendingShare: null,
   showEndpoints: false,
   focusedEndpointId: null,
@@ -57,7 +59,18 @@ function createUiStore() {
       update((s) => ({ ...s, isSharedView: isShared }));
     },
     clearSharedView(): void {
-      update((s) => ({ ...s, isSharedView: false }));
+      update((s) => ({
+        ...s,
+        isSharedView: false,
+        sharedReportMode: false,
+        sharedReportContext: null,
+      }));
+    },
+    setSharedReportMode(enabled: boolean): void {
+      update((s) => ({ ...s, sharedReportMode: enabled }));
+    },
+    setSharedReportContext(context: SharedReportContext | null): void {
+      update((s) => ({ ...s, sharedReportContext: context }));
     },
     setPendingShare(pending: PendingShare): void {
       update((s) => ({ ...s, pendingShare: pending }));

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -250,6 +250,8 @@ export interface UIState {
   showShare: boolean;
   showKeyboardHelp: boolean;
   isSharedView: boolean;
+  sharedReportMode: boolean;
+  sharedReportContext: SharedReportContext | null;
   pendingShare: PendingShare | null;
   showEndpoints: boolean;
 
@@ -274,8 +276,29 @@ export interface UIState {
 }
 
 // ── Share payload ──────────────────────────────────────────────────────────
+export interface ShareReportMetadata {
+  readonly createdAt: number;
+  readonly healthThreshold: number;
+  readonly corsMode: 'no-cors' | 'cors';
+  readonly roundCount: number;
+  readonly totalSampleCount: number;
+  readonly keptSampleCount: number;
+  readonly truncated: boolean;
+}
+
+export interface SharedReportContext {
+  readonly createdAt: number | null;
+  readonly healthThreshold: number | null;
+  readonly corsMode: 'no-cors' | 'cors' | null;
+  readonly roundCount: number;
+  readonly totalSampleCount: number;
+  readonly keptSampleCount: number;
+  readonly truncated: boolean;
+  readonly sourceVersion: 1 | 2;
+}
+
 export interface SharePayload {
-  readonly v: 1;
+  readonly v: 1 | 2;
   readonly mode: 'config' | 'results';
   readonly endpoints: readonly { url: string; enabled: boolean }[];
   readonly settings: {
@@ -286,6 +309,7 @@ export interface SharePayload {
     readonly cap: number;
     readonly corsMode: 'no-cors' | 'cors';
   };
+  readonly report?: ShareReportMetadata;
   readonly results?: readonly {
     readonly samples: readonly {
       readonly round: number;
@@ -318,4 +342,3 @@ export interface PersistedSettings {
     terminalFilters?: TerminalEventType[];
   };
 }
-

--- a/src/lib/utils/diagnostic-report.ts
+++ b/src/lib/utils/diagnostic-report.ts
@@ -1,0 +1,218 @@
+// src/lib/utils/diagnostic-report.ts
+// Pure report model for shared result snapshots. It turns the live diagnostic
+// narrative into a support-ready, read-only artifact.
+
+import type {
+  Endpoint,
+  EndpointStatistics,
+  MeasurementSample,
+  MeasurementState,
+  Settings,
+  SharedReportContext,
+  StatisticsState,
+} from '../types';
+import { buildDiagnosticNarrative, type DiagnosticNarrative } from './diagnostic-narrative';
+import type { VerdictRow } from './verdict';
+
+export interface ReportEndpointRow {
+  readonly endpointId: string;
+  readonly label: string;
+  readonly url: string;
+  readonly color: string;
+  readonly enabled: boolean;
+  readonly sampleCount: number;
+  readonly okCount: number;
+  readonly p50: number | null;
+  readonly p95: number | null;
+  readonly p99: number | null;
+  readonly jitter: number | null;
+  readonly lossPercent: number;
+  readonly lastLatency: number | null;
+  readonly status: 'ok' | 'slow' | 'loss' | 'unready' | 'disabled';
+  readonly implicated: boolean;
+}
+
+export interface DiagnosticReport {
+  readonly diagnosis: DiagnosticNarrative;
+  readonly endpointRows: readonly ReportEndpointRow[];
+  readonly threshold: number;
+  readonly thresholdSource: 'shared' | 'local-default';
+  readonly corsMode: Settings['corsMode'];
+  readonly corsModeSource: 'shared' | 'payload-settings' | 'local-default';
+  readonly roundCount: number;
+  readonly totalSampleCount: number;
+  readonly keptSampleCount: number;
+  readonly truncated: boolean;
+  readonly createdAt: number | null;
+  readonly createdLabel: string;
+  readonly copySummary: string;
+}
+
+interface DiagnosticReportInput {
+  readonly endpoints: readonly Endpoint[];
+  readonly stats: StatisticsState;
+  readonly measurements: MeasurementState;
+  readonly settings: Settings;
+  readonly context: SharedReportContext | null;
+}
+
+function fmtMs(value: number | null): string {
+  return value === null ? '-' : `${Math.round(value)} ms`;
+}
+
+function fmtPct(value: number): string {
+  return `${value.toFixed(1)}%`;
+}
+
+function sampleArrayFor(measurements: MeasurementState, endpointId: string): readonly MeasurementSample[] {
+  return measurements.endpoints[endpointId]?.samples.toArray() ?? [];
+}
+
+function okCount(samples: readonly MeasurementSample[]): number {
+  return samples.filter((sample) => sample.status === 'ok').length;
+}
+
+function statusFor(input: {
+  readonly endpoint: Endpoint;
+  readonly stats: EndpointStatistics | undefined;
+  readonly threshold: number;
+  readonly samples: readonly MeasurementSample[];
+}): ReportEndpointRow['status'] {
+  const { endpoint, stats, threshold, samples } = input;
+  if (!endpoint.enabled) return 'disabled';
+  if (!stats?.ready || samples.length === 0) return 'unready';
+  if (stats.lossPercent > 1) return 'loss';
+  if (stats.p50 > threshold) return 'slow';
+  return 'ok';
+}
+
+function sumSamples(samplesByEndpoint: Readonly<Record<string, readonly MeasurementSample[]>>): number {
+  let total = 0;
+  for (const samples of Object.values(samplesByEndpoint)) total += samples.length;
+  return total;
+}
+
+function defaultCreatedLabel(createdAt: number | null): string {
+  if (createdAt === null) return 'Shared snapshot';
+  return new Date(createdAt).toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function buildEndpointRows(input: {
+  readonly endpoints: readonly Endpoint[];
+  readonly stats: StatisticsState;
+  readonly measurements: MeasurementState;
+  readonly threshold: number;
+  readonly diagnosis: DiagnosticNarrative;
+}): ReportEndpointRow[] {
+  return input.endpoints.map((endpoint) => {
+    const stats = input.stats[endpoint.id];
+    const samples = sampleArrayFor(input.measurements, endpoint.id);
+    const status = statusFor({ endpoint, stats, threshold: input.threshold, samples });
+
+    return {
+      endpointId: endpoint.id,
+      label: endpoint.label,
+      url: endpoint.url,
+      color: endpoint.color,
+      enabled: endpoint.enabled,
+      sampleCount: samples.length,
+      okCount: okCount(samples),
+      p50: stats?.ready ? stats.p50 : null,
+      p95: stats?.ready ? stats.p95 : null,
+      p99: stats?.ready ? stats.p99 : null,
+      jitter: stats?.ready ? stats.stddev : null,
+      lossPercent: stats?.lossPercent ?? 0,
+      lastLatency: input.measurements.endpoints[endpoint.id]?.lastLatency ?? null,
+      status,
+      implicated: input.diagnosis.verdict.worstEpId === endpoint.id,
+    };
+  });
+}
+
+function buildCopySummary(report: Omit<DiagnosticReport, 'copySummary'>): string {
+  const slowRows = report.endpointRows.filter((row) => row.status === 'slow' || row.implicated);
+  const slowLine = slowRows.length > 0
+    ? `Likely affected: ${slowRows.map((row) => `${row.label} (${fmtMs(row.p50)} p50)`).join(', ')}.`
+    : 'No endpoint is currently above the report threshold.';
+  const visibility = report.diagnosis.timingVisibility;
+  const limitation = report.diagnosis.limitations[0];
+  const nextStep = report.diagnosis.nextSteps[0] ?? 'Run another comparison from the affected network.';
+
+  return [
+    `Chronoscope diagnostic report: ${report.diagnosis.verdict.headline} (${report.diagnosis.confidenceLabel}).`,
+    report.diagnosis.explanation,
+    slowLine,
+    `Evidence: ${report.keptSampleCount} samples kept across ${report.endpointRows.length} endpoints; threshold ${fmtMs(report.threshold)}; browser visibility: ${visibility.headline}.`,
+    limitation ? `Caveat: ${limitation.detail}` : '',
+    `Next step: ${nextStep}`,
+  ].filter(Boolean).join('\n');
+}
+
+export function buildDiagnosticReport(input: DiagnosticReportInput): DiagnosticReport {
+  const threshold = input.context?.healthThreshold ?? input.settings.healthThreshold;
+  const thresholdSource = input.context?.healthThreshold === null || input.context === null
+    ? 'local-default'
+    : 'shared';
+  const corsMode = input.context?.corsMode ?? input.settings.corsMode;
+  const corsModeSource = input.context?.corsMode
+    ? (input.context.sourceVersion === 2 ? 'shared' : 'payload-settings')
+    : 'local-default';
+
+  const samplesByEndpoint: Record<string, readonly MeasurementSample[]> = {};
+  for (const endpoint of input.endpoints) {
+    samplesByEndpoint[endpoint.id] = sampleArrayFor(input.measurements, endpoint.id);
+  }
+
+  const monitored = input.endpoints.filter((endpoint) => endpoint.enabled);
+  const rows: VerdictRow[] = [];
+  for (const endpoint of monitored) {
+    const endpointStats = input.stats[endpoint.id];
+    if (endpointStats?.ready) rows.push({ ep: endpoint, stats: endpointStats });
+  }
+
+  const diagnosis = buildDiagnosticNarrative({
+    rows,
+    threshold,
+    corsMode,
+    samplesByEndpoint,
+    monitoredEndpointCount: monitored.length,
+  });
+
+  const fallbackSampleCount = sumSamples(samplesByEndpoint);
+  const reportWithoutSummary: Omit<DiagnosticReport, 'copySummary'> = {
+    diagnosis,
+    endpointRows: buildEndpointRows({
+      endpoints: input.endpoints,
+      stats: input.stats,
+      measurements: input.measurements,
+      threshold,
+      diagnosis,
+    }),
+    threshold,
+    thresholdSource,
+    corsMode,
+    corsModeSource,
+    roundCount: input.context?.roundCount ?? input.measurements.roundCounter,
+    totalSampleCount: input.context?.totalSampleCount ?? fallbackSampleCount,
+    keptSampleCount: input.context?.keptSampleCount ?? fallbackSampleCount,
+    truncated: input.context?.truncated ?? false,
+    createdAt: input.context?.createdAt ?? null,
+    createdLabel: defaultCreatedLabel(input.context?.createdAt ?? null),
+  };
+
+  return {
+    ...reportWithoutSummary,
+    copySummary: buildCopySummary(reportWithoutSummary),
+  };
+}
+
+export function formatReportMetric(value: number | null, suffix: 'ms' | '%' = 'ms'): string {
+  if (suffix === '%') return value === null ? '-' : fmtPct(value);
+  return fmtMs(value);
+}

--- a/src/lib/utils/diagnostic-report.ts
+++ b/src/lib/utils/diagnostic-report.ts
@@ -156,11 +156,9 @@ function buildCopySummary(report: Omit<DiagnosticReport, 'copySummary'>): string
 
 export function buildDiagnosticReport(input: DiagnosticReportInput): DiagnosticReport {
   const threshold = input.context?.healthThreshold ?? input.settings.healthThreshold;
-  const thresholdSource = input.context?.healthThreshold === null || input.context === null
-    ? 'local-default'
-    : 'shared';
+  const thresholdSource = input.context?.healthThreshold != null ? 'shared' : 'local-default';
   const corsMode = input.context?.corsMode ?? input.settings.corsMode;
-  const corsModeSource = input.context?.corsMode
+  const corsModeSource = input.context?.corsMode != null
     ? (input.context.sourceVersion === 2 ? 'shared' : 'payload-settings')
     : 'local-default';
 

--- a/tests/unit/share-manager.test.ts
+++ b/tests/unit/share-manager.test.ts
@@ -75,12 +75,33 @@ describe('share-manager', () => {
     expect(decodeSharePayload('')).toBeNull();
   });
 
-  it('returns null for wrong schema version', async () => {
-    const badPayload = { v: 2, mode: 'config', endpoints: [], settings: {} };
+  it('returns null for unsupported schema version', async () => {
+    const badPayload = { v: 3, mode: 'config', endpoints: [], settings: {} };
     // Manually encode so we bypass our own encodeSharePayload typed guard
     const { default: LZString } = await import('lz-string');
     const manualEncoded = LZString.compressToEncodedURIComponent(JSON.stringify(badPayload));
     expect(decodeSharePayload(manualEncoded)).toBeNull();
+  });
+
+  it('round-trips v2 report metadata for result payloads', () => {
+    const payload: SharePayload = {
+      ...resultsPayload,
+      v: 2,
+      report: {
+        createdAt: 1778352000000,
+        healthThreshold: 120,
+        corsMode: 'no-cors',
+        roundCount: 50,
+        totalSampleCount: 100,
+        keptSampleCount: 100,
+        truncated: false,
+      },
+    };
+
+    const decoded = decodeSharePayload(encodeSharePayload(payload));
+    expect(decoded?.v).toBe(2);
+    expect(decoded?.report?.healthThreshold).toBe(120);
+    expect(decoded?.report?.keptSampleCount).toBe(100);
   });
 
   it('config-only payload is small', () => {

--- a/tests/unit/share-payload-builder.test.ts
+++ b/tests/unit/share-payload-builder.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildConfigSharePayload,
+  buildResultsSharePayload,
+} from '../../src/lib/share/share-payload-builder';
+import type { Endpoint, MeasurementSample, MeasurementState, SampleBuffer } from '../../src/lib/types';
+import { DEFAULT_SETTINGS } from '../../src/lib/types';
+
+function endpoint(id: string): Endpoint {
+  return {
+    id,
+    url: `https://${id}.example.test`,
+    label: id,
+    enabled: true,
+    color: '#67e8f9',
+  };
+}
+
+function ok(round: number): MeasurementSample {
+  return {
+    round,
+    latency: 50 + round,
+    status: 'ok',
+    timestamp: 0,
+  };
+}
+
+function buffer(samples: readonly MeasurementSample[]): SampleBuffer {
+  return {
+    length: samples.length,
+    tailIndex: samples.length,
+    at: (index: number) => samples[index],
+    filter: samples.filter.bind(samples),
+    map: samples.map.bind(samples),
+    find: samples.find.bind(samples),
+    reduce: samples.reduce.bind(samples) as SampleBuffer['reduce'],
+    slice: samples.slice.bind(samples),
+    forEach: samples.forEach.bind(samples),
+    toArray: () => [...samples],
+    [Symbol.iterator]: samples[Symbol.iterator].bind(samples),
+  } as SampleBuffer;
+}
+
+function measurementState(endpointId: string, samples: readonly MeasurementSample[]): MeasurementState {
+  return {
+    lifecycle: 'completed',
+    epoch: 1,
+    roundCounter: samples.length,
+    endpoints: {
+      [endpointId]: {
+        endpointId,
+        samples: buffer(samples),
+        lastLatency: samples.at(-1)?.latency ?? null,
+        lastStatus: samples.at(-1)?.status ?? null,
+        lastErrorMessage: null,
+        tierLevel: 1,
+      },
+    },
+    startedAt: null,
+    stoppedAt: null,
+    freezeEvents: [],
+    errorCount: 0,
+    timeoutCount: 0,
+  };
+}
+
+describe('share-payload-builder', () => {
+  it('builds v1 config payloads', () => {
+    const payload = buildConfigSharePayload([endpoint('api')], DEFAULT_SETTINGS);
+    expect(payload.v).toBe(1);
+    expect(payload.mode).toBe('config');
+    expect(payload.report).toBeUndefined();
+  });
+
+  it('builds v2 result payloads with report metadata', () => {
+    const ep = endpoint('api');
+    const built = buildResultsSharePayload(
+      [ep],
+      DEFAULT_SETTINGS,
+      measurementState(ep.id, Array.from({ length: 12 }, (_, i) => ok(i + 1))),
+      8000,
+      1778352000000,
+    );
+
+    expect(built.payload.v).toBe(2);
+    expect(built.payload.report?.createdAt).toBe(1778352000000);
+    expect(built.payload.report?.healthThreshold).toBe(DEFAULT_SETTINGS.healthThreshold);
+    expect(built.payload.report?.keptSampleCount).toBe(12);
+    expect(built.truncated).toBe(false);
+  });
+
+  it('preserves report metadata overrides when re-copying a report link', () => {
+    const ep = endpoint('api');
+    const built = buildResultsSharePayload(
+      [ep],
+      { ...DEFAULT_SETTINGS, healthThreshold: 999 },
+      measurementState(ep.id, Array.from({ length: 4 }, (_, i) => ok(i + 1))),
+      8000,
+      1778352000000,
+      {
+        createdAt: 1778000000000,
+        healthThreshold: 140,
+        totalSampleCount: 40,
+        truncated: true,
+      },
+    );
+
+    expect(built.payload.report?.createdAt).toBe(1778000000000);
+    expect(built.payload.report?.healthThreshold).toBe(140);
+    expect(built.payload.report?.totalSampleCount).toBe(40);
+    expect(built.payload.report?.keptSampleCount).toBe(4);
+    expect(built.payload.report?.truncated).toBe(true);
+  });
+});

--- a/tests/unit/share-payload-builder.test.ts
+++ b/tests/unit/share-payload-builder.test.ts
@@ -111,4 +111,21 @@ describe('share-payload-builder', () => {
     expect(built.payload.report?.keptSampleCount).toBe(4);
     expect(built.payload.report?.truncated).toBe(true);
   });
+
+  it('keeps keptSampleCount within totalSampleCount when a caller passes a stale total override', () => {
+    const ep = endpoint('api');
+    const built = buildResultsSharePayload(
+      [ep],
+      DEFAULT_SETTINGS,
+      measurementState(ep.id, Array.from({ length: 12 }, (_, i) => ok(i + 1))),
+      8000,
+      1778352000000,
+      {
+        totalSampleCount: 5,
+      },
+    );
+
+    expect(built.payload.report?.keptSampleCount).toBe(12);
+    expect(built.payload.report?.totalSampleCount).toBe(12);
+  });
 });

--- a/tests/unit/share/hash-router.test.ts
+++ b/tests/unit/share/hash-router.test.ts
@@ -75,6 +75,22 @@ function resultsPayload(): SharePayload {
   };
 }
 
+function reportPayload(): SharePayload {
+  return {
+    ...resultsPayload(),
+    v: 2,
+    report: {
+      createdAt: 1778352000000,
+      healthThreshold: 140,
+      corsMode: 'cors',
+      roundCount: 10,
+      totalSampleCount: 20,
+      keptSampleCount: 20,
+      truncated: false,
+    },
+  };
+}
+
 beforeEach(() => {
   endpointStore.setEndpoints([]);
   settingsStore.reset();
@@ -330,5 +346,32 @@ describe('hash-router: results-mode application', () => {
     applySharePayload(resultsPayload());
     const m = get(measurementStore);
     expect(m.lifecycle).toBe('completed');
+  });
+
+  it('opens result links in shared report mode', () => {
+    applySharePayload(resultsPayload());
+    expect(get(uiStore).sharedReportMode).toBe(true);
+  });
+
+  it('stores v2 report metadata without writing runtime settings', () => {
+    applySharePayload(reportPayload());
+
+    const ui = get(uiStore);
+    expect(ui.sharedReportContext?.healthThreshold).toBe(140);
+    expect(ui.sharedReportContext?.corsMode).toBe('cors');
+    expect(ui.sharedReportContext?.sourceVersion).toBe(2);
+
+    const s = get(settingsStore);
+    expect(s.healthThreshold).toBe(DEFAULT_SETTINGS.healthThreshold);
+    expect(s.corsMode).toBe(DEFAULT_SETTINGS.corsMode);
+  });
+
+  it('infers legacy v1 report context from results without threshold metadata', () => {
+    applySharePayload(resultsPayload());
+    const context = get(uiStore).sharedReportContext;
+    expect(context?.sourceVersion).toBe(1);
+    expect(context?.healthThreshold).toBeNull();
+    expect(context?.corsMode).toBe(MALICIOUS_CADENCE.corsMode);
+    expect(context?.keptSampleCount).toBe(20);
   });
 });

--- a/tests/unit/utils/diagnostic-report.test.ts
+++ b/tests/unit/utils/diagnostic-report.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildDiagnosticReport,
+  formatReportMetric,
+} from '../../../src/lib/utils/diagnostic-report';
+import type {
+  Endpoint,
+  EndpointStatistics,
+  MeasurementSample,
+  MeasurementState,
+  SampleBuffer,
+  SharedReportContext,
+} from '../../../src/lib/types';
+import { DEFAULT_SETTINGS } from '../../../src/lib/types';
+
+function endpoint(id: string, label = id): Endpoint {
+  return {
+    id,
+    label,
+    url: `https://${id}.example.test`,
+    enabled: true,
+    color: '#67e8f9',
+  };
+}
+
+function stats(over: Partial<EndpointStatistics> = {}): EndpointStatistics {
+  return {
+    endpointId: over.endpointId ?? 'ep',
+    sampleCount: 30,
+    p50: 50,
+    p95: 70,
+    p99: 90,
+    p25: 40,
+    p75: 60,
+    p90: 65,
+    min: 35,
+    max: 95,
+    stddev: 5,
+    ci95: { lower: 45, upper: 55, margin: 5 },
+    connectionReuseDelta: null,
+    lossPercent: 0,
+    ready: true,
+    ...over,
+  };
+}
+
+function ok(round: number, latency = 50): MeasurementSample {
+  return {
+    round,
+    latency,
+    status: 'ok',
+    timestamp: 0,
+  };
+}
+
+function buffer(samples: readonly MeasurementSample[]): SampleBuffer {
+  return {
+    length: samples.length,
+    tailIndex: samples.length,
+    at: (index: number) => samples[index],
+    filter: samples.filter.bind(samples),
+    map: samples.map.bind(samples),
+    find: samples.find.bind(samples),
+    reduce: samples.reduce.bind(samples) as SampleBuffer['reduce'],
+    slice: samples.slice.bind(samples),
+    forEach: samples.forEach.bind(samples),
+    toArray: () => [...samples],
+    [Symbol.iterator]: samples[Symbol.iterator].bind(samples),
+  } as SampleBuffer;
+}
+
+function measurementState(samplesByEndpoint: Record<string, readonly MeasurementSample[]>): MeasurementState {
+  const endpoints: MeasurementState['endpoints'] = {};
+  for (const [endpointId, samples] of Object.entries(samplesByEndpoint)) {
+    const last = samples.at(-1);
+    endpoints[endpointId] = {
+      endpointId,
+      samples: buffer(samples),
+      lastLatency: last?.latency ?? null,
+      lastStatus: last?.status ?? null,
+      lastErrorMessage: null,
+      tierLevel: 1,
+    };
+  }
+  return {
+    lifecycle: 'completed',
+    epoch: 1,
+    roundCounter: 30,
+    endpoints,
+    startedAt: null,
+    stoppedAt: null,
+    freezeEvents: [],
+    errorCount: 0,
+    timeoutCount: 0,
+  };
+}
+
+const context: SharedReportContext = {
+  createdAt: 1778352000000,
+  healthThreshold: 120,
+  corsMode: 'no-cors',
+  roundCount: 30,
+  totalSampleCount: 90,
+  keptSampleCount: 90,
+  truncated: false,
+  sourceVersion: 2,
+};
+
+describe('buildDiagnosticReport', () => {
+  it('uses shared report metadata for threshold and timing mode without relying on local settings', () => {
+    const endpoints = [
+      endpoint('api', 'API'),
+      endpoint('google', 'Google'),
+      endpoint('cloudflare', 'Cloudflare'),
+    ];
+    const report = buildDiagnosticReport({
+      endpoints,
+      stats: {
+        api: stats({ endpointId: 'api', p50: 240, p95: 280 }),
+        google: stats({ endpointId: 'google', p50: 45, p95: 60 }),
+        cloudflare: stats({ endpointId: 'cloudflare', p50: 38, p95: 55 }),
+      },
+      measurements: measurementState({
+        api: Array.from({ length: 30 }, (_, i) => ok(i + 1, 240)),
+        google: Array.from({ length: 30 }, (_, i) => ok(i + 1, 45)),
+        cloudflare: Array.from({ length: 30 }, (_, i) => ok(i + 1, 38)),
+      }),
+      settings: { ...DEFAULT_SETTINGS, healthThreshold: 999, corsMode: 'cors' },
+      context,
+    });
+
+    expect(report.threshold).toBe(120);
+    expect(report.thresholdSource).toBe('shared');
+    expect(report.corsMode).toBe('no-cors');
+    expect(report.diagnosis.kind).toBe('isolated-endpoint');
+    expect(report.endpointRows.find((row) => row.endpointId === 'api')?.implicated).toBe(true);
+    expect(report.copySummary).toContain('API');
+    expect(report.copySummary).toContain('threshold 120 ms');
+  });
+
+  it('falls back to local defaults for legacy contexts without threshold metadata', () => {
+    const ep = endpoint('google', 'Google');
+    const report = buildDiagnosticReport({
+      endpoints: [ep],
+      stats: { google: stats({ endpointId: 'google', p50: 80 }) },
+      measurements: measurementState({
+        google: Array.from({ length: 30 }, (_, i) => ok(i + 1, 80)),
+      }),
+      settings: { ...DEFAULT_SETTINGS, healthThreshold: 90 },
+      context: { ...context, sourceVersion: 1, healthThreshold: null, corsMode: 'cors' },
+    });
+
+    expect(report.threshold).toBe(90);
+    expect(report.thresholdSource).toBe('local-default');
+    expect(report.corsModeSource).toBe('payload-settings');
+  });
+
+  it('marks truncated reports and carries sample counts through the model', () => {
+    const ep = endpoint('api', 'API');
+    const report = buildDiagnosticReport({
+      endpoints: [ep],
+      stats: { api: stats({ endpointId: 'api' }) },
+      measurements: measurementState({
+        api: Array.from({ length: 10 }, (_, i) => ok(i + 1, 50)),
+      }),
+      settings: DEFAULT_SETTINGS,
+      context: {
+        ...context,
+        totalSampleCount: 300,
+        keptSampleCount: 10,
+        truncated: true,
+      },
+    });
+
+    expect(report.truncated).toBe(true);
+    expect(report.totalSampleCount).toBe(300);
+    expect(report.keptSampleCount).toBe(10);
+  });
+});
+
+describe('formatReportMetric', () => {
+  it('formats missing values as dash', () => {
+    expect(formatReportMetric(null)).toBe('-');
+  });
+
+  it('formats percentages with one decimal place', () => {
+    expect(formatReportMetric(1.234, '%')).toBe('1.2%');
+  });
+});

--- a/tests/visual/ac-verification.spec.ts
+++ b/tests/visual/ac-verification.spec.ts
@@ -1,4 +1,7 @@
 import { test, expect, type Page } from '@playwright/test';
+import { encodeSharePayload } from '../../src/lib/share/share-manager';
+import { MAX_CAP } from '../../src/lib/limits';
+import type { SharePayload } from '../../src/lib/types';
 
 async function uniqueEndpointIds(page: Page): Promise<string[]> {
   await page.waitForSelector('[data-endpoint-id]', { state: 'attached', timeout: 3000 });
@@ -24,6 +27,46 @@ async function injectVisibleSamples(page: Page): Promise<void> {
       jitterMs: 3,
     })));
   }, ids);
+}
+
+function sharedReportUrl(): string {
+  const endpoints = [
+    { url: 'https://api.example.com', enabled: true },
+    { url: 'https://www.google.com', enabled: true },
+    { url: 'https://www.cloudflare.com', enabled: true },
+  ];
+  const results = [240, 45, 38].map((latency) => ({
+    samples: Array.from({ length: 35 }, (_, i) => ({
+      round: i + 1,
+      latency,
+      status: 'ok' as const,
+    })),
+  }));
+  const payload: SharePayload = {
+    v: 2,
+    mode: 'results',
+    endpoints,
+    settings: {
+      timeout: 5000,
+      delay: 0,
+      burstRounds: 50,
+      monitorDelay: 1000,
+      cap: MAX_CAP,
+      corsMode: 'no-cors',
+    },
+    report: {
+      createdAt: 1778352000000,
+      healthThreshold: 120,
+      corsMode: 'no-cors',
+      roundCount: 35,
+      totalSampleCount: 105,
+      keptSampleCount: 105,
+      truncated: false,
+    },
+    results,
+  };
+
+  return `/#s=${encodeSharePayload(payload)}`;
 }
 
 test.describe('Acceptance criteria verification', () => {
@@ -108,6 +151,19 @@ test.describe('Acceptance criteria verification', () => {
 
     await expect(page.locator('section[aria-label="Diagnostic answer"]')).toBeVisible();
     await expect(page.locator('section[aria-label="Browser visibility"]')).toBeVisible();
+    await expect(page.getByText(/Timing-Allow-Origin/i)).toBeVisible();
+  });
+
+  test('shared result link opens as a diagnostic report', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto(sharedReportUrl());
+    await page.waitForSelector('#chronoscope-root');
+
+    await expect(page.getByText('Shared diagnostic report').first()).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Only api\.example\.com looks slow/i })).toBeVisible();
+    await expect(page.getByText(/medium confidence|high confidence/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: /Open Interactive Analysis/i })).toBeVisible();
+    await expect(page.getByRole('table', { name: /Endpoint report table/i })).toContainText('likely source');
     await expect(page.getByText(/Timing-Allow-Origin/i)).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

Implements #3 from the 10-star roadmap: shared result links now open as a support-ready diagnostic report instead of dropping the receiver into the normal app shell with samples loaded.

- adds v2 result-share metadata for report created time, sender threshold, sender CORS mode, sample counts, and truncation state
- keeps report metadata inert: it never writes into runtime settings, preserving the share safety invariant
- adds a pure diagnostic report model plus copy-ready support summary text
- adds a read-only Report view with verdict, confidence, evidence, browser visibility, endpoint table, next steps, and actions
- lets receivers switch from the report into interactive Diagnose/Overview or run the same endpoints from their own network
- keeps legacy v1 result links working via inferred report context

## Verification

- npm run typecheck
- npm run lint
- npm test
- npm run build
- npm run test:visual
- Browser check: opened a v2 shared result link locally, verified it lands on Report view, and verified Open Interactive Analysis switches into Diagnose with the snapshot intact


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Shared links now feature a dedicated diagnostic report mode with detailed analysis summary, verdict evidence, endpoint comparisons, and recommended next steps
  * Added toggle functionality to switch between interactive diagnostic mode and static report view in shared reports
  * Enhanced sharing capabilities with copy-to-clipboard functionality for report summaries and ability to generate shareable report links

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xaedyn/chronoscope/pull/92)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->