### PR TITLE
[codex] Add local history baselines

### DIFF
--- a/src/lib/components/App.svelte
+++ b/src/lib/components/App.svelte
@@ -7,6 +7,9 @@
   import { tokens } from '$lib/tokens';
   import { settingsStore } from '$lib/stores/settings';
   import { endpointStore, buildDefaultEndpoints } from '$lib/stores/endpoints';
+  import { historyStore } from '$lib/stores/history';
+  import { measurementStore } from '$lib/stores/measurements';
+  import { statisticsStore } from '$lib/stores/statistics';
   import { uiStore } from '$lib/stores/ui';
   import { MeasurementEngine } from '$lib/engine/measurement-engine';
   import { detectRegion } from '$lib/regional-defaults';
@@ -126,6 +129,7 @@
   let unsubSettings: (() => void) | null = null;
   let unsubEndpoints: (() => void) | null = null;
   let unsubUi: (() => void) | null = null;
+  let unsubHistoryLifecycle: (() => void) | null = null;
   let destroyShortcuts: (() => void) | null = null;
 
   let persistDebounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -179,6 +183,28 @@
     engine.stop();
   }
 
+  function setupHistorySync(): void {
+    void historyStore.hydrate();
+
+    let prevLifecycle = get(measurementStore).lifecycle;
+    unsubHistoryLifecycle = measurementStore.subscribe((state) => {
+      const cur = state.lifecycle;
+      const prev = prevLifecycle;
+      prevLifecycle = cur;
+
+      const endedLocalRun = (cur === 'stopped' || cur === 'completed')
+        && (prev === 'running' || prev === 'stopping');
+      if (!endedLocalRun || get(uiStore).isSharedView) return;
+
+      void historyStore.recordSession({
+        endpoints: get(endpointStore),
+        measurements: state,
+        stats: get(statisticsStore),
+        settings: get(settingsStore),
+      });
+    });
+  }
+
   // ── Mount ────────────────────────────────────────────────────────────────────
   onMount(() => {
     // 1. Bridge tokens to CSS custom properties
@@ -213,6 +239,9 @@
     // 5. Setup persistence sync
     setupPersistenceSync();
 
+    // 6. Local-only history baselines
+    setupHistorySync();
+
     // 7. Register keyboard shortcuts
     destroyShortcuts = initShortcuts();
   });
@@ -222,6 +251,7 @@
     unsubSettings?.();
     unsubEndpoints?.();
     unsubUi?.();
+    unsubHistoryLifecycle?.();
     destroyShortcuts?.();
     if (persistDebounceTimer !== null) clearTimeout(persistDebounceTimer);
   });

--- a/src/lib/components/CausalVerdictStrip.svelte
+++ b/src/lib/components/CausalVerdictStrip.svelte
@@ -3,6 +3,7 @@
 <!-- — diagnosis is computed in the parent and passed in whole.                -->
 <script lang="ts">
   import type { DiagnosticNarrative } from '$lib/utils/diagnostic-narrative';
+  import type { HistoryBaselineInsight } from '$lib/utils/history-baseline';
   import type { Endpoint } from '$lib/types';
 
   interface Props {
@@ -11,13 +12,26 @@
     avgJitter: number | null;
     avgLoss: number | null;
     drillEndpoint: Endpoint | null;
+    baselineInsight?: HistoryBaselineInsight | null;
     onDrill: (epId: string) => void;
   }
 
-  let { diagnosis, avgP50, avgJitter, avgLoss, drillEndpoint, onDrill }: Props = $props();
+  let { diagnosis, avgP50, avgJitter, avgLoss, drillEndpoint, baselineInsight = null, onDrill }: Props = $props();
   const verdict = $derived(diagnosis.verdict);
   const primaryLimitation = $derived(diagnosis.limitations[0] ?? null);
   const primaryNextStep = $derived(diagnosis.nextSteps[0] ?? null);
+  const baselineChip = $derived.by(() => {
+    if (baselineInsight === null || diagnosis.kind === 'collecting') return null;
+    if (baselineInsight.status === 'collecting') return null;
+    if (baselineInsight.status === 'no-history') return 'No baseline';
+    if (baselineInsight.status === 'normal') return 'Baseline normal';
+
+    const comparison = baselineInsight.comparisons.find((item) => (
+      item.status === 'severe' || item.status === 'elevated'
+    ));
+    const ratio = Math.max(comparison?.p50Ratio ?? 0, comparison?.p95Ratio ?? 0);
+    return ratio > 0 ? `${ratio.toFixed(1)}x baseline` : 'Baseline high';
+  });
 
   const fmtInt = (n: number | null): string => (n == null ? '—' : String(Math.round(n)));
   const fmt1 = (n: number | null): string => (n == null ? '—' : n.toFixed(1));
@@ -40,6 +54,14 @@
       class:high={diagnosis.confidence === 'high'}
       title={diagnosis.confidenceReason}
     >{diagnosis.confidenceLabel}</span>
+    {#if baselineChip && baselineInsight}
+      <span
+        class="verdict-baseline-chip"
+        class:hot={baselineInsight.status === 'elevated' || baselineInsight.status === 'severe'}
+        class:normal={baselineInsight.status === 'normal'}
+        title={`${baselineInsight.detail} ${baselineInsight.privacyNote}`}
+      >{baselineChip}</span>
+    {/if}
   </div>
   {#if diagnosis.kind !== 'collecting'}
     <p class="verdict-explanation">{diagnosis.explanation}</p>
@@ -185,6 +207,29 @@
   }
   .verdict-confidence.low {
     color: var(--t3);
+  }
+  .verdict-baseline-chip {
+    flex: 0 0 auto;
+    padding: 3px 7px;
+    border-radius: 999px;
+    border: 1px solid var(--border-mid);
+    color: var(--t3);
+    background: rgba(255, 255, 255, 0.03);
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-kicker);
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+  .verdict-baseline-chip.hot {
+    color: var(--accent-amber);
+    border-color: rgba(251, 191, 36, 0.24);
+    background: rgba(251, 191, 36, 0.06);
+  }
+  .verdict-baseline-chip.normal {
+    color: var(--accent-green);
+    border-color: rgba(134, 239, 172, 0.22);
+    background: rgba(134, 239, 172, 0.05);
   }
   .verdict-explanation {
     grid-column: 1 / -1;

--- a/src/lib/components/OverviewView.svelte
+++ b/src/lib/components/OverviewView.svelte
@@ -8,11 +8,13 @@
 <script lang="ts">
   import { onDestroy, untrack } from 'svelte';
   import { measurementStore } from '$lib/stores/measurements';
+  import { historyStore } from '$lib/stores/history';
   import { statisticsStore } from '$lib/stores/statistics';
   import { settingsStore } from '$lib/stores/settings';
   import { uiStore } from '$lib/stores/ui';
   import { networkQualityStore, monitoredEndpointsStore } from '$lib/stores/derived';
   import { buildDiagnosticNarrative, type DiagnosticNarrative } from '$lib/utils/diagnostic-narrative';
+  import { buildHistoryBaselineInsight, type HistoryBaselineInsight } from '$lib/utils/history-baseline';
   import type { VerdictRow } from '$lib/utils/verdict';
   import { tokens } from '$lib/tokens';
   import ChronographDial from './ChronographDial.svelte';
@@ -36,6 +38,7 @@
   // Math.max(0, ...empty) === 0, which is the correct sentinel for "no data yet".
   const p99Across = $derived(Math.max(0, ...monitored.map((ep) => stats[ep.id]?.p99 ?? 0)));
   const measurements = $derived($measurementStore);
+  const history = $derived($historyStore);
   const threshold = $derived(settings.healthThreshold);
   const score = $derived($networkQualityStore);
   const paused = $derived(
@@ -220,6 +223,12 @@
     samplesByEndpoint,
     monitoredEndpointCount: monitored.length,
   }));
+  const historyBaselineInsight: HistoryBaselineInsight = $derived(buildHistoryBaselineInsight({
+    endpoints: monitored,
+    stats,
+    history: history.sessions,
+    currentStartedAt: measurements.startedAt,
+  }));
 
   // Average metrics for the verdict strip triptych (backing evidence).
   const avgP50 = $derived.by(() => {
@@ -302,6 +311,7 @@
         {avgJitter}
         {avgLoss}
         {drillEndpoint}
+        baselineInsight={historyBaselineInsight}
         onDrill={handleEnrichedDrill}
       />
     </div>

--- a/src/lib/components/ReportView.svelte
+++ b/src/lib/components/ReportView.svelte
@@ -3,6 +3,7 @@
 <script lang="ts">
   import { get } from 'svelte/store';
   import { endpointStore } from '$lib/stores/endpoints';
+  import { historyStore } from '$lib/stores/history';
   import { measurementStore } from '$lib/stores/measurements';
   import { settingsStore } from '$lib/stores/settings';
   import { statisticsStore } from '$lib/stores/statistics';
@@ -10,10 +11,12 @@
   import { buildShareURL } from '$lib/share/share-manager';
   import { buildResultsSharePayload } from '$lib/share/share-payload-builder';
   import { buildDiagnosticReport, formatReportMetric } from '$lib/utils/diagnostic-report';
+  import { buildHistoryBaselineInsight } from '$lib/utils/history-baseline';
   import { tokens } from '$lib/tokens';
 
   const endpoints = $derived($endpointStore);
   const measurements = $derived($measurementStore);
+  const history = $derived($historyStore);
   const settings = $derived($settingsStore);
   const stats = $derived($statisticsStore);
   const context = $derived($uiStore.sharedReportContext);
@@ -27,6 +30,17 @@
   }));
   const additionalLimitations = $derived(
     report.diagnosis.limitations.filter((limit) => limit.id !== 'timing-visibility'),
+  );
+  const baselineInsight = $derived(buildHistoryBaselineInsight({
+    endpoints,
+    stats,
+    history: history.sessions,
+    currentStartedAt: measurements.startedAt,
+  }));
+  const baselineRows = $derived(
+    baselineInsight.comparisons
+      .filter((comparison) => comparison.status !== 'unready')
+      .slice(0, 4),
   );
 
   let copiedSummary = $state(false);
@@ -184,6 +198,27 @@
               {#if limit.action}
                 <small>{limit.action}</small>
               {/if}
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </section>
+
+    <section class="report-panel baseline-panel" aria-label="Baseline context">
+      <div class="section-kicker">Baseline context</div>
+      <h2>{baselineInsight.headline}</h2>
+      <p>{baselineInsight.detail}</p>
+      <p class="privacy-note">{baselineInsight.privacyNote}</p>
+      {#if baselineRows.length > 0}
+        <div class="baseline-list">
+          {#each baselineRows as comparison (comparison.endpointId)}
+            <div
+              class="baseline-row"
+              class:hot={comparison.status === 'elevated' || comparison.status === 'severe'}
+            >
+              <strong>{comparison.label}</strong>
+              <span>{comparison.summary}</span>
+              <small>{comparison.priorSessionCount} prior local {comparison.priorSessionCount === 1 ? 'run' : 'runs'}</small>
             </div>
           {/each}
         </div>
@@ -404,6 +439,39 @@
     color: var(--t2);
     line-height: 1.5;
   }
+  .baseline-panel {
+    grid-column: 1 / -1;
+  }
+  .privacy-note {
+    margin-top: 8px;
+    color: var(--t3) !important;
+    font-size: var(--ts-xs);
+  }
+  .baseline-list {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+    margin-top: 12px;
+  }
+  .baseline-row {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    padding: 10px;
+    border: 1px solid rgba(255,255,255,.07);
+    border-radius: 7px;
+    background: rgba(255,255,255,.035);
+  }
+  .baseline-row.hot {
+    border-color: rgba(251,191,36,.2);
+    background: rgba(251,191,36,.06);
+  }
+  .baseline-row span,
+  .baseline-row small {
+    color: var(--t3);
+    line-height: 1.4;
+  }
   .guidance {
     padding-left: 10px;
     border-left: 2px solid var(--accent-cyan);
@@ -524,6 +592,9 @@
       grid-template-columns: 1fr;
     }
     .evidence-grid {
+      grid-template-columns: 1fr;
+    }
+    .baseline-list {
       grid-template-columns: 1fr;
     }
     .endpoint-table {

--- a/src/lib/components/SettingsDrawer.svelte
+++ b/src/lib/components/SettingsDrawer.svelte
@@ -6,6 +6,7 @@
   import { get } from 'svelte/store';
   import { uiStore } from '$lib/stores/ui';
   import { settingsStore } from '$lib/stores/settings';
+  import { historyStore } from '$lib/stores/history';
   import { measurementStore } from '$lib/stores/measurements';
   import { endpointStore } from '$lib/stores/endpoints';
   import { clearPersistedSettings } from '$lib/utils/persistence';
@@ -134,8 +135,10 @@
   }
 
   let showClearConfirm = $state(false);
+  let showClearHistoryConfirm = $state(false);
   let showResetConfirm = $state(false);
   let showResetRegionalConfirm = $state(false);
+  let historyCount = $derived($historyStore.sessions.length);
 
   function requestResetRegional(): void {
     showResetRegionalConfirm = true;
@@ -177,6 +180,20 @@
 
   function cancelClear(): void {
     showClearConfirm = false;
+  }
+
+  function requestClearHistory(): void {
+    showClearHistoryConfirm = true;
+  }
+
+  function confirmClearHistory(): void {
+    if (isRunning) return;
+    showClearHistoryConfirm = false;
+    void historyStore.clear();
+  }
+
+  function cancelClearHistory(): void {
+    showClearHistoryConfirm = false;
   }
 
   function requestReset(): void {
@@ -364,6 +381,21 @@
             <div class="confirm-actions">
               <button type="button" class="btn-danger" disabled={isRunning} onclick={confirmReset}>Yes, reset</button>
               <button type="button" class="btn-secondary" onclick={cancelReset}>Cancel</button>
+            </div>
+          </div>
+        {/if}
+
+        <!-- Clear local history -->
+        {#if !showClearHistoryConfirm}
+          <button type="button" class="btn-danger" disabled={isRunning || historyCount === 0} aria-disabled={isRunning || historyCount === 0} onclick={requestClearHistory}>
+            Clear local history
+          </button>
+        {:else}
+          <div class="confirm-group" role="alert" aria-live="assertive">
+            <p class="confirm-text">Deletes {historyCount} saved baseline {historyCount === 1 ? 'run' : 'runs'} from this browser. Continue?</p>
+            <div class="confirm-actions">
+              <button type="button" class="btn-danger" disabled={isRunning} onclick={confirmClearHistory}>Yes, clear</button>
+              <button type="button" class="btn-secondary" onclick={cancelClearHistory}>Cancel</button>
             </div>
           </div>
         {/if}

--- a/src/lib/history/indexeddb-history.ts
+++ b/src/lib/history/indexeddb-history.ts
@@ -30,8 +30,8 @@ function transactionDone(transaction: IDBTransaction): Promise<void> {
   });
 }
 
-async function openHistoryDb(): Promise<IDBDatabase | null> {
-  if (!hasIndexedDb()) return null;
+function openHistoryDb(): Promise<IDBDatabase | null> {
+  if (!hasIndexedDb()) return Promise.resolve(null);
 
   const request = indexedDB.open(DB_NAME, DB_VERSION);
   request.onupgradeneeded = () => {

--- a/src/lib/history/indexeddb-history.ts
+++ b/src/lib/history/indexeddb-history.ts
@@ -1,0 +1,151 @@
+// src/lib/history/indexeddb-history.ts
+// Browser IndexedDB adapter for local session history.
+
+import type { HistorySessionSummary } from './session-summary';
+
+const DB_NAME = 'chronoscope-history';
+const DB_VERSION = 1;
+const STORE_NAME = 'sessions';
+const CREATED_AT_INDEX = 'createdAt';
+const DEFAULT_LIMIT = 100;
+const DEFAULT_MAX_SESSIONS = 100;
+const DEFAULT_MAX_AGE_DAYS = 30;
+
+function hasIndexedDb(): boolean {
+  return typeof indexedDB !== 'undefined';
+}
+
+function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error('IndexedDB request failed'));
+  });
+}
+
+function transactionDone(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error ?? new Error('IndexedDB transaction failed'));
+    transaction.onabort = () => reject(transaction.error ?? new Error('IndexedDB transaction aborted'));
+  });
+}
+
+async function openHistoryDb(): Promise<IDBDatabase | null> {
+  if (!hasIndexedDb()) return null;
+
+  const request = indexedDB.open(DB_NAME, DB_VERSION);
+  request.onupgradeneeded = () => {
+    const db = request.result;
+    if (!db.objectStoreNames.contains(STORE_NAME)) {
+      const store = db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+      store.createIndex(CREATED_AT_INDEX, 'createdAt');
+    }
+  };
+
+  return requestToPromise(request);
+}
+
+export async function saveHistorySession(session: HistorySessionSummary): Promise<boolean> {
+  const db = await openHistoryDb();
+  if (!db) return false;
+
+  try {
+    const transaction = db.transaction(STORE_NAME, 'readwrite');
+    const done = transactionDone(transaction);
+    transaction.objectStore(STORE_NAME).put(session);
+    await done;
+    return true;
+  } finally {
+    db.close();
+  }
+}
+
+export async function listHistorySessions(limit = DEFAULT_LIMIT): Promise<HistorySessionSummary[]> {
+  const db = await openHistoryDb();
+  if (!db) return [];
+
+  try {
+    const transaction = db.transaction(STORE_NAME, 'readonly');
+    const done = transactionDone(transaction);
+    const index = transaction.objectStore(STORE_NAME).index(CREATED_AT_INDEX);
+    const sessions: HistorySessionSummary[] = [];
+
+    await new Promise<void>((resolve, reject) => {
+      const request = index.openCursor(null, 'prev');
+      request.onsuccess = () => {
+        const cursor = request.result;
+        if (!cursor || sessions.length >= limit) {
+          resolve();
+          return;
+        }
+        sessions.push(cursor.value as HistorySessionSummary);
+        cursor.continue();
+      };
+      request.onerror = () => reject(request.error ?? new Error('IndexedDB cursor failed'));
+    });
+
+    await done;
+    return sessions;
+  } finally {
+    db.close();
+  }
+}
+
+export async function deleteHistorySession(id: string): Promise<boolean> {
+  const db = await openHistoryDb();
+  if (!db) return false;
+
+  try {
+    const transaction = db.transaction(STORE_NAME, 'readwrite');
+    const done = transactionDone(transaction);
+    transaction.objectStore(STORE_NAME).delete(id);
+    await done;
+    return true;
+  } finally {
+    db.close();
+  }
+}
+
+export async function clearHistorySessions(): Promise<boolean> {
+  const db = await openHistoryDb();
+  if (!db) return false;
+
+  try {
+    const transaction = db.transaction(STORE_NAME, 'readwrite');
+    const done = transactionDone(transaction);
+    transaction.objectStore(STORE_NAME).clear();
+    await done;
+    return true;
+  } finally {
+    db.close();
+  }
+}
+
+export async function pruneHistorySessions(options: {
+  readonly maxSessions?: number;
+  readonly maxAgeDays?: number;
+} = {}): Promise<boolean> {
+  const db = await openHistoryDb();
+  if (!db) return false;
+
+  const maxSessions = options.maxSessions ?? DEFAULT_MAX_SESSIONS;
+  const maxAgeMs = (options.maxAgeDays ?? DEFAULT_MAX_AGE_DAYS) * 24 * 60 * 60 * 1000;
+  const cutoff = Date.now() - maxAgeMs;
+
+  try {
+    const all = await listHistorySessions(Number.MAX_SAFE_INTEGER);
+    const idsToDelete = all
+      .filter((session, index) => index >= maxSessions || session.createdAt < cutoff)
+      .map((session) => session.id);
+    if (idsToDelete.length === 0) return true;
+
+    const transaction = db.transaction(STORE_NAME, 'readwrite');
+    const done = transactionDone(transaction);
+    const store = transaction.objectStore(STORE_NAME);
+    for (const id of idsToDelete) store.delete(id);
+    await done;
+    return true;
+  } finally {
+    db.close();
+  }
+}

--- a/src/lib/history/session-summary.ts
+++ b/src/lib/history/session-summary.ts
@@ -1,0 +1,220 @@
+// src/lib/history/session-summary.ts
+// Compact local-only summaries of completed measurement runs.
+
+import type {
+  Endpoint,
+  EndpointStatistics,
+  MeasurementSample,
+  MeasurementState,
+  Settings,
+  StatisticsState,
+  TestLifecycleState,
+} from '../types';
+import { buildDiagnosticNarrative, type DiagnosticNarrative } from '../utils/diagnostic-narrative';
+import { percentileSorted, stddev } from '../utils/statistics';
+import type { VerdictRow } from '../utils/verdict';
+
+export interface HistoryEndpointSummary {
+  readonly endpointId: string;
+  readonly key: string;
+  readonly url: string;
+  readonly label: string;
+  readonly enabled: boolean;
+  readonly sampleCount: number;
+  readonly okCount: number;
+  readonly lossPercent: number;
+  readonly p50: number | null;
+  readonly p95: number | null;
+  readonly p99: number | null;
+  readonly stddev: number | null;
+  readonly lastLatency: number | null;
+  readonly baselineEligible: boolean;
+}
+
+export interface HistorySessionSummary {
+  readonly id: string;
+  readonly createdAt: number;
+  readonly startedAt: number | null;
+  readonly stoppedAt: number | null;
+  readonly durationMs: number | null;
+  readonly lifecycle: TestLifecycleState;
+  readonly roundCount: number;
+  readonly endpointCount: number;
+  readonly baselineEligibleEndpointCount: number;
+  readonly endpointKeys: readonly string[];
+  readonly settings: {
+    readonly healthThreshold: number;
+    readonly corsMode: Settings['corsMode'];
+    readonly timeout: number;
+  };
+  readonly verdict: {
+    readonly headline: string;
+    readonly kind: DiagnosticNarrative['kind'];
+    readonly confidence: DiagnosticNarrative['confidence'];
+  };
+  readonly endpoints: readonly HistoryEndpointSummary[];
+}
+
+export interface BuildHistorySessionSummaryInput {
+  readonly id?: string;
+  readonly now?: number;
+  readonly endpoints: readonly Endpoint[];
+  readonly measurements: MeasurementState;
+  readonly stats: StatisticsState;
+  readonly settings: Settings;
+}
+
+const BASELINE_MIN_TOTAL_SAMPLES = 30;
+const BASELINE_MIN_OK_SAMPLES = 20;
+const BASELINE_MAX_LOSS_PERCENT = 20;
+
+function safePathname(pathname: string): string {
+  if (pathname === '' || pathname === '/') return '';
+  return pathname.replace(/\/+$/, '');
+}
+
+export function normalizeHistoryEndpointKey(url: string): string {
+  const trimmed = url.trim();
+  try {
+    const parsed = new URL(trimmed);
+    const protocol = parsed.protocol.toLowerCase();
+    const host = parsed.host.toLowerCase();
+    return `${protocol}//${host}${safePathname(parsed.pathname)}`;
+  } catch {
+    return trimmed;
+  }
+}
+
+function sampleArrayFor(measurements: MeasurementState, endpointId: string): readonly MeasurementSample[] {
+  return measurements.endpoints[endpointId]?.samples.toArray() ?? [];
+}
+
+function computeFallbackStats(samples: readonly MeasurementSample[]): Pick<HistoryEndpointSummary, 'p50' | 'p95' | 'p99' | 'stddev'> {
+  const latencies = samples
+    .filter((sample) => sample.status === 'ok' && Number.isFinite(sample.latency))
+    .map((sample) => sample.latency)
+    .sort((a, b) => a - b);
+
+  if (latencies.length === 0) {
+    return { p50: null, p95: null, p99: null, stddev: null };
+  }
+
+  return {
+    p50: percentileSorted(latencies, 50),
+    p95: percentileSorted(latencies, 95),
+    p99: percentileSorted(latencies, 99),
+    stddev: stddev(latencies),
+  };
+}
+
+function finiteOrNull(value: number | null | undefined): number | null {
+  return value != null && Number.isFinite(value) ? value : null;
+}
+
+function buildEndpointSummary(
+  endpoint: Endpoint,
+  stat: EndpointStatistics | undefined,
+  measurements: MeasurementState,
+): HistoryEndpointSummary {
+  const samples = sampleArrayFor(measurements, endpoint.id);
+  const okCount = samples.filter((sample) => sample.status === 'ok').length;
+  const fallback = computeFallbackStats(samples);
+  const sampleCount = samples.length;
+  const lossPercent = sampleCount > 0
+    ? ((sampleCount - okCount) / sampleCount) * 100
+    : 0;
+  const p50 = finiteOrNull(okCount > 0 ? (stat?.p50 ?? fallback.p50) : null);
+  const p95 = finiteOrNull(okCount > 0 ? (stat?.p95 ?? fallback.p95) : null);
+  const p99 = finiteOrNull(okCount > 0 ? (stat?.p99 ?? fallback.p99) : null);
+  const sd = finiteOrNull(okCount > 0 ? (stat?.stddev ?? fallback.stddev) : null);
+  const baselineEligible = endpoint.enabled
+    && sampleCount >= BASELINE_MIN_TOTAL_SAMPLES
+    && okCount >= BASELINE_MIN_OK_SAMPLES
+    && lossPercent <= BASELINE_MAX_LOSS_PERCENT
+    && p50 !== null
+    && p95 !== null;
+
+  return {
+    endpointId: endpoint.id,
+    key: normalizeHistoryEndpointKey(endpoint.url),
+    url: endpoint.url,
+    label: endpoint.label,
+    enabled: endpoint.enabled,
+    sampleCount,
+    okCount,
+    lossPercent,
+    p50,
+    p95,
+    p99,
+    stddev: sd,
+    lastLatency: finiteOrNull(measurements.endpoints[endpoint.id]?.lastLatency),
+    baselineEligible,
+  };
+}
+
+function buildVerdict(input: BuildHistorySessionSummaryInput): HistorySessionSummary['verdict'] {
+  const monitored = input.endpoints.filter((endpoint) => endpoint.enabled);
+  const rows: VerdictRow[] = [];
+  const samplesByEndpoint: Record<string, readonly MeasurementSample[]> = {};
+
+  for (const endpoint of monitored) {
+    const endpointStats = input.stats[endpoint.id];
+    samplesByEndpoint[endpoint.id] = sampleArrayFor(input.measurements, endpoint.id);
+    if (endpointStats?.ready) rows.push({ ep: endpoint, stats: endpointStats });
+  }
+
+  const diagnosis = buildDiagnosticNarrative({
+    rows,
+    threshold: input.settings.healthThreshold,
+    corsMode: input.settings.corsMode,
+    samplesByEndpoint,
+    monitoredEndpointCount: monitored.length,
+  });
+
+  return {
+    headline: diagnosis.verdict.headline,
+    kind: diagnosis.kind,
+    confidence: diagnosis.confidence,
+  };
+}
+
+function makeHistoryId(now: number): string {
+  const random = Math.random().toString(36).slice(2, 9);
+  return `hist_${now}_${random}`;
+}
+
+export function buildHistorySessionSummary(
+  input: BuildHistorySessionSummaryInput,
+): HistorySessionSummary | null {
+  const now = input.now ?? Date.now();
+  const endpointSummaries = input.endpoints.map((endpoint) => (
+    buildEndpointSummary(endpoint, input.stats[endpoint.id], input.measurements)
+  ));
+  const totalSamples = endpointSummaries.reduce((sum, endpoint) => sum + endpoint.sampleCount, 0);
+  if (totalSamples === 0) return null;
+
+  const baselineEligibleEndpoints = endpointSummaries.filter((endpoint) => endpoint.baselineEligible);
+  const uniqueEndpointKeys = [...new Set(endpointSummaries.map((endpoint) => endpoint.key))];
+  const { startedAt, stoppedAt } = input.measurements;
+
+  return {
+    id: input.id ?? makeHistoryId(now),
+    createdAt: now,
+    startedAt,
+    stoppedAt,
+    durationMs: startedAt !== null && stoppedAt !== null ? Math.max(0, stoppedAt - startedAt) : null,
+    lifecycle: input.measurements.lifecycle,
+    roundCount: input.measurements.roundCounter,
+    endpointCount: endpointSummaries.length,
+    baselineEligibleEndpointCount: baselineEligibleEndpoints.length,
+    endpointKeys: uniqueEndpointKeys,
+    settings: {
+      healthThreshold: input.settings.healthThreshold,
+      corsMode: input.settings.corsMode,
+      timeout: input.settings.timeout,
+    },
+    verdict: buildVerdict(input),
+    endpoints: endpointSummaries,
+  };
+}
+

--- a/src/lib/stores/history.ts
+++ b/src/lib/stores/history.ts
@@ -1,0 +1,154 @@
+// src/lib/stores/history.ts
+// Svelte facade over local-only session history persistence.
+
+import { writable } from 'svelte/store';
+import type { BuildHistorySessionSummaryInput, HistorySessionSummary } from '../history/session-summary';
+import { buildHistorySessionSummary } from '../history/session-summary';
+import {
+  clearHistorySessions,
+  deleteHistorySession,
+  listHistorySessions,
+  pruneHistorySessions,
+  saveHistorySession,
+} from '../history/indexeddb-history';
+
+export interface HistoryStoreState {
+  readonly sessions: readonly HistorySessionSummary[];
+  readonly hydrated: boolean;
+  readonly saving: boolean;
+  readonly error: string | null;
+}
+
+export interface HistoryStorage {
+  list(): Promise<readonly HistorySessionSummary[]>;
+  save(session: HistorySessionSummary): Promise<boolean | undefined>;
+  delete(id: string): Promise<boolean | undefined>;
+  clear(): Promise<boolean | undefined>;
+  prune(): Promise<boolean | undefined>;
+}
+
+export interface HistoryStore {
+  subscribe: ReturnType<typeof writable<HistoryStoreState>>['subscribe'];
+  hydrate(): Promise<readonly HistorySessionSummary[]>;
+  saveSession(session: HistorySessionSummary): Promise<boolean>;
+  recordSession(input: BuildHistorySessionSummaryInput): Promise<HistorySessionSummary | null>;
+  deleteSession(id: string): Promise<boolean>;
+  clear(): Promise<boolean>;
+}
+
+const initialState: HistoryStoreState = {
+  sessions: [],
+  hydrated: false,
+  saving: false,
+  error: null,
+};
+
+export const indexedDbHistoryStorage: HistoryStorage = {
+  list: () => listHistorySessions(),
+  save: (session) => saveHistorySession(session),
+  delete: (id) => deleteHistorySession(id),
+  clear: () => clearHistorySessions(),
+  prune: () => pruneHistorySessions(),
+};
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function sortSessions(sessions: readonly HistorySessionSummary[]): HistorySessionSummary[] {
+  return [...sessions].sort((a, b) => b.createdAt - a.createdAt);
+}
+
+function upsertSession(
+  sessions: readonly HistorySessionSummary[],
+  next: HistorySessionSummary,
+): HistorySessionSummary[] {
+  const filtered = sessions.filter((session) => session.id !== next.id);
+  return sortSessions([next, ...filtered]);
+}
+
+export function createHistoryStore(storage: HistoryStorage = indexedDbHistoryStorage): HistoryStore {
+  const { subscribe, set, update } = writable<HistoryStoreState>(initialState);
+
+  async function hydrate(): Promise<readonly HistorySessionSummary[]> {
+    try {
+      const sessions = sortSessions(await storage.list());
+      set({ sessions, hydrated: true, saving: false, error: null });
+      return sessions;
+    } catch (error) {
+      const message = errorMessage(error);
+      update((state) => ({ ...state, hydrated: true, saving: false, error: message }));
+      return [];
+    }
+  }
+
+  async function saveSession(session: HistorySessionSummary): Promise<boolean> {
+    update((state) => ({ ...state, saving: true, error: null }));
+    try {
+      const saved = await storage.save(session);
+      if (saved === false) {
+        update((state) => ({ ...state, saving: false, error: 'History storage is unavailable.' }));
+        return false;
+      }
+      await storage.prune();
+      update((state) => ({
+        ...state,
+        sessions: upsertSession(state.sessions, session),
+        saving: false,
+        error: null,
+      }));
+      return true;
+    } catch (error) {
+      const message = errorMessage(error);
+      update((state) => ({ ...state, saving: false, error: message }));
+      return false;
+    }
+  }
+
+  async function recordSession(input: BuildHistorySessionSummaryInput): Promise<HistorySessionSummary | null> {
+    const session = buildHistorySessionSummary(input);
+    if (!session || session.baselineEligibleEndpointCount === 0) return null;
+    return await saveSession(session) ? session : null;
+  }
+
+  async function deleteSession(id: string): Promise<boolean> {
+    try {
+      const deleted = await storage.delete(id);
+      if (deleted === false) return false;
+      update((state) => ({
+        ...state,
+        sessions: state.sessions.filter((session) => session.id !== id),
+        error: null,
+      }));
+      return true;
+    } catch (error) {
+      const message = errorMessage(error);
+      update((state) => ({ ...state, error: message }));
+      return false;
+    }
+  }
+
+  async function clear(): Promise<boolean> {
+    try {
+      const cleared = await storage.clear();
+      if (cleared === false) return false;
+      set({ sessions: [], hydrated: true, saving: false, error: null });
+      return true;
+    } catch (error) {
+      const message = errorMessage(error);
+      update((state) => ({ ...state, error: message }));
+      return false;
+    }
+  }
+
+  return {
+    subscribe,
+    hydrate,
+    saveSession,
+    recordSession,
+    deleteSession,
+    clear,
+  };
+}
+
+export const historyStore = createHistoryStore();

--- a/src/lib/utils/history-baseline.ts
+++ b/src/lib/utils/history-baseline.ts
@@ -1,0 +1,288 @@
+// src/lib/utils/history-baseline.ts
+// Local-history baseline comparison. Pure, deterministic, and share-safe.
+
+import type { Endpoint, EndpointStatistics, StatisticsState } from '../types';
+import type { HistoryEndpointSummary, HistorySessionSummary } from '../history/session-summary';
+import { normalizeHistoryEndpointKey } from '../history/session-summary';
+import { percentileSorted } from './statistics';
+
+export type HistoryBaselineStatus = 'collecting' | 'no-history' | 'normal' | 'elevated' | 'severe';
+export type EndpointBaselineStatus = 'no-history' | 'unready' | 'normal' | 'elevated' | 'severe';
+
+export interface EndpointBaselineComparison {
+  readonly endpointId: string;
+  readonly key: string;
+  readonly label: string;
+  readonly status: EndpointBaselineStatus;
+  readonly priorSessionCount: number;
+  readonly baselineP50: number | null;
+  readonly baselineP95: number | null;
+  readonly baselineLossPercent: number | null;
+  readonly currentP50: number | null;
+  readonly currentP95: number | null;
+  readonly currentLossPercent: number | null;
+  readonly p50Ratio: number | null;
+  readonly p95Ratio: number | null;
+  readonly summary: string;
+}
+
+export interface HistoryBaselineInsight {
+  readonly status: HistoryBaselineStatus;
+  readonly headline: string;
+  readonly detail: string;
+  readonly privacyNote: string;
+  readonly comparisons: readonly EndpointBaselineComparison[];
+}
+
+export interface BuildHistoryBaselineInsightInput {
+  readonly endpoints: readonly Endpoint[];
+  readonly stats: StatisticsState;
+  readonly history: readonly HistorySessionSummary[];
+  readonly currentStartedAt?: number | null;
+  readonly minSessions?: number;
+}
+
+const DEFAULT_MIN_SESSIONS = 3;
+const MAX_PRIOR_SESSIONS = 20;
+const ELEVATED_P50_RATIO = 1.5;
+const ELEVATED_P95_RATIO = 1.6;
+const SEVERE_P50_RATIO = 2.5;
+const SEVERE_P95_RATIO = 2.7;
+const ELEVATED_LOSS_DELTA = 2;
+const SEVERE_LOSS_DELTA = 5;
+const PRIVACY_NOTE = 'Local to this browser; history is not included in shared links.';
+
+function median(values: readonly number[]): number | null {
+  const finite = values.filter(Number.isFinite).sort((a, b) => a - b);
+  if (finite.length === 0) return null;
+  return percentileSorted(finite, 50);
+}
+
+function ratio(current: number | null, baseline: number | null): number | null {
+  if (current === null || baseline === null || baseline <= 0) return null;
+  return current / baseline;
+}
+
+function fmtMs(value: number | null): string {
+  return value === null ? '-' : `${Math.round(value)} ms`;
+}
+
+function fmtRatio(value: number | null): string {
+  return value === null ? '-' : `${value.toFixed(1)}x`;
+}
+
+function worstRatio(comparison: EndpointBaselineComparison): number | null {
+  const ratios = [comparison.p50Ratio, comparison.p95Ratio]
+    .filter((value): value is number => value !== null && Number.isFinite(value));
+  if (ratios.length === 0) return null;
+  return Math.max(...ratios);
+}
+
+function currentReady(stat: EndpointStatistics | undefined): boolean {
+  return Boolean(stat?.ready && stat.sampleCount >= 30 && stat.p50 > 0 && stat.p95 > 0);
+}
+
+function sessionIsCurrent(session: HistorySessionSummary, currentStartedAt: number | null | undefined): boolean {
+  return currentStartedAt != null && session.startedAt === currentStartedAt;
+}
+
+function findEligibleEndpointSummaries(
+  history: readonly HistorySessionSummary[],
+  endpointKey: string,
+  currentStartedAt: number | null | undefined,
+): HistoryEndpointSummary[] {
+  return history
+    .filter((session) => !sessionIsCurrent(session, currentStartedAt))
+    .sort((a, b) => b.createdAt - a.createdAt)
+    .flatMap((session) => session.endpoints.filter((endpoint) => (
+      endpoint.key === endpointKey
+      && endpoint.baselineEligible
+      && endpoint.p50 !== null
+      && endpoint.p95 !== null
+    )))
+    .slice(0, MAX_PRIOR_SESSIONS);
+}
+
+function classifyComparison(input: {
+  readonly current: EndpointStatistics | undefined;
+  readonly baselineP50: number | null;
+  readonly baselineP95: number | null;
+  readonly baselineLossPercent: number | null;
+}): Pick<EndpointBaselineComparison, 'status' | 'p50Ratio' | 'p95Ratio' | 'summary'> {
+  const { current, baselineP50, baselineP95, baselineLossPercent } = input;
+  if (!current || !currentReady(current)) {
+    return {
+      status: 'unready',
+      p50Ratio: null,
+      p95Ratio: null,
+      summary: 'Collecting enough current samples for a baseline comparison.',
+    };
+  }
+
+  const p50Ratio = ratio(current.p50, baselineP50);
+  const p95Ratio = ratio(current.p95, baselineP95);
+  const lossDelta = baselineLossPercent === null ? 0 : current.lossPercent - baselineLossPercent;
+  const severe = (p50Ratio !== null && p50Ratio >= SEVERE_P50_RATIO)
+    || (p95Ratio !== null && p95Ratio >= SEVERE_P95_RATIO)
+    || (current.lossPercent >= 5 && lossDelta >= SEVERE_LOSS_DELTA);
+  const elevated = severe
+    || (p50Ratio !== null && p50Ratio >= ELEVATED_P50_RATIO)
+    || (p95Ratio !== null && p95Ratio >= ELEVATED_P95_RATIO)
+    || (current.lossPercent >= 2 && lossDelta >= ELEVATED_LOSS_DELTA);
+
+  if (severe) {
+    return {
+      status: 'severe',
+      p50Ratio,
+      p95Ratio,
+      summary: `Current p50 is ${fmtRatio(p50Ratio)} baseline (${fmtMs(current.p50)} vs ${fmtMs(baselineP50)}).`,
+    };
+  }
+
+  if (elevated) {
+    return {
+      status: 'elevated',
+      p50Ratio,
+      p95Ratio,
+      summary: `Current p50 is ${fmtRatio(p50Ratio)} baseline (${fmtMs(current.p50)} vs ${fmtMs(baselineP50)}).`,
+    };
+  }
+
+  return {
+    status: 'normal',
+    p50Ratio,
+    p95Ratio,
+    summary: `Current p50 is close to baseline (${fmtMs(current.p50)} vs ${fmtMs(baselineP50)}).`,
+  };
+}
+
+function buildComparison(input: {
+  readonly endpoint: Endpoint;
+  readonly current: EndpointStatistics | undefined;
+  readonly history: readonly HistorySessionSummary[];
+  readonly currentStartedAt: number | null | undefined;
+  readonly minSessions: number;
+}): EndpointBaselineComparison {
+  const key = normalizeHistoryEndpointKey(input.endpoint.url);
+  const prior = findEligibleEndpointSummaries(input.history, key, input.currentStartedAt);
+
+  if (prior.length < input.minSessions) {
+    return {
+      endpointId: input.endpoint.id,
+      key,
+      label: input.endpoint.label,
+      status: currentReady(input.current) ? 'no-history' : 'unready',
+      priorSessionCount: prior.length,
+      baselineP50: null,
+      baselineP95: null,
+      baselineLossPercent: null,
+      currentP50: currentReady(input.current) ? input.current?.p50 ?? null : null,
+      currentP95: currentReady(input.current) ? input.current?.p95 ?? null : null,
+      currentLossPercent: currentReady(input.current) ? input.current?.lossPercent ?? null : null,
+      p50Ratio: null,
+      p95Ratio: null,
+      summary: `Needs ${input.minSessions} eligible prior runs; found ${prior.length}.`,
+    };
+  }
+
+  const baselineP50 = median(prior.map((endpoint) => endpoint.p50 ?? 0));
+  const baselineP95 = median(prior.map((endpoint) => endpoint.p95 ?? 0));
+  const baselineLossPercent = median(prior.map((endpoint) => endpoint.lossPercent));
+  const classified = classifyComparison({
+    current: input.current,
+    baselineP50,
+    baselineP95,
+    baselineLossPercent,
+  });
+
+  return {
+    endpointId: input.endpoint.id,
+    key,
+    label: input.endpoint.label,
+    status: classified.status,
+    priorSessionCount: prior.length,
+    baselineP50,
+    baselineP95,
+    baselineLossPercent,
+    currentP50: currentReady(input.current) ? input.current?.p50 ?? null : null,
+    currentP95: currentReady(input.current) ? input.current?.p95 ?? null : null,
+    currentLossPercent: currentReady(input.current) ? input.current?.lossPercent ?? null : null,
+    p50Ratio: classified.p50Ratio,
+    p95Ratio: classified.p95Ratio,
+    summary: classified.summary,
+  };
+}
+
+function pickWorst(comparisons: readonly EndpointBaselineComparison[]): EndpointBaselineComparison | null {
+  const actionable = comparisons.filter((comparison) => (
+    comparison.status === 'severe' || comparison.status === 'elevated'
+  ));
+  if (actionable.length === 0) return null;
+  return actionable.sort((a, b) => (worstRatio(b) ?? 0) - (worstRatio(a) ?? 0))[0] ?? null;
+}
+
+export function buildHistoryBaselineInsight(input: BuildHistoryBaselineInsightInput): HistoryBaselineInsight {
+  const minSessions = input.minSessions ?? DEFAULT_MIN_SESSIONS;
+  const monitored = input.endpoints.filter((endpoint) => endpoint.enabled);
+  const comparisons = monitored.map((endpoint) => buildComparison({
+    endpoint,
+    current: input.stats[endpoint.id],
+    history: input.history,
+    currentStartedAt: input.currentStartedAt,
+    minSessions,
+  }));
+  const readyComparisons = comparisons.filter((comparison) => comparison.status !== 'unready');
+
+  if (monitored.length > 0 && readyComparisons.length === 0) {
+    return {
+      status: 'collecting',
+      headline: 'Collecting enough samples for baseline comparison.',
+      detail: 'Chronoscope compares against local history after the current run has enough samples.',
+      privacyNote: PRIVACY_NOTE,
+      comparisons,
+    };
+  }
+
+  const comparable = readyComparisons.filter((comparison) => comparison.status !== 'no-history');
+  if (comparable.length === 0) {
+    return {
+      status: 'no-history',
+      headline: 'No local baseline yet for these endpoints.',
+      detail: `Run the same endpoint at least ${minSessions} times from this browser to establish a useful baseline.`,
+      privacyNote: PRIVACY_NOTE,
+      comparisons,
+    };
+  }
+
+  const worst = pickWorst(comparable);
+  if (worst?.status === 'severe') {
+    const multiple = fmtRatio(worstRatio(worst));
+    return {
+      status: 'severe',
+      headline: `${worst.label} is far above its local baseline.`,
+      detail: `${worst.label} is ${multiple} above its usual latency across ${worst.priorSessionCount} prior local runs. ${worst.summary}`,
+      privacyNote: PRIVACY_NOTE,
+      comparisons,
+    };
+  }
+
+  if (worst?.status === 'elevated') {
+    const multiple = fmtRatio(worstRatio(worst));
+    return {
+      status: 'elevated',
+      headline: `${worst.label} is above its local baseline.`,
+      detail: `${worst.label} is ${multiple} above its usual latency across ${worst.priorSessionCount} prior local runs. ${worst.summary}`,
+      privacyNote: PRIVACY_NOTE,
+      comparisons,
+    };
+  }
+
+  const sessionCount = Math.max(...comparable.map((comparison) => comparison.priorSessionCount));
+  return {
+    status: 'normal',
+    headline: 'This run matches your local baseline.',
+    detail: `Compared with up to ${sessionCount} prior local runs for the same endpoints, latency is within the usual range.`,
+    privacyNote: PRIVACY_NOTE,
+    comparisons,
+  };
+}

--- a/tests/unit/history/session-summary.test.ts
+++ b/tests/unit/history/session-summary.test.ts
@@ -78,7 +78,7 @@ function measurementState(over: Partial<MeasurementState> = {}): MeasurementStat
             status: 'ok' as const,
             timestamp: timestamp - 12_000 + i,
           })),
-          [Symbol.iterator]: function* () {
+          *[Symbol.iterator]() {
             yield* this.toArray();
           },
         },

--- a/tests/unit/history/session-summary.test.ts
+++ b/tests/unit/history/session-summary.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import { buildHistorySessionSummary, normalizeHistoryEndpointKey } from '../../../src/lib/history/session-summary';
+import type { Endpoint, EndpointStatistics, MeasurementState, Settings } from '../../../src/lib/types';
+
+const settings: Settings = {
+  timeout: 5000,
+  delay: 0,
+  burstRounds: 50,
+  monitorDelay: 1000,
+  cap: 3600,
+  corsMode: 'no-cors',
+  healthThreshold: 120,
+};
+
+function endpoint(over: Partial<Endpoint> = {}): Endpoint {
+  return {
+    id: 'api',
+    url: 'https://API.Example.com/status/',
+    enabled: true,
+    label: 'API',
+    color: '#67e8f9',
+    ...over,
+  };
+}
+
+function stats(over: Partial<EndpointStatistics> = {}): EndpointStatistics {
+  return {
+    endpointId: 'api',
+    sampleCount: 36,
+    p50: 84,
+    p95: 130,
+    p99: 160,
+    p25: 78,
+    p75: 96,
+    p90: 112,
+    min: 70,
+    max: 170,
+    stddev: 12,
+    ci95: { lower: 80, upper: 88, margin: 4 },
+    connectionReuseDelta: null,
+    lossPercent: 0,
+    ready: true,
+    ...over,
+  };
+}
+
+function measurementState(over: Partial<MeasurementState> = {}): MeasurementState {
+  const timestamp = 1_765_000_000_000;
+  return {
+    lifecycle: 'completed',
+    epoch: 1,
+    roundCounter: 36,
+    startedAt: timestamp - 12_000,
+    stoppedAt: timestamp,
+    freezeEvents: [],
+    errorCount: 0,
+    timeoutCount: 0,
+    endpoints: {
+      api: {
+        endpointId: 'api',
+        lastLatency: 90,
+        lastStatus: 'ok',
+        lastErrorMessage: null,
+        tierLevel: 1,
+        samples: {
+          length: 36,
+          tailIndex: 36,
+          at: () => undefined,
+          filter: () => [],
+          map: () => [],
+          find: () => undefined,
+          reduce: (_callback, initial) => initial,
+          slice: () => [],
+          forEach: () => undefined,
+          toArray: () => Array.from({ length: 36 }, (_, i) => ({
+            round: i + 1,
+            latency: 80 + (i % 4),
+            status: 'ok' as const,
+            timestamp: timestamp - 12_000 + i,
+          })),
+          [Symbol.iterator]: function* () {
+            yield* this.toArray();
+          },
+        },
+      },
+    },
+    ...over,
+  };
+}
+
+describe('history session summaries', () => {
+  it('normalizes endpoint URLs into stable local-history keys', () => {
+    expect(normalizeHistoryEndpointKey(' HTTPS://API.Example.COM/status/?cache=1#frag '))
+      .toBe('https://api.example.com/status');
+    expect(normalizeHistoryEndpointKey('not a url')).toBe('not a url');
+  });
+
+  it('captures a compact, baseline-eligible session summary', () => {
+    const summary = buildHistorySessionSummary({
+      id: 'hist-fixed',
+      now: 1_765_000_000_000,
+      endpoints: [endpoint()],
+      measurements: measurementState(),
+      stats: { api: stats() },
+      settings,
+    });
+
+    expect(summary?.id).toBe('hist-fixed');
+    expect(summary?.roundCount).toBe(36);
+    expect(summary?.baselineEligibleEndpointCount).toBe(1);
+    expect(summary?.endpointKeys).toEqual(['https://api.example.com/status']);
+    expect(summary?.endpoints[0]).toMatchObject({
+      key: 'https://api.example.com/status',
+      label: 'API',
+      sampleCount: 36,
+      okCount: 36,
+      p50: 84,
+      p95: 130,
+      lastLatency: 90,
+      baselineEligible: true,
+    });
+  });
+
+  it('returns null when a session has no retained samples', () => {
+    const summary = buildHistorySessionSummary({
+      endpoints: [endpoint()],
+      measurements: measurementState({
+        roundCounter: 0,
+        endpoints: {},
+      }),
+      stats: {},
+      settings,
+    });
+
+    expect(summary).toBeNull();
+  });
+});

--- a/tests/unit/stores/history.test.ts
+++ b/tests/unit/stores/history.test.ts
@@ -49,11 +49,14 @@ describe('historyStore', () => {
   it('hydrates, saves, and sorts local sessions by newest first', async () => {
     const saved: HistorySessionSummary[] = [session({ id: 'old', createdAt: 1 })];
     const storage: HistoryStorage = {
-      list: vi.fn(async () => saved),
-      save: vi.fn(async (next) => { saved.push(next); return true; }),
-      delete: vi.fn(async () => true),
-      clear: vi.fn(async () => true),
-      prune: vi.fn(async () => true),
+      list: vi.fn(() => Promise.resolve(saved)),
+      save: vi.fn((next) => {
+        saved.push(next);
+        return Promise.resolve(true);
+      }),
+      delete: vi.fn(() => Promise.resolve(true)),
+      clear: vi.fn(() => Promise.resolve(true)),
+      prune: vi.fn(() => Promise.resolve(true)),
     };
     const store = createHistoryStore(storage);
 
@@ -69,11 +72,11 @@ describe('historyStore', () => {
 
   it('keeps the UI usable when storage fails', async () => {
     const storage: HistoryStorage = {
-      list: vi.fn(async () => { throw new Error('blocked'); }),
-      save: vi.fn(async () => { throw new Error('blocked'); }),
-      delete: vi.fn(async () => true),
-      clear: vi.fn(async () => true),
-      prune: vi.fn(async () => true),
+      list: vi.fn(() => Promise.reject(new Error('blocked'))),
+      save: vi.fn(() => Promise.reject(new Error('blocked'))),
+      delete: vi.fn(() => Promise.resolve(true)),
+      clear: vi.fn(() => Promise.resolve(true)),
+      prune: vi.fn(() => Promise.resolve(true)),
     };
     const store = createHistoryStore(storage);
 

--- a/tests/unit/stores/history.test.ts
+++ b/tests/unit/stores/history.test.ts
@@ -1,0 +1,85 @@
+import { get } from 'svelte/store';
+import { describe, expect, it, vi } from 'vitest';
+import { createHistoryStore, type HistoryStorage } from '../../../src/lib/stores/history';
+import type { HistorySessionSummary } from '../../../src/lib/history/session-summary';
+
+function session(over: Partial<HistorySessionSummary> = {}): HistorySessionSummary {
+  return {
+    id: 'hist-1',
+    createdAt: 1_765_000_000_000,
+    startedAt: 1_765_000_000_000 - 10_000,
+    stoppedAt: 1_765_000_000_000,
+    durationMs: 10_000,
+    lifecycle: 'completed',
+    roundCount: 40,
+    endpointCount: 1,
+    baselineEligibleEndpointCount: 1,
+    endpointKeys: ['https://api.example.com/status'],
+    settings: {
+      healthThreshold: 120,
+      corsMode: 'no-cors',
+      timeout: 5000,
+    },
+    verdict: {
+      headline: 'No endpoint is clearly slow',
+      kind: 'healthy',
+      confidence: 'high',
+    },
+    endpoints: [{
+      endpointId: 'api',
+      key: 'https://api.example.com/status',
+      url: 'https://api.example.com/status',
+      label: 'API',
+      enabled: true,
+      sampleCount: 40,
+      okCount: 40,
+      lossPercent: 0,
+      p50: 100,
+      p95: 150,
+      p99: 180,
+      stddev: 10,
+      lastLatency: 100,
+      baselineEligible: true,
+    }],
+    ...over,
+  };
+}
+
+describe('historyStore', () => {
+  it('hydrates, saves, and sorts local sessions by newest first', async () => {
+    const saved: HistorySessionSummary[] = [session({ id: 'old', createdAt: 1 })];
+    const storage: HistoryStorage = {
+      list: vi.fn(async () => saved),
+      save: vi.fn(async (next) => { saved.push(next); return true; }),
+      delete: vi.fn(async () => true),
+      clear: vi.fn(async () => true),
+      prune: vi.fn(async () => true),
+    };
+    const store = createHistoryStore(storage);
+
+    await store.hydrate();
+    expect(get(store).sessions.map((item) => item.id)).toEqual(['old']);
+
+    await store.saveSession(session({ id: 'new', createdAt: 2 }));
+
+    expect(storage.save).toHaveBeenCalledWith(expect.objectContaining({ id: 'new' }));
+    expect(storage.prune).toHaveBeenCalled();
+    expect(get(store).sessions.map((item) => item.id)).toEqual(['new', 'old']);
+  });
+
+  it('keeps the UI usable when storage fails', async () => {
+    const storage: HistoryStorage = {
+      list: vi.fn(async () => { throw new Error('blocked'); }),
+      save: vi.fn(async () => { throw new Error('blocked'); }),
+      delete: vi.fn(async () => true),
+      clear: vi.fn(async () => true),
+      prune: vi.fn(async () => true),
+    };
+    const store = createHistoryStore(storage);
+
+    await expect(store.hydrate()).resolves.toEqual([]);
+    await expect(store.saveSession(session())).resolves.toBe(false);
+
+    expect(get(store).error).toContain('blocked');
+  });
+});

--- a/tests/unit/utils/history-baseline.test.ts
+++ b/tests/unit/utils/history-baseline.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import { buildHistoryBaselineInsight } from '../../../src/lib/utils/history-baseline';
+import type { Endpoint, EndpointStatistics } from '../../../src/lib/types';
+import type { HistorySessionSummary } from '../../../src/lib/history/session-summary';
+
+function endpoint(over: Partial<Endpoint> = {}): Endpoint {
+  return {
+    id: 'api',
+    url: 'https://api.example.com/status',
+    enabled: true,
+    label: 'API',
+    color: '#67e8f9',
+    ...over,
+  };
+}
+
+function stats(over: Partial<EndpointStatistics> = {}): EndpointStatistics {
+  return {
+    endpointId: 'api',
+    sampleCount: 40,
+    p50: 100,
+    p95: 150,
+    p99: 180,
+    p25: 90,
+    p75: 120,
+    p90: 140,
+    min: 80,
+    max: 200,
+    stddev: 10,
+    ci95: { lower: 95, upper: 105, margin: 5 },
+    connectionReuseDelta: null,
+    lossPercent: 0,
+    ready: true,
+    ...over,
+  };
+}
+
+function session(id: string, p50: number, over: Partial<HistorySessionSummary['endpoints'][number]> = {}): HistorySessionSummary {
+  const createdAt = 1_765_000_000_000 + Number(id.replace(/\D/g, '') || 0);
+  const endpointKey = 'https://api.example.com/status';
+  const endpointSummary = {
+    endpointId: 'api',
+    key: endpointKey,
+    url: 'https://api.example.com/status',
+    label: 'API',
+    enabled: true,
+    sampleCount: 40,
+    okCount: 40,
+    lossPercent: 0,
+    p50,
+    p95: p50 * 1.5,
+    p99: p50 * 1.8,
+    stddev: 10,
+    lastLatency: p50,
+    baselineEligible: true,
+    ...over,
+  };
+
+  return {
+    id,
+    createdAt,
+    startedAt: createdAt - 10_000,
+    stoppedAt: createdAt,
+    durationMs: 10_000,
+    lifecycle: 'completed',
+    roundCount: 40,
+    endpointCount: 1,
+    baselineEligibleEndpointCount: endpointSummary.baselineEligible ? 1 : 0,
+    endpointKeys: [endpointKey],
+    settings: {
+      healthThreshold: 120,
+      corsMode: 'no-cors',
+      timeout: 5000,
+    },
+    verdict: {
+      headline: 'No endpoint is clearly slow',
+      kind: 'healthy',
+      confidence: 'high',
+    },
+    endpoints: [endpointSummary],
+  };
+}
+
+describe('history baseline insight', () => {
+  it('explains when no local baseline exists yet', () => {
+    const insight = buildHistoryBaselineInsight({
+      endpoints: [endpoint()],
+      stats: { api: stats() },
+      history: [],
+    });
+
+    expect(insight.status).toBe('no-history');
+    expect(insight.headline).toContain('No local baseline');
+  });
+
+  it('marks the current run normal when it matches prior local sessions', () => {
+    const insight = buildHistoryBaselineInsight({
+      endpoints: [endpoint()],
+      stats: { api: stats({ p50: 103, p95: 154 }) },
+      history: [session('hist-1', 98), session('hist-2', 100), session('hist-3', 102)],
+    });
+
+    expect(insight.status).toBe('normal');
+    expect(insight.headline).toContain('matches your local baseline');
+    expect(insight.comparisons[0]?.baselineP50).toBe(100);
+  });
+
+  it('flags a severe baseline regression in plain language', () => {
+    const insight = buildHistoryBaselineInsight({
+      endpoints: [endpoint()],
+      stats: { api: stats({ p50: 310, p95: 480 }) },
+      history: [session('hist-1', 98), session('hist-2', 100), session('hist-3', 102)],
+    });
+
+    expect(insight.status).toBe('severe');
+    expect(insight.headline).toContain('API');
+    expect(insight.detail).toContain('3.1x');
+    expect(insight.comparisons[0]?.status).toBe('severe');
+  });
+
+  it('ignores weak sessions and the current session when building baselines', () => {
+    const currentStartedAt = 1_765_000_010_000;
+    const insight = buildHistoryBaselineInsight({
+      endpoints: [endpoint()],
+      stats: { api: stats({ p50: 125, p95: 180 }) },
+      currentStartedAt,
+      history: [
+        session('hist-1', 100),
+        session('hist-2', 102),
+        session('hist-3', 104, { baselineEligible: false, sampleCount: 6 }),
+        { ...session('hist-current', 900), startedAt: currentStartedAt },
+        session('hist-4', 101),
+      ],
+    });
+
+    expect(insight.status).toBe('normal');
+    expect(insight.comparisons[0]?.priorSessionCount).toBe(3);
+    expect(insight.comparisons[0]?.baselineP50).toBe(101);
+  });
+});


### PR DESCRIPTION
## Summary
- add local-only IndexedDB session history with conservative baseline eligibility
- compare current runs against prior local baselines and surface plain-language baseline context
- show a compact overview baseline chip, full report baseline context, and a settings action to clear local history

## Test Plan
- npm run typecheck
- npm run lint
- npm test
- npm run build
- Playwright smoke check with seeded local history for the overview baseline chip
