### PR TITLE
[codex] Add Cloudflare remote vantage layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ latency, not a synthetic cloud monitor.
 
 ## What It Does Today
 
-- Runs entirely in the browser with no account or backend required.
+- Runs in the browser with no account required; optional Cloudflare Functions
+  add an outside vantage point and short hosted report links.
 - Probes enabled endpoints in synchronized rounds using Web Workers.
 - Starts with region-aware default endpoints and supports custom endpoints.
 - Shows three shipped views:
@@ -21,7 +22,10 @@ latency, not a synthetic cloud monitor.
     browser timing data is available, and recent samples.
 - Supports endpoint nicknames, reordering, enabling/disabling, regional resets,
   timing settings, CORS mode selection, and local persistence.
-- Shares configs and result snapshots through compressed URL hashes.
+- Shares configs and result snapshots through compressed URL hashes, with
+  optional KV-backed `/r/:id` hosted report permalinks on Cloudflare.
+- Can compare the browser's path with a Cloudflare edge probe, then preserve
+  that outside-vantage evidence in shared reports.
 - Blocks private/local hosts from shared URLs while still allowing local testing
   for endpoints added directly by the current user.
 
@@ -33,7 +37,9 @@ Resource Timing phase data is limited for cross-origin endpoints unless the
 target server exposes timing headers.
 
 The optional local diagnostic companion agent adds local-only DNS, TLS, route,
-WiFi, and browser-history context when run by the user.
+WiFi, and browser-history context when run by the user. The optional Cloudflare
+layer adds remote edge probes, short hosted report links, and a saturation
+endpoint; see `docs/cloudflare-remote-vantage.md`.
 
 ## Quick Start
 
@@ -53,6 +59,7 @@ npm test
 npm run build
 npm run test:visual
 npm run companion
+npm run deploy
 ```
 
 `npm run test:visual` uses Playwright and starts the Vite dev server from
@@ -65,9 +72,13 @@ npm run companion
   settings, and UI state.
 - `src/lib/components/` - topbar, rail, views, drawers, popovers, and charts.
 - `src/lib/share/` - compressed share payload generation and validation.
+- `src/lib/remote-vantage/` - Cloudflare edge probe client, report persistence
+  client, and browser/remote diagnosis fusion.
+- `functions/` - Cloudflare Pages Functions for remote probes, hosted reports,
+  health, and saturation downloads.
+- `companion/` - optional signed local diagnostic companion agent.
 - `src/lib/security/` - URL safety checks for direct and shared endpoints.
 - `src/lib/regional-defaults.ts` - region detection and default endpoint sets.
-- `companion/` - optional signed local diagnostic companion agent.
 - `tests/unit/` - Vitest unit and component coverage.
 - `tests/visual/` - Playwright visual, accessibility, and browser-flow checks.
 - `docs/vision/` - product vision and longer-term platform direction.

--- a/docs/cloudflare-remote-vantage.md
+++ b/docs/cloudflare-remote-vantage.md
@@ -24,8 +24,9 @@ Configure these on the Cloudflare Pages project:
 - `CHRONOSCOPE_REPORTS`: KV namespace for hosted reports. Reports expire after
   30 days.
 - `CHRONOSCOPE_SATURATION`: optional R2 bucket/object binding. When an object
-  named `chronoscope-saturation.bin` matches the requested byte count exactly,
-  the function serves it; otherwise it generates a deterministic stream.
+  named `chronoscope-saturation.bin` exists and its size matches the requested
+  byte count exactly, the function serves it; otherwise it generates a
+  deterministic stream.
 
 If `CHRONOSCOPE_REPORTS` is absent, report creation returns a structured
 `fallback: "hash"` response and the browser copies the existing hash-based URL

--- a/docs/cloudflare-remote-vantage.md
+++ b/docs/cloudflare-remote-vantage.md
@@ -1,0 +1,71 @@
+# Cloudflare Remote Vantage Layer
+
+Chronoscope stays browser-first, but the optional Cloudflare layer adds an
+outside network witness. It answers the question the browser cannot answer on
+its own: "does this endpoint look bad only from my path, or also from an edge
+outside my network?"
+
+## Capabilities
+
+- Remote probe: `POST /api/vantage/probe` fetches up to eight public HTTP(S)
+  targets from the Cloudflare edge and returns bounded timing/status/header
+  evidence.
+- Hosted reports: `POST /api/reports` stores a validated results snapshot in
+  KV and returns a short `/r/:id` permalink. `GET /api/reports/:id` retrieves it.
+- Saturation endpoint: `GET /api/vantage/saturation?bytes=...` streams a
+  bounded binary response for browser-side download saturation checks.
+- Health check: `GET /api/vantage/health` reports edge metadata and configured
+  capabilities.
+
+## Bindings
+
+Configure these on the Cloudflare Pages project:
+
+- `CHRONOSCOPE_REPORTS`: KV namespace for hosted reports. Reports expire after
+  30 days.
+- `CHRONOSCOPE_SATURATION`: optional R2 bucket/object binding. When an object
+  named `chronoscope-saturation.bin` matches the requested byte count exactly,
+  the function serves it; otherwise it generates a deterministic stream.
+
+If `CHRONOSCOPE_REPORTS` is absent, report creation returns a structured
+`fallback: "hash"` response and the browser copies the existing hash-based URL
+instead.
+
+## Safety Boundaries
+
+- Remote probes accept only public `http:` and `https:` URLs on ports 80/443.
+- Credentials, localhost, link-local, private IPv4 ranges, obvious local IPv6
+  ranges, `.local`, and `.internal` hosts are rejected before fetch.
+- Probe responses expose only `content-type`, `server`, `cache-control`, and
+  `cf-cache-status`, each length-bounded.
+- Hosted report payloads are size-capped and revalidated by the browser before
+  being applied.
+- Remote vantage evidence is serialized into shared results so recipients see
+  the same outside-path comparison the sender captured.
+
+## Local Verification
+
+```bash
+npm run typecheck
+npm run lint
+npm test
+npm run build
+```
+
+The focused edge contract tests live in:
+
+- `tests/unit/remote-vantage/functions.test.ts`
+- `tests/unit/remote-vantage/insight.test.ts`
+- `tests/unit/stores/remote-vantage.test.ts`
+- `tests/unit/share/hosted-report-router.test.ts`
+- `tests/unit/share/share-payload-builder-remote.test.ts`
+
+## Deploy
+
+```bash
+npm run deploy
+```
+
+`public/_routes.json` keeps Pages Functions scoped to `/api/*`, and
+`public/_redirects` lets `/r/:id` open the SPA before it fetches the stored
+report from `/api/reports/:id`.

--- a/functions/_shared/remote-vantage.ts
+++ b/functions/_shared/remote-vantage.ts
@@ -1,0 +1,378 @@
+import type { SharePayload } from '../../src/lib/types';
+import type {
+  HostedReportCreateResponse,
+  HostedReportLoadResponse,
+  RemoteVantageEdge,
+  RemoteVantageProbeRequest,
+  RemoteVantageProbeResponse,
+  RemoteVantageResult,
+  RemoteVantageTarget,
+  RemoteVantageVerdict,
+} from '../../src/lib/remote-vantage/types';
+
+export interface ReportKV {
+  get(key: string): Promise<string | null>;
+  put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>;
+}
+
+export interface SaturationBucket {
+  get(key: string): Promise<{ readonly body: ReadableStream | null; readonly size: number } | null>;
+}
+
+export interface RemoteProbeOptions {
+  readonly cf?: Partial<RemoteVantageEdge> | null;
+  readonly fetcher?: typeof fetch;
+  readonly now?: () => number;
+}
+
+export interface HostedReportOptions {
+  readonly reports?: ReportKV;
+  readonly id?: string;
+  readonly idFactory?: () => string;
+  readonly now?: () => number;
+}
+
+export interface SaturationOptions {
+  readonly bucket?: SaturationBucket;
+}
+
+const MAX_TARGETS = 8;
+const MAX_REPORT_BYTES = 120_000;
+const REPORT_TTL_SECONDS = 60 * 60 * 24 * 30;
+const REPORT_ID_PATTERN = /^[a-zA-Z0-9_-]{8,80}$/;
+const PROBE_TIMEOUT_MS = 4500;
+const SLOW_REMOTE_MS = 500;
+const DEFAULT_SATURATION_BYTES = 25 * 1024 * 1024;
+const MAX_SATURATION_BYTES = 100 * 1024 * 1024;
+const CHUNK_BYTES = 64 * 1024;
+const PUBLIC_PORTS = new Set(['', '80', '443']);
+const EXPOSED_HEADERS = ['content-type', 'server', 'cache-control', 'cf-cache-status'];
+
+function json(status: number, payload: unknown, extraHeaders: HeadersInit = {}): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'no-store',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET,POST,HEAD,OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+      ...extraHeaders,
+    },
+  });
+}
+
+function parseBody(request: Request): Promise<unknown> {
+  const contentType = request.headers.get('content-type') ?? '';
+  if (!contentType.includes('application/json')) {
+    throw new Error('Expected application/json.');
+  }
+  return request.json() as Promise<unknown>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function parseIPv4(hostname: string): number[] | null {
+  const parts = hostname.split('.');
+  if (parts.length !== 4) return null;
+  const octets = parts.map((part) => Number(part));
+  if (octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) return null;
+  return octets;
+}
+
+function isBlockedIPv4(hostname: string): boolean {
+  const octets = parseIPv4(hostname);
+  if (!octets) return false;
+  const [first = 0, second = 0] = octets;
+  return (
+    first === 0 ||
+    first === 10 ||
+    first === 127 ||
+    first === 169 && second === 254 ||
+    first === 172 && second >= 16 && second <= 31 ||
+    first === 192 && second === 168 ||
+    first === 100 && second >= 64 && second <= 127 ||
+    first >= 224
+  );
+}
+
+function isBlockedHostname(hostname: string): boolean {
+  const lower = hostname.toLowerCase();
+  if (
+    lower === 'localhost' ||
+    lower.endsWith('.localhost') ||
+    lower.endsWith('.local') ||
+    lower.endsWith('.internal')
+  ) return true;
+  if (isBlockedIPv4(lower)) return true;
+  if (lower.includes(':')) {
+    return lower === '::1' ||
+      lower === '[::1]' ||
+      lower.startsWith('fc') ||
+      lower.startsWith('fd') ||
+      lower.startsWith('fe80') ||
+      lower === '::';
+  }
+  return false;
+}
+
+function parsePublicUrl(raw: unknown): URL {
+  if (typeof raw !== 'string' || raw.length > 2048) {
+    throw new Error('Target URL must be a public http(s) URL.');
+  }
+  const url = new URL(raw);
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new Error('Target URL must be a public http(s) URL.');
+  }
+  if (url.username || url.password || isBlockedHostname(url.hostname) || !PUBLIC_PORTS.has(url.port)) {
+    throw new Error('Target URL must be a public http(s) URL.');
+  }
+  return url;
+}
+
+function parseTargets(payload: unknown): RemoteVantageTarget[] {
+  if (!isRecord(payload) || !Array.isArray(payload.targets)) {
+    throw new Error('Request body must include targets.');
+  }
+  if (payload.targets.length === 0 || payload.targets.length > MAX_TARGETS) {
+    throw new Error(`Remote vantage supports 1-${MAX_TARGETS} targets per request.`);
+  }
+
+  return payload.targets.map((target, index) => {
+    if (!isRecord(target)) throw new Error('Each target must be an object.');
+    const url = parsePublicUrl(target.url);
+    return {
+      id: typeof target.id === 'string' && target.id ? target.id.slice(0, 80) : `target-${index + 1}`,
+      label: typeof target.label === 'string' && target.label ? target.label.slice(0, 120) : url.hostname,
+      url: url.toString(),
+    };
+  });
+}
+
+function edgeFrom(cf?: Partial<RemoteVantageEdge> | null): RemoteVantageEdge {
+  return {
+    ...(cf?.colo ? { colo: String(cf.colo) } : {}),
+    ...(cf?.country ? { country: String(cf.country) } : {}),
+    ...(cf?.city ? { city: String(cf.city) } : {}),
+    ...(cf?.region ? { region: String(cf.region) } : {}),
+    ...(cf?.timezone ? { timezone: String(cf.timezone) } : {}),
+  };
+}
+
+function exposedHeaders(headers: Headers): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const key of EXPOSED_HEADERS) {
+    const value = headers.get(key);
+    if (value) out[key] = value.slice(0, 160);
+  }
+  return out;
+}
+
+function verdictFor(status: number | null, durationMs: number, ok: boolean): RemoteVantageVerdict {
+  if (!ok || status === null) return 'unreachable';
+  if (status >= 500) return 'http-error';
+  if (durationMs >= SLOW_REMOTE_MS) return 'slow';
+  return 'reachable';
+}
+
+async function probeTarget(target: RemoteVantageTarget, options: Required<Pick<RemoteProbeOptions, 'fetcher' | 'now'>>): Promise<RemoteVantageResult> {
+  const startedAt = performance.now();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+
+  try {
+    const response = await options.fetcher(target.url, {
+      method: 'GET',
+      redirect: 'manual',
+      signal: controller.signal,
+      headers: {
+        Accept: '*/*',
+        'Cache-Control': 'no-cache',
+        Range: 'bytes=0-0',
+        'User-Agent': 'Chronoscope-Remote-Vantage/1.0',
+      },
+      cf: {
+        cacheTtl: 0,
+        cacheEverything: false,
+      },
+    } as RequestInit & { cf: Record<string, unknown> });
+    const durationMs = Math.max(0, Math.round(performance.now() - startedAt));
+    const ok = response.status < 500;
+    await response.body?.cancel().catch(() => undefined);
+    return {
+      endpointId: target.id,
+      label: target.label,
+      url: target.url,
+      ok,
+      status: response.status,
+      statusText: response.statusText || null,
+      durationMs,
+      checkedAt: options.now(),
+      verdict: verdictFor(response.status, durationMs, ok),
+      headers: exposedHeaders(response.headers),
+    };
+  } catch (error) {
+    return {
+      endpointId: target.id,
+      label: target.label,
+      url: target.url,
+      ok: false,
+      status: null,
+      statusText: null,
+      durationMs: Math.max(0, Math.round(performance.now() - startedAt)),
+      checkedAt: options.now(),
+      verdict: 'unreachable',
+      headers: {},
+      error: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function handleRemoteProbe(request: Request, options: RemoteProbeOptions = {}): Promise<Response> {
+  if (request.method === 'OPTIONS') return json(204, {});
+  if (request.method !== 'POST') return json(405, { ok: false, error: 'Method not allowed.' });
+
+  try {
+    const body = await parseBody(request);
+    const parsed: RemoteVantageProbeRequest = { targets: parseTargets(body) };
+    const fetcher = options.fetcher ?? fetch;
+    const now = options.now ?? Date.now;
+    const results = await Promise.all(parsed.targets.map((target) => probeTarget(target, { fetcher, now })));
+    const payload: RemoteVantageProbeResponse = {
+      ok: true,
+      generatedAt: now(),
+      edge: edgeFrom(options.cf),
+      results,
+    };
+    return json(200, payload);
+  } catch (error) {
+    return json(400, {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function isSharePayloadLike(value: unknown): value is SharePayload {
+  if (!isRecord(value)) return false;
+  if (value.v !== 1 && value.v !== 2) return false;
+  if (value.mode !== 'config' && value.mode !== 'results') return false;
+  if (!Array.isArray(value.endpoints) || value.endpoints.length > 50) return false;
+  if (!isRecord(value.settings)) return false;
+  if (value.mode === 'results' && !Array.isArray(value.results)) return false;
+  return true;
+}
+
+function reportId(factory?: () => string): string {
+  if (factory) return factory();
+  return `r_${crypto.randomUUID().replaceAll('-', '').slice(0, 24)}`;
+}
+
+export async function handleCreateHostedReport(request: Request, options: HostedReportOptions = {}): Promise<Response> {
+  if (request.method === 'OPTIONS') return json(204, {});
+  if (request.method !== 'POST') return json(405, { ok: false, error: 'Method not allowed.' });
+  if (!options.reports) {
+    const fallback: HostedReportCreateResponse = {
+      ok: false,
+      fallback: 'hash',
+      error: 'Report persistence is not configured.',
+    };
+    return json(503, fallback);
+  }
+
+  try {
+    const raw = await parseBody(request);
+    if (!isRecord(raw) || !isSharePayloadLike(raw.payload)) {
+      return json(400, { ok: false, error: 'Invalid report payload.' });
+    }
+    const serialized = JSON.stringify(raw.payload);
+    if (new TextEncoder().encode(serialized).byteLength > MAX_REPORT_BYTES) {
+      return json(413, { ok: false, error: 'Report payload is too large.' });
+    }
+
+    const id = reportId(options.idFactory);
+    const now = options.now ?? Date.now;
+    await options.reports.put(`report:${id}`, serialized, { expirationTtl: REPORT_TTL_SECONDS });
+    return json(201, {
+      ok: true,
+      id,
+      url: `${new URL(request.url).origin}/r/${id}`,
+      expiresAt: now() + REPORT_TTL_SECONDS * 1000,
+    } satisfies HostedReportCreateResponse);
+  } catch (error) {
+    return json(400, {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export async function handleGetHostedReport(request: Request, options: HostedReportOptions = {}): Promise<Response> {
+  if (request.method === 'OPTIONS') return json(204, {});
+  if (request.method !== 'GET') return json(405, { ok: false, error: 'Method not allowed.' });
+  const id = options.id ?? new URL(request.url).pathname.split('/').filter(Boolean).at(-1) ?? '';
+  if (!REPORT_ID_PATTERN.test(id)) return json(400, { ok: false, error: 'Invalid report id.' });
+  if (!options.reports) return json(503, { ok: false, error: 'Report persistence is not configured.' });
+
+  const stored = await options.reports.get(`report:${id}`);
+  if (!stored) return json(404, { ok: false, error: 'Report not found or expired.' });
+
+  const payload = JSON.parse(stored) as unknown;
+  if (!isSharePayloadLike(payload)) return json(500, { ok: false, error: 'Stored report is invalid.' });
+  return json(200, { ok: true, payload } satisfies HostedReportLoadResponse);
+}
+
+function requestedSaturationBytes(request: Request): number {
+  const url = new URL(request.url);
+  const raw = Number(url.searchParams.get('bytes') ?? DEFAULT_SATURATION_BYTES);
+  if (!Number.isFinite(raw)) return DEFAULT_SATURATION_BYTES;
+  return Math.max(1, Math.min(MAX_SATURATION_BYTES, Math.floor(raw)));
+}
+
+function generatedSaturationStream(totalBytes: number): ReadableStream<Uint8Array> {
+  let sent = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      const remaining = totalBytes - sent;
+      if (remaining <= 0) {
+        controller.close();
+        return;
+      }
+      const size = Math.min(CHUNK_BYTES, remaining);
+      const chunk = new Uint8Array(size);
+      for (let index = 0; index < size; index++) chunk[index] = (sent + index) % 251;
+      sent += size;
+      controller.enqueue(chunk);
+    },
+  });
+}
+
+export async function handleSaturationRequest(request: Request, options: SaturationOptions = {}): Promise<Response> {
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    return json(405, { ok: false, error: 'Method not allowed.' });
+  }
+  const bytes = requestedSaturationBytes(request);
+  const headers = {
+    'Content-Type': 'application/octet-stream',
+    'Cache-Control': 'no-store',
+    'Access-Control-Allow-Origin': '*',
+    'Content-Length': String(bytes),
+    'X-Chronoscope-Saturation-Bytes': String(bytes),
+  };
+
+  if (request.method === 'HEAD') return new Response(null, { status: 200, headers });
+
+  const bucketObject = await options.bucket?.get('chronoscope-saturation.bin');
+  if (bucketObject?.body && bucketObject.size === bytes) {
+    return new Response(bucketObject.body.pipeThrough(new TransformStream()), { status: 200, headers });
+  }
+  return new Response(generatedSaturationStream(bytes), { status: 200, headers });
+}

--- a/functions/_shared/remote-vantage.ts
+++ b/functions/_shared/remote-vantage.ts
@@ -49,7 +49,7 @@ const PUBLIC_PORTS = new Set(['', '80', '443']);
 const EXPOSED_HEADERS = ['content-type', 'server', 'cache-control', 'cf-cache-status'];
 
 function json(status: number, payload: unknown, extraHeaders: HeadersInit = {}): Response {
-  return new Response(JSON.stringify(payload), {
+  return new Response(status === 204 ? null : JSON.stringify(payload), {
     status,
     headers: {
       'Content-Type': 'application/json; charset=utf-8',
@@ -102,6 +102,29 @@ function isBlockedIPv4(hostname: string): boolean {
   );
 }
 
+function isBlockedIPv4MappedIPv6(hostname: string): boolean {
+  const stripped = hostname.startsWith('[') && hostname.endsWith(']')
+    ? hostname.slice(1, -1)
+    : hostname;
+  if (!stripped.startsWith('::ffff:')) return false;
+
+  const embedded = stripped.slice('::ffff:'.length);
+  if (isBlockedIPv4(embedded)) return true;
+
+  const hexMapped = embedded.match(/^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (!hexMapped || hexMapped[1] === undefined || hexMapped[2] === undefined) return false;
+
+  const hi = parseInt(hexMapped[1], 16);
+  const lo = parseInt(hexMapped[2], 16);
+  const ipv4 = [
+    (hi >> 8) & 0xff,
+    hi & 0xff,
+    (lo >> 8) & 0xff,
+    lo & 0xff,
+  ].join('.');
+  return isBlockedIPv4(ipv4);
+}
+
 function isBlockedHostname(hostname: string): boolean {
   const lower = hostname.toLowerCase();
   if (
@@ -112,6 +135,8 @@ function isBlockedHostname(hostname: string): boolean {
   ) return true;
   if (isBlockedIPv4(lower)) return true;
   if (lower.includes(':')) {
+    const stripped = lower.startsWith('[') && lower.endsWith(']') ? lower.slice(1, -1) : lower;
+    if (isBlockedIPv4MappedIPv6(stripped)) return true;
     return lower === '::1' ||
       lower === '[::1]' ||
       lower.startsWith('fc') ||
@@ -325,9 +350,13 @@ export async function handleGetHostedReport(request: Request, options: HostedRep
   const stored = await options.reports.get(`report:${id}`);
   if (!stored) return json(404, { ok: false, error: 'Report not found or expired.' });
 
-  const payload = JSON.parse(stored) as unknown;
-  if (!isSharePayloadLike(payload)) return json(500, { ok: false, error: 'Stored report is invalid.' });
-  return json(200, { ok: true, payload } satisfies HostedReportLoadResponse);
+  try {
+    const payload = JSON.parse(stored) as unknown;
+    if (!isSharePayloadLike(payload)) return json(500, { ok: false, error: 'Stored report is invalid.' });
+    return json(200, { ok: true, payload } satisfies HostedReportLoadResponse);
+  } catch {
+    return json(500, { ok: false, error: 'Stored report is invalid.' });
+  }
 }
 
 function requestedSaturationBytes(request: Request): number {
@@ -356,6 +385,7 @@ function generatedSaturationStream(totalBytes: number): ReadableStream<Uint8Arra
 }
 
 export async function handleSaturationRequest(request: Request, options: SaturationOptions = {}): Promise<Response> {
+  if (request.method === 'OPTIONS') return json(204, {});
   if (request.method !== 'GET' && request.method !== 'HEAD') {
     return json(405, { ok: false, error: 'Method not allowed.' });
   }

--- a/functions/_shared/remote-vantage.ts
+++ b/functions/_shared/remote-vantage.ts
@@ -74,10 +74,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
-function isFiniteNumber(value: unknown): value is number {
-  return typeof value === 'number' && Number.isFinite(value);
-}
-
 function parseIPv4(hostname: string): number[] | null {
   const parts = hostname.split('.');
   if (parts.length !== 4) return null;
@@ -292,8 +288,7 @@ function isSharePayloadLike(value: unknown): value is SharePayload {
   if (value.mode !== 'config' && value.mode !== 'results') return false;
   if (!Array.isArray(value.endpoints) || value.endpoints.length > 50) return false;
   if (!isRecord(value.settings)) return false;
-  if (value.mode === 'results' && !Array.isArray(value.results)) return false;
-  return true;
+  return value.mode !== 'results' || Array.isArray(value.results);
 }
 
 function reportId(factory?: () => string): string {

--- a/functions/api/reports/[id].ts
+++ b/functions/api/reports/[id].ts
@@ -8,14 +8,14 @@ function reportId(params: EventContext<Env, string, { id?: string }>['params']):
   return typeof params.id === 'string' ? params.id : '';
 }
 
-export const onRequestGet: PagesFunction<Env> = async (context) => {
+export const onRequestGet: PagesFunction<Env> = (context) => {
   return handleGetHostedReport(context.request, {
     reports: context.env.CHRONOSCOPE_REPORTS,
     id: reportId(context.params),
   });
 };
 
-export const onRequestOptions: PagesFunction<Env> = async (context) => {
+export const onRequestOptions: PagesFunction<Env> = (context) => {
   return handleGetHostedReport(context.request, {
     id: reportId(context.params),
   });

--- a/functions/api/reports/[id].ts
+++ b/functions/api/reports/[id].ts
@@ -1,0 +1,22 @@
+import { handleGetHostedReport, type ReportKV } from '../../_shared/remote-vantage';
+
+interface Env {
+  CHRONOSCOPE_REPORTS?: ReportKV;
+}
+
+function reportId(params: EventContext<Env, string, { id?: string }>['params']): string {
+  return typeof params.id === 'string' ? params.id : '';
+}
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  return handleGetHostedReport(context.request, {
+    reports: context.env.CHRONOSCOPE_REPORTS,
+    id: reportId(context.params),
+  });
+};
+
+export const onRequestOptions: PagesFunction<Env> = async (context) => {
+  return handleGetHostedReport(context.request, {
+    id: reportId(context.params),
+  });
+};

--- a/functions/api/reports/index.ts
+++ b/functions/api/reports/index.ts
@@ -4,12 +4,12 @@ interface Env {
   CHRONOSCOPE_REPORTS?: ReportKV;
 }
 
-export const onRequestPost: PagesFunction<Env> = async (context) => {
+export const onRequestPost: PagesFunction<Env> = (context) => {
   return handleCreateHostedReport(context.request, {
     reports: context.env.CHRONOSCOPE_REPORTS,
   });
 };
 
-export const onRequestOptions: PagesFunction<Env> = async (context) => {
+export const onRequestOptions: PagesFunction<Env> = (context) => {
   return handleCreateHostedReport(context.request);
 };

--- a/functions/api/reports/index.ts
+++ b/functions/api/reports/index.ts
@@ -1,0 +1,15 @@
+import { handleCreateHostedReport, type ReportKV } from '../../_shared/remote-vantage';
+
+interface Env {
+  CHRONOSCOPE_REPORTS?: ReportKV;
+}
+
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  return handleCreateHostedReport(context.request, {
+    reports: context.env.CHRONOSCOPE_REPORTS,
+  });
+};
+
+export const onRequestOptions: PagesFunction<Env> = async (context) => {
+  return handleCreateHostedReport(context.request);
+};

--- a/functions/api/vantage/health.ts
+++ b/functions/api/vantage/health.ts
@@ -3,7 +3,7 @@ interface Env {
   CHRONOSCOPE_SATURATION?: unknown;
 }
 
-export const onRequestGet: PagesFunction<Env> = async (context) => {
+export const onRequestGet: PagesFunction<Env> = (context) => {
   const edge = {
     ...(context.request.cf?.colo ? { colo: String(context.request.cf.colo) } : {}),
     ...(context.request.cf?.country ? { country: String(context.request.cf.country) } : {}),

--- a/functions/api/vantage/health.ts
+++ b/functions/api/vantage/health.ts
@@ -1,0 +1,29 @@
+interface Env {
+  CHRONOSCOPE_REPORTS?: unknown;
+  CHRONOSCOPE_SATURATION?: unknown;
+}
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  const edge = {
+    ...(context.request.cf?.colo ? { colo: String(context.request.cf.colo) } : {}),
+    ...(context.request.cf?.country ? { country: String(context.request.cf.country) } : {}),
+    ...(context.request.cf?.city ? { city: String(context.request.cf.city) } : {}),
+    ...(context.request.cf?.region ? { region: String(context.request.cf.region) } : {}),
+  };
+
+  return new Response(JSON.stringify({
+    ok: true,
+    version: 1,
+    edge,
+    capabilities: {
+      remoteHttpTiming: true,
+      hostedReports: Boolean(context.env.CHRONOSCOPE_REPORTS),
+      saturationEndpoint: true,
+    },
+  }), {
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'no-store',
+    },
+  });
+};

--- a/functions/api/vantage/probe.ts
+++ b/functions/api/vantage/probe.ts
@@ -1,0 +1,13 @@
+import { handleRemoteProbe } from '../../_shared/remote-vantage';
+
+interface Env {}
+
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  return handleRemoteProbe(context.request, {
+    cf: context.request.cf,
+  });
+};
+
+export const onRequestOptions: PagesFunction<Env> = async (context) => {
+  return handleRemoteProbe(context.request);
+};

--- a/functions/api/vantage/probe.ts
+++ b/functions/api/vantage/probe.ts
@@ -1,13 +1,13 @@
 import { handleRemoteProbe } from '../../_shared/remote-vantage';
 
-interface Env {}
+type Env = Record<string, never>;
 
-export const onRequestPost: PagesFunction<Env> = async (context) => {
+export const onRequestPost: PagesFunction<Env> = (context) => {
   return handleRemoteProbe(context.request, {
     cf: context.request.cf,
   });
 };
 
-export const onRequestOptions: PagesFunction<Env> = async (context) => {
+export const onRequestOptions: PagesFunction<Env> = (context) => {
   return handleRemoteProbe(context.request);
 };

--- a/functions/api/vantage/saturation.ts
+++ b/functions/api/vantage/saturation.ts
@@ -15,3 +15,7 @@ export const onRequestHead: PagesFunction<Env> = async (context) => {
     bucket: context.env.CHRONOSCOPE_SATURATION,
   });
 };
+
+export const onRequestOptions: PagesFunction<Env> = async (context) => {
+  return handleSaturationRequest(context.request);
+};

--- a/functions/api/vantage/saturation.ts
+++ b/functions/api/vantage/saturation.ts
@@ -4,18 +4,18 @@ interface Env {
   CHRONOSCOPE_SATURATION?: SaturationBucket;
 }
 
-export const onRequestGet: PagesFunction<Env> = async (context) => {
+export const onRequestGet: PagesFunction<Env> = (context) => {
   return handleSaturationRequest(context.request, {
     bucket: context.env.CHRONOSCOPE_SATURATION,
   });
 };
 
-export const onRequestHead: PagesFunction<Env> = async (context) => {
+export const onRequestHead: PagesFunction<Env> = (context) => {
   return handleSaturationRequest(context.request, {
     bucket: context.env.CHRONOSCOPE_SATURATION,
   });
 };
 
-export const onRequestOptions: PagesFunction<Env> = async (context) => {
+export const onRequestOptions: PagesFunction<Env> = (context) => {
   return handleSaturationRequest(context.request);
 };

--- a/functions/api/vantage/saturation.ts
+++ b/functions/api/vantage/saturation.ts
@@ -1,0 +1,17 @@
+import { handleSaturationRequest, type SaturationBucket } from '../../_shared/remote-vantage';
+
+interface Env {
+  CHRONOSCOPE_SATURATION?: SaturationBucket;
+}
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  return handleSaturationRequest(context.request, {
+    bucket: context.env.CHRONOSCOPE_SATURATION,
+  });
+};
+
+export const onRequestHead: PagesFunction<Env> = async (context) => {
+  return handleSaturationRequest(context.request, {
+    bucket: context.env.CHRONOSCOPE_SATURATION,
+  });
+};

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022", "WebWorker"],
+    "types": ["@cloudflare/workers-types"],
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["./**/*.ts", "../src/lib/remote-vantage/**/*.ts", "../src/lib/types.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.11.1",
+        "@cloudflare/workers-types": "^4.20260509.1",
         "@playwright/test": "^1.59.1",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
         "@testing-library/svelte": "^5.3.1",
@@ -186,6 +187,13 @@
       "bin": {
         "specificity": "bin/cli.js"
       }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260509.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260509.1.tgz",
+      "integrity": "sha512-jFlTTD+0MK/01TdL5sHIsQ8RqzfmvBsGl4hSp87INv2+JIs/JF6EL9J8enuCz6z3fNdfOKISNbGCIrzZRXVrcw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && npm run typecheck:functions",
+    "typecheck:functions": "tsc -p functions/tsconfig.json --noEmit",
     "lint": "eslint src",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -20,6 +21,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.1",
+    "@cloudflare/workers-types": "^4.20260509.1",
     "@playwright/test": "^1.59.1",
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
     "@testing-library/svelte": "^5.3.1",

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,1 @@
+/r/* /index.html 200

--- a/public/_routes.json
+++ b/public/_routes.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "include": ["/api/*"],
+  "exclude": ["/assets/*", "/*.js", "/*.css", "/*.png", "/*.svg", "/*.ico"]
+}

--- a/src/lib/components/App.svelte
+++ b/src/lib/components/App.svelte
@@ -15,7 +15,7 @@
   import { detectRegion } from '$lib/regional-defaults';
   import { applyPersistedSettings } from '$lib/utils/apply-persisted-settings';
   import { loadPersistedSettings, saveSettings, CURRENT_VERSION } from '$lib/utils/persistence';
-  import { initHashRouter } from '$lib/share/hash-router';
+  import { initHashRouter, initHostedReportRouter } from '$lib/share/hash-router';
   import { initShortcuts } from '$lib/utils/shortcuts';
   import type { PersistedSettings } from '$lib/types';
   import Layout from './Layout.svelte';
@@ -206,12 +206,15 @@
   }
 
   // ── Mount ────────────────────────────────────────────────────────────────────
-  onMount(() => {
+  async function bootstrap(): Promise<void> {
     // 1. Bridge tokens to CSS custom properties
     bridgeTokensToCss();
 
     // 2. Check for share URL — takes priority over persisted settings
-    const shareMode = initHashRouter();
+    let shareMode = initHashRouter();
+    if (shareMode === null) {
+      shareMode = await initHostedReportRouter();
+    }
 
     // 3. Load persisted settings. Skip ONLY for results-mode shares — those
     //    mutate the stores (endpoints + measurement snapshot) for read-only
@@ -244,6 +247,10 @@
 
     // 7. Register keyboard shortcuts
     destroyShortcuts = initShortcuts();
+  }
+
+  onMount(() => {
+    void bootstrap();
   });
 
   onDestroy(() => {

--- a/src/lib/components/App.svelte
+++ b/src/lib/components/App.svelte
@@ -250,7 +250,9 @@
   }
 
   onMount(() => {
-    void bootstrap();
+    void bootstrap().catch((error) => {
+      console.warn('[Chronoscope] App bootstrap failed:', error);
+    });
   });
 
   onDestroy(() => {

--- a/src/lib/components/DiagnoseView.svelte
+++ b/src/lib/components/DiagnoseView.svelte
@@ -8,9 +8,11 @@
 <script lang="ts">
   import { monitoredEndpointsStore } from '$lib/stores/derived';
   import { measurementStore } from '$lib/stores/measurements';
+  import { remoteVantageStore } from '$lib/stores/remote-vantage';
   import { settingsStore } from '$lib/stores/settings';
   import { statisticsStore } from '$lib/stores/statistics';
   import { uiStore } from '$lib/stores/ui';
+  import { buildRemoteVantageInsight } from '$lib/remote-vantage/insight';
   import { describeTimingVisibility, type DiagnosticConfidence } from '$lib/utils/diagnostic-narrative';
   import { phaseHypothesis, PHASE_LABELS, type PhaseBreakdown, type Tier2Phase } from '$lib/utils/verdict';
   import { buildHistogram, buildCorrelation } from '$lib/utils/diagnose-stats';
@@ -22,12 +24,20 @@
   const stats = $derived($statisticsStore);
   const measurements = $derived($measurementStore);
   const settings = $derived($settingsStore);
+  const remoteVantage = $derived($remoteVantageStore);
   const focusedId = $derived($uiStore.focusedEndpointId);
 
   const focusedEndpoint = $derived(
     focusedId === null ? null : monitored.find((ep) => ep.id === focusedId) ?? null,
   );
   const focusedStats = $derived(focusedEndpoint ? stats[focusedEndpoint.id] : undefined);
+  const remoteInsight = $derived(buildRemoteVantageInsight({
+    endpoint: focusedEndpoint,
+    stats: focusedStats,
+    threshold: settings.healthThreshold,
+    probe: remoteVantage.lastProbe,
+  }));
+  const remoteBusy = $derived(remoteVantage.status === 'checking' || remoteVantage.status === 'probing');
 
   // ── Mode toggle ──────────────────────────────────────────────────────────
   let mode = $state<'p50' | 'p95'>('p50');
@@ -195,6 +205,10 @@
     mode = next;
   }
 
+  async function handleRemoteCheck(): Promise<void> {
+    await remoteVantageStore.runProbe(monitored);
+  }
+
   // ── Accessibility summary for the hero bar ────────────────────────────────
   const heroAria = $derived(
     phases === null
@@ -324,6 +338,49 @@
       <p class="visibility-detail">{timingVisibility.detail}</p>
       {#if timingVisibility.action}
         <p class="visibility-action">{timingVisibility.action}</p>
+      {/if}
+    </section>
+
+    <section
+      class="diagnose-remote"
+      class:local-path={remoteInsight.status === 'local-path'}
+      class:remote-confirms={remoteInsight.status === 'remote-confirms' || remoteInsight.status === 'remote-error'}
+      aria-label="Remote vantage"
+    >
+      <div class="remote-head">
+        <div>
+          <div class="diagnose-section-kicker">Remote vantage</div>
+          <p class="remote-headline">{remoteInsight.headline}</p>
+        </div>
+        <button
+          type="button"
+          class="diagnose-chip diagnose-chip-action"
+          disabled={remoteBusy}
+          aria-disabled={remoteBusy}
+          onclick={handleRemoteCheck}
+        >
+          {remoteBusy ? 'Checking…' : 'Check from Cloudflare'}
+        </button>
+      </div>
+      <p class="remote-detail">{remoteInsight.detail}</p>
+      <dl class="remote-evidence">
+        <div>
+          <dt>Edge</dt>
+          <dd>{remoteInsight.edgeLabel}</dd>
+        </div>
+        <div>
+          <dt>Status</dt>
+          <dd>{remoteInsight.result?.status ?? '—'}</dd>
+        </div>
+        <div>
+          <dt>Remote time</dt>
+          <dd>{remoteInsight.result ? `${fmt(remoteInsight.result.durationMs)} ms` : '—'}</dd>
+        </div>
+      </dl>
+      {#if remoteVantage.error}
+        <p class="remote-error">{remoteVantage.error}</p>
+      {:else}
+        <p class="remote-action">{remoteInsight.action}</p>
       {/if}
     </section>
 
@@ -576,7 +633,8 @@
 
   /* ── Diagnostic answer + browser visibility ───────────────────────────── */
   .diagnose-answer,
-  .diagnose-visibility {
+  .diagnose-visibility,
+  .diagnose-remote {
     display: flex;
     flex-direction: column;
     gap: 10px;
@@ -670,6 +728,74 @@
   }
   .visibility-action {
     color: var(--accent-cyan);
+  }
+
+  .diagnose-remote.local-path {
+    border-color: rgba(103, 232, 249, 0.28);
+    background: rgba(103, 232, 249, 0.04);
+  }
+  .diagnose-remote.remote-confirms {
+    border-color: rgba(251, 191, 36, 0.28);
+    background: rgba(251, 191, 36, 0.045);
+  }
+  .remote-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+  .remote-headline,
+  .remote-detail,
+  .remote-action,
+  .remote-error {
+    margin: 0;
+  }
+  .remote-headline {
+    color: var(--t1);
+    font-size: var(--ts-md);
+    line-height: 1.4;
+  }
+  .remote-detail,
+  .remote-action,
+  .remote-error {
+    color: var(--t3);
+    font-size: var(--ts-sm);
+    line-height: 1.45;
+  }
+  .remote-action {
+    color: var(--accent-cyan);
+  }
+  .remote-error {
+    color: var(--accent-amber);
+  }
+  .remote-evidence {
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 10px;
+  }
+  .remote-evidence div {
+    min-width: 0;
+    padding-top: 8px;
+    border-top: 1px solid var(--border-mid);
+  }
+  .remote-evidence dt {
+    margin: 0 0 3px;
+    color: var(--t4);
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-kicker);
+    text-transform: uppercase;
+  }
+  .remote-evidence dd {
+    margin: 0;
+    color: var(--t1);
+    font-family: var(--mono);
+    font-size: var(--ts-sm);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   /* ── Cross-endpoint correlation ────────────────────────────────────────── */

--- a/src/lib/components/ReportView.svelte
+++ b/src/lib/components/ReportView.svelte
@@ -8,8 +8,9 @@
   import { settingsStore } from '$lib/stores/settings';
   import { statisticsStore } from '$lib/stores/statistics';
   import { uiStore } from '$lib/stores/ui';
+  import { remoteVantageStore } from '$lib/stores/remote-vantage';
   import { buildShareURL } from '$lib/share/share-manager';
-  import { buildResultsSharePayload } from '$lib/share/share-payload-builder';
+  import { buildResultsSharePayload, MAX_SHARE_URL_CHARS } from '$lib/share/share-payload-builder';
   import { buildDiagnosticReport, formatReportMetric } from '$lib/utils/diagnostic-report';
   import { buildHistoryBaselineInsight } from '$lib/utils/history-baseline';
   import { tokens } from '$lib/tokens';
@@ -17,6 +18,7 @@
   const endpoints = $derived($endpointStore);
   const measurements = $derived($measurementStore);
   const history = $derived($historyStore);
+  const remoteVantage = $derived($remoteVantageStore);
   const settings = $derived($settingsStore);
   const stats = $derived($statisticsStore);
   const context = $derived($uiStore.sharedReportContext);
@@ -63,28 +65,42 @@
     });
   }
 
-  function handleCopyLink(): void {
+  async function handleCopyLink(): Promise<void> {
     const settingsForReport = {
       ...get(settingsStore),
       healthThreshold: report.threshold,
       corsMode: report.corsMode,
     };
-    const built = buildResultsSharePayload(
+    const metadata = {
+      createdAt: report.createdAt ?? Date.now(),
+      healthThreshold: report.threshold,
+      corsMode: report.corsMode,
+      roundCount: report.roundCount,
+      totalSampleCount: report.totalSampleCount,
+      truncated: report.truncated,
+    };
+    const builtForHostedReport = buildResultsSharePayload(
       get(endpointStore),
       settingsForReport,
       get(measurementStore),
-      undefined,
+      100_000,
       Date.now(),
-      {
-        createdAt: report.createdAt ?? Date.now(),
-        healthThreshold: report.threshold,
-        corsMode: report.corsMode,
-        roundCount: report.roundCount,
-        totalSampleCount: report.totalSampleCount,
-        truncated: report.truncated,
-      },
+      metadata,
+      get(remoteVantageStore).lastProbe,
     );
-    copyText(buildShareURL(built.payload), () => {
+    const hostedUrl = await remoteVantageStore.createHostedReport(builtForHostedReport.payload);
+    const fallbackPayload = hostedUrl === null
+      ? buildResultsSharePayload(
+          get(endpointStore),
+          settingsForReport,
+          get(measurementStore),
+          MAX_SHARE_URL_CHARS,
+          Date.now(),
+          metadata,
+          get(remoteVantageStore).lastProbe,
+        ).payload
+      : null;
+    copyText(hostedUrl ?? buildShareURL(fallbackPayload ?? builtForHostedReport.payload), () => {
       copiedLink = true;
     });
   }
@@ -222,6 +238,28 @@
             </div>
           {/each}
         </div>
+      {/if}
+    </section>
+
+    <section class="report-panel remote-panel" aria-label="Remote vantage">
+      <div class="section-kicker">Remote vantage</div>
+      {#if remoteVantage.lastProbe}
+        <h2>{remoteVantage.lastProbe.edge.colo ?? 'Cloudflare edge'} outside check</h2>
+        <p>{remoteVantage.lastProbe.edge.city || remoteVantage.lastProbe.edge.country
+          ? [remoteVantage.lastProbe.edge.city, remoteVantage.lastProbe.edge.country].filter(Boolean).join(' · ')
+          : 'Cloudflare checked these endpoints from outside the browser network.'}</p>
+        <div class="remote-list">
+          {#each remoteVantage.lastProbe.results.slice(0, 4) as result (result.endpointId)}
+            <div class="remote-row" class:hot={result.verdict === 'slow' || result.verdict === 'http-error' || result.verdict === 'unreachable'}>
+              <strong>{result.label}</strong>
+              <span>{result.status ?? 'failed'} · {Math.round(result.durationMs)} ms</span>
+              <small>{result.verdict}</small>
+            </div>
+          {/each}
+        </div>
+      {:else}
+        <h2>Outside vantage not captured</h2>
+        <p>Run a remote check in Diagnose before sharing when you need evidence from beyond the local browser path.</p>
       {/if}
     </section>
   </div>
@@ -469,6 +507,31 @@
   }
   .baseline-row span,
   .baseline-row small {
+    color: var(--t3);
+    line-height: 1.4;
+  }
+  .remote-list {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+    margin-top: 12px;
+  }
+  .remote-row {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    padding: 10px;
+    border: 1px solid rgba(103,232,249,.16);
+    border-radius: 7px;
+    background: rgba(103,232,249,.045);
+  }
+  .remote-row.hot {
+    border-color: rgba(251,191,36,.22);
+    background: rgba(251,191,36,.06);
+  }
+  .remote-row span,
+  .remote-row small {
     color: var(--t3);
     line-height: 1.4;
   }

--- a/src/lib/components/SharePopover.svelte
+++ b/src/lib/components/SharePopover.svelte
@@ -45,7 +45,7 @@
       get(measurementStore),
       MAX_SHARE_URL_CHARS,
       Date.now(),
-      {},
+      undefined,
       get(remoteVantageStore).lastProbe,
     );
   }

--- a/src/lib/components/SharePopover.svelte
+++ b/src/lib/components/SharePopover.svelte
@@ -8,6 +8,7 @@
   import { endpointStore } from '$lib/stores/endpoints';
   import { settingsStore } from '$lib/stores/settings';
   import { measurementStore } from '$lib/stores/measurements';
+  import { remoteVantageStore } from '$lib/stores/remote-vantage';
   import { buildShareURL } from '$lib/share/share-manager';
   import {
     buildConfigSharePayload,
@@ -43,6 +44,9 @@
       get(settingsStore),
       get(measurementStore),
       MAX_SHARE_URL_CHARS,
+      Date.now(),
+      {},
+      get(remoteVantageStore).lastProbe,
     );
   }
 

--- a/src/lib/remote-vantage/client.ts
+++ b/src/lib/remote-vantage/client.ts
@@ -29,14 +29,17 @@ export interface RemoteVantageClient {
   loadHostedReport(id: string): Promise<HostedReportLoadResponse>;
 }
 
-async function parseJsonResponse<T>(response: Response): Promise<T> {
+async function parseJsonResponse<T>(response: Response, allowedStatuses: readonly number[] = []): Promise<T> {
   const text = await response.text();
   const payload = text ? JSON.parse(text) as unknown : null;
-  if (!response.ok) {
+  if (!response.ok && !allowedStatuses.includes(response.status)) {
     const message = typeof payload === 'object' && payload !== null && 'error' in payload
       ? String((payload as { error: unknown }).error)
       : `Remote vantage request failed with HTTP ${response.status}`;
     throw new Error(message);
+  }
+  if (payload === null) {
+    throw new Error('Remote vantage returned an empty response.');
   }
   return payload as T;
 }
@@ -74,10 +77,7 @@ export function createRemoteVantageClient(fetcher: typeof fetch = fetch): Remote
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ payload }),
       });
-      if (response.status === 503) {
-        return response.json() as Promise<HostedReportCreateResponse>;
-      }
-      return parseJsonResponse<HostedReportCreateResponse>(response);
+      return parseJsonResponse<HostedReportCreateResponse>(response, [503]);
     },
 
     async loadHostedReport(id: string): Promise<HostedReportLoadResponse> {

--- a/src/lib/remote-vantage/client.ts
+++ b/src/lib/remote-vantage/client.ts
@@ -1,0 +1,90 @@
+import type { Endpoint, SharePayload } from '../types';
+import type {
+  HostedReportCreateResponse,
+  HostedReportLoadResponse,
+  RemoteVantageProbeRequest,
+  RemoteVantageProbeResponse,
+  RemoteVantageTarget,
+} from './types';
+
+export interface RemoteVantageHealth {
+  readonly ok: boolean;
+  readonly version: number;
+  readonly edge?: {
+    readonly colo?: string;
+    readonly country?: string;
+    readonly city?: string;
+  };
+  readonly capabilities: {
+    readonly remoteHttpTiming: boolean;
+    readonly hostedReports: boolean;
+    readonly saturationEndpoint: boolean;
+  };
+}
+
+export interface RemoteVantageClient {
+  checkHealth(): Promise<RemoteVantageHealth>;
+  runProbe(request: RemoteVantageProbeRequest): Promise<RemoteVantageProbeResponse>;
+  createHostedReport(payload: SharePayload): Promise<HostedReportCreateResponse>;
+  loadHostedReport(id: string): Promise<HostedReportLoadResponse>;
+}
+
+async function parseJsonResponse<T>(response: Response): Promise<T> {
+  const text = await response.text();
+  const payload = text ? JSON.parse(text) as unknown : null;
+  if (!response.ok) {
+    const message = typeof payload === 'object' && payload !== null && 'error' in payload
+      ? String((payload as { error: unknown }).error)
+      : `Remote vantage request failed with HTTP ${response.status}`;
+    throw new Error(message);
+  }
+  return payload as T;
+}
+
+export function endpointsToRemoteTargets(endpoints: readonly Endpoint[]): RemoteVantageTarget[] {
+  return endpoints
+    .filter((endpoint) => endpoint.enabled)
+    .slice(0, 8)
+    .map((endpoint) => ({
+      id: endpoint.id,
+      label: endpoint.label,
+      url: endpoint.url,
+    }));
+}
+
+export function createRemoteVantageClient(fetcher: typeof fetch = fetch): RemoteVantageClient {
+  return {
+    async checkHealth(): Promise<RemoteVantageHealth> {
+      const response = await fetcher('/api/vantage/health', { method: 'GET' });
+      return parseJsonResponse<RemoteVantageHealth>(response);
+    },
+
+    async runProbe(request: RemoteVantageProbeRequest): Promise<RemoteVantageProbeResponse> {
+      const response = await fetcher('/api/vantage/probe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(request),
+      });
+      return parseJsonResponse<RemoteVantageProbeResponse>(response);
+    },
+
+    async createHostedReport(payload: SharePayload): Promise<HostedReportCreateResponse> {
+      const response = await fetcher('/api/reports', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ payload }),
+      });
+      if (response.status === 503) {
+        return response.json() as Promise<HostedReportCreateResponse>;
+      }
+      return parseJsonResponse<HostedReportCreateResponse>(response);
+    },
+
+    async loadHostedReport(id: string): Promise<HostedReportLoadResponse> {
+      const response = await fetcher(`/api/reports/${encodeURIComponent(id)}`, { method: 'GET' });
+      return parseJsonResponse<HostedReportLoadResponse>(response);
+    },
+  };
+}
+
+export const remoteVantageClient = createRemoteVantageClient();

--- a/src/lib/remote-vantage/insight.ts
+++ b/src/lib/remote-vantage/insight.ts
@@ -1,0 +1,105 @@
+import type { Endpoint, EndpointStatistics } from '../types';
+import type { RemoteVantageProbeResponse, RemoteVantageResult } from './types';
+
+export type RemoteVantageInsightStatus =
+  | 'unavailable'
+  | 'remote-normal'
+  | 'local-path'
+  | 'remote-confirms'
+  | 'remote-error';
+
+export interface RemoteVantageInsight {
+  readonly status: RemoteVantageInsightStatus;
+  readonly headline: string;
+  readonly detail: string;
+  readonly action: string;
+  readonly edgeLabel: string;
+  readonly result: RemoteVantageResult | null;
+}
+
+interface RemoteVantageInsightInput {
+  readonly endpoint: Endpoint | null;
+  readonly stats: EndpointStatistics | undefined;
+  readonly threshold: number;
+  readonly probe: RemoteVantageProbeResponse | null;
+}
+
+function fmtMs(value: number): string {
+  return `${Math.round(value)} ms`;
+}
+
+function edgeLabel(probe: RemoteVantageProbeResponse | null): string {
+  if (!probe) return 'Cloudflare edge';
+  const parts = [probe.edge.colo, probe.edge.city, probe.edge.country].filter(Boolean);
+  return parts.length > 0 ? parts.join(' · ') : 'Cloudflare edge';
+}
+
+function resultFor(endpoint: Endpoint | null, probe: RemoteVantageProbeResponse | null): RemoteVantageResult | null {
+  if (!endpoint || !probe) return null;
+  return probe.results.find((result) => result.endpointId === endpoint.id || result.url === endpoint.url) ?? null;
+}
+
+export function buildRemoteVantageInsight(input: RemoteVantageInsightInput): RemoteVantageInsight {
+  const result = resultFor(input.endpoint, input.probe);
+  const label = input.endpoint?.label ?? 'this endpoint';
+  const edge = edgeLabel(input.probe);
+
+  if (!input.endpoint || !result) {
+    return {
+      status: 'unavailable',
+      headline: 'Remote vantage not checked yet',
+      detail: 'Chronoscope can ask Cloudflare to fetch the same endpoint from outside your network.',
+      action: 'Run a remote check to compare your browser path against a Cloudflare edge.',
+      edgeLabel: edge,
+      result: null,
+    };
+  }
+
+  const browserP50 = input.stats?.ready ? input.stats.p50 : null;
+  const browserSlow = browserP50 !== null && browserP50 > input.threshold;
+  const remoteSlow = result.verdict === 'slow' || result.durationMs > input.threshold;
+
+  if (!result.ok || result.verdict === 'unreachable' || result.verdict === 'http-error') {
+    return {
+      status: 'remote-error',
+      headline: `${edge} cannot cleanly reach ${label}`,
+      detail: result.status === null
+        ? `The remote probe failed after ${fmtMs(result.durationMs)}.`
+        : `The remote probe got HTTP ${result.status} in ${fmtMs(result.durationMs)}.`,
+      action: 'Compare from your browser and another network; if both fail, the origin, CDN, or DNS path is the likely source.',
+      edgeLabel: edge,
+      result,
+    };
+  }
+
+  if (browserSlow && !remoteSlow) {
+    return {
+      status: 'local-path',
+      headline: `Cloudflare reaches ${label} normally`,
+      detail: `${edge} reached it in ${fmtMs(result.durationMs)} while your browser p50 is ${fmtMs(browserP50 ?? 0)}, pointing toward your browser path, ISP, VPN, WiFi, or local network.`,
+      action: 'Use the local companion agent or another network to narrow the local path.',
+      edgeLabel: edge,
+      result,
+    };
+  }
+
+  if (browserSlow && remoteSlow) {
+    return {
+      status: 'remote-confirms',
+      headline: `${label} is also slow from Cloudflare`,
+      detail: `${edge} took ${fmtMs(result.durationMs)} and your browser p50 is ${fmtMs(browserP50 ?? 0)}, so the endpoint, CDN, or a broad upstream path is implicated.`,
+      action: 'Share the report with the service owner; it now contains outside-vantage evidence.',
+      edgeLabel: edge,
+      result,
+    };
+  }
+
+  return {
+    status: 'remote-normal',
+    headline: `${edge} reaches ${label} in ${fmtMs(result.durationMs)}`,
+    detail: 'The outside vantage is currently healthy for this endpoint.',
+    action: 'Keep the check available for intermittent issues or include it in a support report.',
+    edgeLabel: edge,
+    result,
+  };
+}

--- a/src/lib/remote-vantage/insight.ts
+++ b/src/lib/remote-vantage/insight.ts
@@ -4,6 +4,7 @@ import type { RemoteVantageProbeResponse, RemoteVantageResult } from './types';
 export type RemoteVantageInsightStatus =
   | 'unavailable'
   | 'remote-normal'
+  | 'remote-slow-only'
   | 'local-path'
   | 'remote-confirms'
   | 'remote-error';
@@ -89,6 +90,17 @@ export function buildRemoteVantageInsight(input: RemoteVantageInsightInput): Rem
       headline: `${label} is also slow from Cloudflare`,
       detail: `${edge} took ${fmtMs(result.durationMs)} and your browser p50 is ${fmtMs(browserP50 ?? 0)}, so the endpoint, CDN, or a broad upstream path is implicated.`,
       action: 'Share the report with the service owner; it now contains outside-vantage evidence.',
+      edgeLabel: edge,
+      result,
+    };
+  }
+
+  if (!browserSlow && remoteSlow) {
+    return {
+      status: 'remote-slow-only',
+      headline: `${label} is slow from ${edge}, but not your browser`,
+      detail: `${edge} took ${fmtMs(result.durationMs)}${browserP50 !== null ? ` while your browser p50 is ${fmtMs(browserP50)}` : ''}, suggesting the outside edge path or origin may be inconsistent right now.`,
+      action: 'Run the check again or compare another outside vantage before blaming the local network.',
       edgeLabel: edge,
       result,
     };

--- a/src/lib/remote-vantage/types.ts
+++ b/src/lib/remote-vantage/types.ts
@@ -1,0 +1,47 @@
+import type {
+  SharePayload,
+  ShareRemoteVantageEdge,
+  ShareRemoteVantageResult,
+  ShareRemoteVantageSnapshot,
+  ShareRemoteVantageVerdict,
+} from '../types';
+
+export interface RemoteVantageTarget {
+  readonly id: string;
+  readonly label: string;
+  readonly url: string;
+}
+
+export interface RemoteVantageProbeRequest {
+  readonly targets: readonly RemoteVantageTarget[];
+}
+
+export type RemoteVantageEdge = ShareRemoteVantageEdge;
+
+export type RemoteVantageVerdict = ShareRemoteVantageVerdict;
+
+export type RemoteVantageResult = ShareRemoteVantageResult;
+
+export interface RemoteVantageProbeResponse extends ShareRemoteVantageSnapshot {
+  readonly ok: boolean;
+}
+
+export interface HostedReportSuccess {
+  readonly ok: true;
+  readonly id: string;
+  readonly url: string;
+  readonly expiresAt: number;
+}
+
+export interface HostedReportFallback {
+  readonly ok: false;
+  readonly fallback: 'hash';
+  readonly error: string;
+}
+
+export type HostedReportCreateResponse = HostedReportSuccess | HostedReportFallback;
+
+export interface HostedReportLoadResponse {
+  readonly ok: true;
+  readonly payload: SharePayload;
+}

--- a/src/lib/share/hash-router.ts
+++ b/src/lib/share/hash-router.ts
@@ -231,7 +231,7 @@ export function applySharePayload(payload: SharePayload): string[] {
     uiStore.setSharedReportContext(buildSharedReportContext(payload));
     uiStore.setSharedView(true);
     uiStore.setSharedReportMode(true);
-    remoteVantageStore.setProbe(payload.remoteVantage ? { ok: true, ...payload.remoteVantage } : null);
+    remoteVantageStore.setProbe(payload.remoteVantage ? { ...payload.remoteVantage, ok: true } : null);
   } else {
     uiStore.setSharedView(false);
     uiStore.setSharedReportMode(false);

--- a/src/lib/share/hash-router.ts
+++ b/src/lib/share/hash-router.ts
@@ -18,6 +18,7 @@
 import { parseShareURL } from './share-manager';
 import { endpointStore, MAX_ENDPOINTS } from '../stores/endpoints';
 import { measurementStore } from '../stores/measurements';
+import { remoteVantageStore } from '../stores/remote-vantage';
 import { uiStore } from '../stores/ui';
 import type {
   SharePayload,
@@ -29,6 +30,7 @@ import type {
 import { tokens } from '../tokens';
 import { get } from 'svelte/store';
 import { displayLabel } from '../endpoint/displayLabel';
+import { validateSharePayload } from './share-validator';
 
 // Upper bound for the round counter materialized from a share payload.
 // Matches the sample cap (10 000 per endpoint × 50 endpoints) with generous
@@ -146,6 +148,7 @@ export function applySharePayload(payload: SharePayload): string[] {
   // timeout=100); applying it would amplify a future Start click. The
   // receiver always probes at their own defaults, full stop.
   if (payload.mode === 'config') {
+    remoteVantageStore.setProbe(null);
     uiStore.setPendingShare({
       mode: 'config',
       endpoints: uniqueEndpoints(payload.endpoints),
@@ -228,10 +231,12 @@ export function applySharePayload(payload: SharePayload): string[] {
     uiStore.setSharedReportContext(buildSharedReportContext(payload));
     uiStore.setSharedView(true);
     uiStore.setSharedReportMode(true);
+    remoteVantageStore.setProbe(payload.remoteVantage ? { ok: true, ...payload.remoteVantage } : null);
   } else {
     uiStore.setSharedView(false);
     uiStore.setSharedReportMode(false);
     uiStore.setSharedReportContext(null);
+    remoteVantageStore.setProbe(null);
   }
 
   return ids;
@@ -291,4 +296,30 @@ export function initHashRouter(): 'config' | 'results' | null {
   history.replaceState(null, '', window.location.pathname + window.location.search);
 
   return payload.mode;
+}
+
+export async function initHostedReportRouter(fetcher: typeof fetch = fetch): Promise<'config' | 'results' | null> {
+  if (typeof window === 'undefined') return null;
+
+  const match = /^\/r\/([^/?#]+)\/?$/.exec(window.location.pathname);
+  if (!match) return null;
+
+  const id = match[1];
+  if (!id) return null;
+
+  try {
+    const response = await fetcher(`/api/reports/${encodeURIComponent(id)}`, { method: 'GET' });
+    if (!response.ok) return null;
+    const body = await response.json() as unknown;
+    if (body === null || typeof body !== 'object' || (body as { ok?: unknown }).ok !== true) return null;
+    const payload = validateSharePayload((body as { payload?: unknown }).payload);
+    if (!payload) return null;
+
+    applySharePayload(payload);
+    history.replaceState(null, '', `/${window.location.search}`);
+    return payload.mode;
+  } catch (error) {
+    console.warn('[Chronoscope] Hosted report load failed:', error);
+    return null;
+  }
 }

--- a/src/lib/share/share-manager.ts
+++ b/src/lib/share/share-manager.ts
@@ -4,8 +4,7 @@
 
 import LZString from 'lz-string';
 import type { SharePayload, Settings } from '../types';
-import { isSafeSharedUrl } from '../utils/url-safety';
-import { MAX_CAP } from '../limits';
+import { validateSharePayload } from './share-validator';
 
 // ── Share settings helper ──────────────────────────────────────────────────
 // Explicitly destructures only the 6 allowed share fields.
@@ -41,111 +40,6 @@ export function decodeSharePayload(encoded: string): SharePayload | null {
     console.warn('[Chronoscope] Share URL decode error:', err);
     return null;
   }
-}
-
-// ── Schema validation ──────────────────────────────────────────────────────
-
-function isFiniteNumber(v: unknown): boolean {
-  return typeof v === 'number' && Number.isFinite(v);
-}
-
-function isNonNegativeFiniteNumber(v: unknown): boolean {
-  return isFiniteNumber(v) && (v as number) >= 0;
-}
-
-function validateSharePayload(data: unknown): SharePayload | null {
-  if (data === null || typeof data !== 'object') return null;
-  const obj = data as Record<string, unknown>;
-
-  if (obj['v'] !== 1 && obj['v'] !== 2) return null;
-  if (obj['mode'] !== 'config' && obj['mode'] !== 'results') return null;
-  if (!Array.isArray(obj['endpoints'])) return null;
-  if ((obj['endpoints'] as unknown[]).length > 50) return null;
-
-  // mode:'results' without a results array is structurally invalid: the
-  // payload claims to carry a snapshot but doesn't. Pre-fix, the apply
-  // path silently took the else branch (no measurement load, no shared
-  // banner) but had already written endpoints to endpointStore — leaving
-  // the user with attacker URLs in the rail and no indicator. Reject at
-  // the validator so the apply path never sees a half-formed payload.
-  if (obj['mode'] === 'results' && obj['results'] === undefined) return null;
-
-  for (const ep of obj['endpoints'] as unknown[]) {
-    if (ep === null || typeof ep !== 'object') return null;
-    const e = ep as Record<string, unknown>;
-    if (!isSafeSharedUrl(e['url'])) return null;
-    if (typeof e['enabled'] !== 'boolean') return null;
-    // Reject unknown per-entry keys. Allowlist: url, enabled. Hybrid Bet (share-side): nicknames stay local; schema-level rejection at boundary.
-    for (const key of Object.keys(e)) {
-      if (key !== 'url' && key !== 'enabled') return null;
-    }
-  }
-
-  const settings = obj['settings'];
-  if (settings === null || typeof settings !== 'object') return null;
-  const s = settings as Record<string, unknown>;
-  if (!isNonNegativeFiniteNumber(s['timeout']) || (s['timeout'] as number) > 15000) return null;
-  if (!isNonNegativeFiniteNumber(s['delay'])) return null;
-  if (!isNonNegativeFiniteNumber(s['cap']) || (s['cap'] as number) > MAX_CAP) return null;
-  if (s['burstRounds'] !== undefined && (!isNonNegativeFiniteNumber(s['burstRounds']) || (s['burstRounds'] as number) > 500)) return null;
-  if (s['monitorDelay'] !== undefined && (!isNonNegativeFiniteNumber(s['monitorDelay']) || (s['monitorDelay'] as number) > 60000)) return null;
-  if (s['corsMode'] !== 'no-cors' && s['corsMode'] !== 'cors') return null;
-
-  if (obj['report'] !== undefined) {
-    if (obj['mode'] !== 'results') return null;
-    if (obj['v'] !== 2) return null;
-    const report = obj['report'];
-    if (report === null || typeof report !== 'object') return null;
-    const r = report as Record<string, unknown>;
-    const allowedReportKeys = new Set([
-      'createdAt',
-      'healthThreshold',
-      'corsMode',
-      'roundCount',
-      'totalSampleCount',
-      'keptSampleCount',
-      'truncated',
-    ]);
-    for (const key of Object.keys(r)) {
-      if (!allowedReportKeys.has(key)) return null;
-    }
-    if (!isNonNegativeFiniteNumber(r['createdAt'])) return null;
-    if (!isNonNegativeFiniteNumber(r['healthThreshold']) || (r['healthThreshold'] as number) > 15000) return null;
-    if (r['corsMode'] !== 'no-cors' && r['corsMode'] !== 'cors') return null;
-    if (!isNonNegativeFiniteNumber(r['roundCount']) || (r['roundCount'] as number) > 1_000_000) return null;
-    if (!isNonNegativeFiniteNumber(r['totalSampleCount']) || (r['totalSampleCount'] as number) > 500_000) return null;
-    if (!isNonNegativeFiniteNumber(r['keptSampleCount']) || (r['keptSampleCount'] as number) > 500_000) return null;
-    if ((r['keptSampleCount'] as number) > (r['totalSampleCount'] as number)) return null;
-    if (typeof r['truncated'] !== 'boolean') return null;
-  }
-
-  // Reject unknown top-level keys. Allowlist: v, mode, endpoints, settings, results, report. Symmetric with per-entry.
-  const ALLOWED_TOP_LEVEL = new Set(['v', 'mode', 'endpoints', 'settings', 'results', 'report']);
-  for (const key of Object.keys(obj)) {
-    if (!ALLOWED_TOP_LEVEL.has(key)) return null;
-  }
-
-  if (obj['results'] !== undefined) {
-    if (!Array.isArray(obj['results'])) return null;
-    if ((obj['results'] as unknown[]).length > 50) return null;
-    for (const result of obj['results'] as unknown[]) {
-      if (result === null || typeof result !== 'object') return null;
-      const r = result as Record<string, unknown>;
-      if (!Array.isArray(r['samples'])) return null;
-      if ((r['samples'] as unknown[]).length > 10_000) return null;
-      for (const sample of r['samples'] as unknown[]) {
-        if (sample === null || typeof sample !== 'object') return null;
-        const samp = sample as Record<string, unknown>;
-        if (
-          !isNonNegativeFiniteNumber(samp['round']) ||
-          !isNonNegativeFiniteNumber(samp['latency']) ||
-          (samp['status'] !== 'ok' && samp['status'] !== 'timeout' && samp['status'] !== 'error')
-        ) return null;
-      }
-    }
-  }
-
-  return data as SharePayload;
 }
 
 // ── URL construction ───────────────────────────────────────────────────────

--- a/src/lib/share/share-payload-builder.ts
+++ b/src/lib/share/share-payload-builder.ts
@@ -2,7 +2,14 @@
 // Pure builders for config and result share payloads. Keeping this outside the
 // popover lets ReportView copy the exact report link that SharePopover emits.
 
-import type { Endpoint, MeasurementState, Settings, SharePayload, ShareReportMetadata } from '../types';
+import type {
+  Endpoint,
+  MeasurementState,
+  Settings,
+  SharePayload,
+  ShareRemoteVantageSnapshot,
+  ShareReportMetadata,
+} from '../types';
 import { estimateShareSize, toSharedSettings, truncatePayload } from './share-manager';
 
 export const MAX_SHARE_URL_CHARS = 8000;
@@ -55,6 +62,29 @@ function withReportMetadata(
   return { ...payload, report: metadata };
 }
 
+function serializeRemoteVantage(
+  remoteVantage: ShareRemoteVantageSnapshot | null | undefined,
+): ShareRemoteVantageSnapshot | undefined {
+  if (!remoteVantage) return undefined;
+  return {
+    generatedAt: remoteVantage.generatedAt,
+    edge: { ...remoteVantage.edge },
+    results: remoteVantage.results.slice(0, 8).map((result) => ({
+      endpointId: result.endpointId,
+      label: result.label,
+      url: result.url,
+      ok: result.ok,
+      status: result.status,
+      statusText: result.statusText,
+      durationMs: result.durationMs,
+      checkedAt: result.checkedAt,
+      verdict: result.verdict,
+      headers: { ...result.headers },
+      ...(result.error ? { error: result.error } : {}),
+    })),
+  };
+}
+
 export function buildResultsSharePayload(
   endpoints: readonly Endpoint[],
   settings: Settings,
@@ -62,6 +92,7 @@ export function buildResultsSharePayload(
   maxChars = MAX_SHARE_URL_CHARS,
   now = Date.now(),
   reportMetadata: Partial<ShareReportMetadata> = {},
+  remoteVantage: ShareRemoteVantageSnapshot | null = null,
 ): BuiltResultsSharePayload {
   const results = buildResults(endpoints, measurements);
   const keptSampleCount = countSamples(results);
@@ -79,6 +110,7 @@ export function buildResultsSharePayload(
     keptSampleCount,
     truncated: reportMetadata.truncated ?? false,
   };
+  const serializedRemoteVantage = serializeRemoteVantage(remoteVantage);
 
   const basePayload: SharePayload = {
     v: 2,
@@ -86,6 +118,7 @@ export function buildResultsSharePayload(
     endpoints: endpoints.map(ep => ({ url: ep.url, enabled: ep.enabled })),
     settings: toSharedSettings(settings),
     report: metadata,
+    ...(serializedRemoteVantage ? { remoteVantage: serializedRemoteVantage } : {}),
     results,
   };
 

--- a/src/lib/share/share-validator.ts
+++ b/src/lib/share/share-validator.ts
@@ -1,0 +1,179 @@
+import { MAX_CAP } from '../limits';
+import type { SharePayload } from '../types';
+import { isSafeSharedUrl } from '../utils/url-safety';
+
+const ALLOWED_TOP_LEVEL = new Set(['v', 'mode', 'endpoints', 'settings', 'results', 'report', 'remoteVantage']);
+const ALLOWED_REPORT_KEYS = new Set([
+  'createdAt',
+  'healthThreshold',
+  'corsMode',
+  'roundCount',
+  'totalSampleCount',
+  'keptSampleCount',
+  'truncated',
+]);
+const ALLOWED_REMOTE_KEYS = new Set(['generatedAt', 'edge', 'results']);
+const ALLOWED_EDGE_KEYS = new Set(['colo', 'country', 'city', 'region', 'timezone']);
+const ALLOWED_REMOTE_RESULT_KEYS = new Set([
+  'endpointId',
+  'label',
+  'url',
+  'ok',
+  'status',
+  'statusText',
+  'durationMs',
+  'checkedAt',
+  'verdict',
+  'headers',
+  'error',
+]);
+const ALLOWED_REMOTE_HEADERS = new Set(['content-type', 'server', 'cache-control', 'cf-cache-status']);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isFiniteNumber(value: unknown): boolean {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isNonNegativeFiniteNumber(value: unknown): boolean {
+  return isFiniteNumber(value) && (value as number) >= 0;
+}
+
+function isStringWithin(value: unknown, maxLength: number, minLength = 0): value is string {
+  return typeof value === 'string' && value.length >= minLength && value.length <= maxLength;
+}
+
+function hasOnlyKeys(record: Record<string, unknown>, allowed: ReadonlySet<string>): boolean {
+  for (const key of Object.keys(record)) {
+    if (!allowed.has(key)) return false;
+  }
+  return true;
+}
+
+function validateReport(report: unknown, obj: Record<string, unknown>): boolean {
+  if (obj['mode'] !== 'results' || obj['v'] !== 2) return false;
+  if (!isRecord(report)) return false;
+  if (!hasOnlyKeys(report, ALLOWED_REPORT_KEYS)) return false;
+  if (!isNonNegativeFiniteNumber(report['createdAt'])) return false;
+  if (!isNonNegativeFiniteNumber(report['healthThreshold']) || (report['healthThreshold'] as number) > 15000) return false;
+  if (report['corsMode'] !== 'no-cors' && report['corsMode'] !== 'cors') return false;
+  if (!isNonNegativeFiniteNumber(report['roundCount']) || (report['roundCount'] as number) > 1_000_000) return false;
+  if (!isNonNegativeFiniteNumber(report['totalSampleCount']) || (report['totalSampleCount'] as number) > 500_000) return false;
+  if (!isNonNegativeFiniteNumber(report['keptSampleCount']) || (report['keptSampleCount'] as number) > 500_000) return false;
+  if ((report['keptSampleCount'] as number) > (report['totalSampleCount'] as number)) return false;
+  return typeof report['truncated'] === 'boolean';
+}
+
+function validateRemoteHeaders(headers: unknown): boolean {
+  if (!isRecord(headers)) return false;
+  if (Object.keys(headers).length > ALLOWED_REMOTE_HEADERS.size) return false;
+  for (const [key, value] of Object.entries(headers)) {
+    if (!ALLOWED_REMOTE_HEADERS.has(key)) return false;
+    if (!isStringWithin(value, 160)) return false;
+  }
+  return true;
+}
+
+function validateRemoteEdge(edge: unknown): boolean {
+  if (!isRecord(edge)) return false;
+  if (!hasOnlyKeys(edge, ALLOWED_EDGE_KEYS)) return false;
+  for (const value of Object.values(edge)) {
+    if (value !== undefined && !isStringWithin(value, 120)) return false;
+  }
+  return true;
+}
+
+function validateRemoteVantage(remote: unknown, obj: Record<string, unknown>): boolean {
+  if (obj['mode'] !== 'results' || obj['v'] !== 2) return false;
+  if (!isRecord(remote)) return false;
+  if (!hasOnlyKeys(remote, ALLOWED_REMOTE_KEYS)) return false;
+  if (!isNonNegativeFiniteNumber(remote['generatedAt'])) return false;
+  if (!validateRemoteEdge(remote['edge'])) return false;
+  if (!Array.isArray(remote['results']) || remote['results'].length === 0 || remote['results'].length > 8) return false;
+
+  for (const result of remote['results']) {
+    if (!isRecord(result)) return false;
+    if (!hasOnlyKeys(result, ALLOWED_REMOTE_RESULT_KEYS)) return false;
+    if (!isStringWithin(result['endpointId'], 80, 1)) return false;
+    if (!isStringWithin(result['label'], 120, 1)) return false;
+    if (!isSafeSharedUrl(result['url'])) return false;
+    if (typeof result['ok'] !== 'boolean') return false;
+    const status = result['status'];
+    if (status !== null && (!Number.isInteger(status) || (status as number) < 100 || (status as number) > 599)) return false;
+    const statusText = result['statusText'];
+    if (statusText !== null && !isStringWithin(statusText, 80)) return false;
+    if (!isNonNegativeFiniteNumber(result['durationMs']) || (result['durationMs'] as number) > 60_000) return false;
+    if (!isNonNegativeFiniteNumber(result['checkedAt'])) return false;
+    if (
+      result['verdict'] !== 'reachable' &&
+      result['verdict'] !== 'slow' &&
+      result['verdict'] !== 'http-error' &&
+      result['verdict'] !== 'unreachable'
+    ) return false;
+    if (!validateRemoteHeaders(result['headers'])) return false;
+    if (result['error'] !== undefined && !isStringWithin(result['error'], 240)) return false;
+  }
+
+  return true;
+}
+
+export function validateSharePayload(data: unknown): SharePayload | null {
+  if (!isRecord(data)) return null;
+  const obj = data;
+
+  if (obj['v'] !== 1 && obj['v'] !== 2) return null;
+  if (obj['mode'] !== 'config' && obj['mode'] !== 'results') return null;
+  if (!Array.isArray(obj['endpoints'])) return null;
+  if ((obj['endpoints'] as unknown[]).length > 50) return null;
+
+  // mode:'results' without a results array is structurally invalid: the
+  // payload claims to carry a snapshot but doesn't.
+  if (obj['mode'] === 'results' && obj['results'] === undefined) return null;
+
+  for (const ep of obj['endpoints'] as unknown[]) {
+    if (!isRecord(ep)) return null;
+    if (!isSafeSharedUrl(ep['url'])) return null;
+    if (typeof ep['enabled'] !== 'boolean') return null;
+    for (const key of Object.keys(ep)) {
+      if (key !== 'url' && key !== 'enabled') return null;
+    }
+  }
+
+  const settings = obj['settings'];
+  if (!isRecord(settings)) return null;
+  if (!isNonNegativeFiniteNumber(settings['timeout']) || (settings['timeout'] as number) > 15000) return null;
+  if (!isNonNegativeFiniteNumber(settings['delay'])) return null;
+  if (!isNonNegativeFiniteNumber(settings['cap']) || (settings['cap'] as number) > MAX_CAP) return null;
+  if (settings['burstRounds'] !== undefined && (!isNonNegativeFiniteNumber(settings['burstRounds']) || (settings['burstRounds'] as number) > 500)) return null;
+  if (settings['monitorDelay'] !== undefined && (!isNonNegativeFiniteNumber(settings['monitorDelay']) || (settings['monitorDelay'] as number) > 60000)) return null;
+  if (settings['corsMode'] !== 'no-cors' && settings['corsMode'] !== 'cors') return null;
+
+  if (obj['report'] !== undefined && !validateReport(obj['report'], obj)) return null;
+  if (obj['remoteVantage'] !== undefined && !validateRemoteVantage(obj['remoteVantage'], obj)) return null;
+
+  for (const key of Object.keys(obj)) {
+    if (!ALLOWED_TOP_LEVEL.has(key)) return null;
+  }
+
+  if (obj['results'] !== undefined) {
+    if (!Array.isArray(obj['results'])) return null;
+    if ((obj['results'] as unknown[]).length > 50) return null;
+    for (const result of obj['results'] as unknown[]) {
+      if (!isRecord(result)) return null;
+      if (!Array.isArray(result['samples'])) return null;
+      if ((result['samples'] as unknown[]).length > 10_000) return null;
+      for (const sample of result['samples'] as unknown[]) {
+        if (!isRecord(sample)) return null;
+        if (
+          !isNonNegativeFiniteNumber(sample['round']) ||
+          !isNonNegativeFiniteNumber(sample['latency']) ||
+          (sample['status'] !== 'ok' && sample['status'] !== 'timeout' && sample['status'] !== 'error')
+        ) return null;
+      }
+    }
+  }
+
+  return data as unknown as SharePayload;
+}

--- a/src/lib/share/share-validator.ts
+++ b/src/lib/share/share-validator.ts
@@ -28,6 +28,8 @@ const ALLOWED_REMOTE_RESULT_KEYS = new Set([
   'error',
 ]);
 const ALLOWED_REMOTE_HEADERS = new Set(['content-type', 'server', 'cache-control', 'cf-cache-status']);
+const ALLOWED_RESULT_KEYS = new Set(['samples']);
+const MAX_DELAY_MS = 60_000;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -144,7 +146,7 @@ export function validateSharePayload(data: unknown): SharePayload | null {
   const settings = obj['settings'];
   if (!isRecord(settings)) return null;
   if (!isNonNegativeFiniteNumber(settings['timeout']) || (settings['timeout'] as number) > 15000) return null;
-  if (!isNonNegativeFiniteNumber(settings['delay'])) return null;
+  if (!isNonNegativeFiniteNumber(settings['delay']) || (settings['delay'] as number) > MAX_DELAY_MS) return null;
   if (!isNonNegativeFiniteNumber(settings['cap']) || (settings['cap'] as number) > MAX_CAP) return null;
   if (settings['burstRounds'] !== undefined && (!isNonNegativeFiniteNumber(settings['burstRounds']) || (settings['burstRounds'] as number) > 500)) return null;
   if (settings['monitorDelay'] !== undefined && (!isNonNegativeFiniteNumber(settings['monitorDelay']) || (settings['monitorDelay'] as number) > 60000)) return null;
@@ -162,6 +164,7 @@ export function validateSharePayload(data: unknown): SharePayload | null {
     if ((obj['results'] as unknown[]).length > 50) return null;
     for (const result of obj['results'] as unknown[]) {
       if (!isRecord(result)) return null;
+      if (!hasOnlyKeys(result, ALLOWED_RESULT_KEYS)) return null;
       if (!Array.isArray(result['samples'])) return null;
       if ((result['samples'] as unknown[]).length > 10_000) return null;
       for (const sample of result['samples'] as unknown[]) {

--- a/src/lib/stores/remote-vantage.ts
+++ b/src/lib/stores/remote-vantage.ts
@@ -1,0 +1,124 @@
+import { writable } from 'svelte/store';
+import {
+  endpointsToRemoteTargets,
+  remoteVantageClient,
+  type RemoteVantageClient,
+  type RemoteVantageHealth,
+} from '../remote-vantage/client';
+import type { HostedReportCreateResponse, RemoteVantageProbeResponse } from '../remote-vantage/types';
+import type { Endpoint, SharePayload } from '../types';
+
+export type RemoteVantageStatus = 'idle' | 'checking' | 'connected' | 'probing' | 'error';
+
+export interface RemoteVantageState {
+  readonly status: RemoteVantageStatus;
+  readonly health: RemoteVantageHealth | null;
+  readonly lastProbe: RemoteVantageProbeResponse | null;
+  readonly hostedReport: HostedReportCreateResponse | null;
+  readonly hostedReportFallback: 'hash' | null;
+  readonly error: string | null;
+}
+
+export interface RemoteVantageStore {
+  subscribe: ReturnType<typeof writable<RemoteVantageState>>['subscribe'];
+  checkHealth(): Promise<boolean>;
+  runProbe(endpoints: readonly Endpoint[]): Promise<RemoteVantageProbeResponse | null>;
+  createHostedReport(payload: SharePayload): Promise<string | null>;
+  setProbe(probe: RemoteVantageProbeResponse | null): void;
+  reset(): void;
+}
+
+const initialState: RemoteVantageState = {
+  status: 'idle',
+  health: null,
+  lastProbe: null,
+  hostedReport: null,
+  hostedReportFallback: null,
+  error: null,
+};
+
+function messageFrom(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function createRemoteVantageStore(client: RemoteVantageClient = remoteVantageClient): RemoteVantageStore {
+  const { subscribe, set, update } = writable<RemoteVantageState>(initialState);
+
+  async function checkHealth(): Promise<boolean> {
+    update((state) => ({ ...state, status: 'checking', error: null }));
+    try {
+      const health = await client.checkHealth();
+      update((state) => ({ ...state, status: 'connected', health, error: null }));
+      return true;
+    } catch (error) {
+      update((state) => ({ ...state, status: 'error', error: messageFrom(error) }));
+      return false;
+    }
+  }
+
+  async function runProbe(endpoints: readonly Endpoint[]): Promise<RemoteVantageProbeResponse | null> {
+    const targets = endpointsToRemoteTargets(endpoints);
+    if (targets.length === 0) {
+      update((state) => ({
+        ...state,
+        status: 'error',
+        error: 'Enable at least one endpoint before running a remote check.',
+      }));
+      return null;
+    }
+
+    update((state) => ({ ...state, status: 'probing', error: null }));
+    try {
+      const probe = await client.runProbe({ targets });
+      update((state) => ({ ...state, status: 'connected', lastProbe: probe, error: null }));
+      return probe;
+    } catch (error) {
+      update((state) => ({ ...state, status: 'error', error: messageFrom(error) }));
+      return null;
+    }
+  }
+
+  async function createHostedReport(payload: SharePayload): Promise<string | null> {
+    try {
+      const response = await client.createHostedReport(payload);
+      if (!response.ok) {
+        update((state) => ({
+          ...state,
+          hostedReport: response,
+          hostedReportFallback: response.fallback,
+          error: null,
+        }));
+        return null;
+      }
+      update((state) => ({
+        ...state,
+        hostedReport: response,
+        hostedReportFallback: null,
+        error: null,
+      }));
+      return response.url;
+    } catch (error) {
+      update((state) => ({ ...state, hostedReportFallback: 'hash', error: messageFrom(error) }));
+      return null;
+    }
+  }
+
+  function setProbe(probe: RemoteVantageProbeResponse | null): void {
+    update((state) => ({ ...state, lastProbe: probe }));
+  }
+
+  function reset(): void {
+    set(initialState);
+  }
+
+  return {
+    subscribe,
+    checkHealth,
+    runProbe,
+    createHostedReport,
+    setProbe,
+    reset,
+  };
+}
+
+export const remoteVantageStore = createRemoteVantageStore();

--- a/src/lib/stores/remote-vantage.ts
+++ b/src/lib/stores/remote-vantage.ts
@@ -79,11 +79,13 @@ export function createRemoteVantageStore(client: RemoteVantageClient = remoteVan
   }
 
   async function createHostedReport(payload: SharePayload): Promise<string | null> {
+    update((state) => ({ ...state, status: 'checking', error: null }));
     try {
       const response = await client.createHostedReport(payload);
       if (!response.ok) {
         update((state) => ({
           ...state,
+          status: 'connected',
           hostedReport: response,
           hostedReportFallback: response.fallback,
           error: null,
@@ -92,13 +94,19 @@ export function createRemoteVantageStore(client: RemoteVantageClient = remoteVan
       }
       update((state) => ({
         ...state,
+        status: 'connected',
         hostedReport: response,
         hostedReportFallback: null,
         error: null,
       }));
       return response.url;
     } catch (error) {
-      update((state) => ({ ...state, hostedReportFallback: 'hash', error: messageFrom(error) }));
+      update((state) => ({
+        ...state,
+        status: 'error',
+        hostedReportFallback: 'hash',
+        error: messageFrom(error),
+      }));
       return null;
     }
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -297,6 +297,36 @@ export interface SharedReportContext {
   readonly sourceVersion: 1 | 2;
 }
 
+export interface ShareRemoteVantageEdge {
+  readonly colo?: string;
+  readonly country?: string;
+  readonly city?: string;
+  readonly region?: string;
+  readonly timezone?: string;
+}
+
+export type ShareRemoteVantageVerdict = 'reachable' | 'slow' | 'http-error' | 'unreachable';
+
+export interface ShareRemoteVantageResult {
+  readonly endpointId: string;
+  readonly label: string;
+  readonly url: string;
+  readonly ok: boolean;
+  readonly status: number | null;
+  readonly statusText: string | null;
+  readonly durationMs: number;
+  readonly checkedAt: number;
+  readonly verdict: ShareRemoteVantageVerdict;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly error?: string;
+}
+
+export interface ShareRemoteVantageSnapshot {
+  readonly generatedAt: number;
+  readonly edge: ShareRemoteVantageEdge;
+  readonly results: readonly ShareRemoteVantageResult[];
+}
+
 export interface SharePayload {
   readonly v: 1 | 2;
   readonly mode: 'config' | 'results';
@@ -310,6 +340,7 @@ export interface SharePayload {
     readonly corsMode: 'no-cors' | 'cors';
   };
   readonly report?: ShareReportMetadata;
+  readonly remoteVantage?: ShareRemoteVantageSnapshot;
   readonly results?: readonly {
     readonly samples: readonly {
       readonly round: number;

--- a/tests/unit/remote-vantage/functions.test.ts
+++ b/tests/unit/remote-vantage/functions.test.ts
@@ -107,6 +107,22 @@ describe('Cloudflare remote vantage functions', () => {
     expect(fetcher).not.toHaveBeenCalled();
   });
 
+  it('rejects IPv4-mapped IPv6 private probe URLs before fetching', async () => {
+    const fetcher = vi.fn();
+    const request = new Request('https://chronoscope.dev/api/vantage/probe', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        targets: [{ id: 'ep-1', label: 'Router', url: 'http://[::ffff:127.0.0.1]/' }],
+      }),
+    });
+
+    const response = await handleRemoteProbe(request, { fetcher });
+
+    expect(response.status).toBe(400);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
   it('stores and retrieves hosted reports when KV is bound', async () => {
     const kv = new FakeKV();
     const createRequest = new Request('https://chronoscope.dev/api/reports', {
@@ -135,6 +151,22 @@ describe('Cloudflare remote vantage functions', () => {
     await expect(fetched.json()).resolves.toEqual({ ok: true, payload: sharePayload });
   });
 
+  it('returns a structured error when a hosted report is corrupted', async () => {
+    const kv = new FakeKV();
+    await kv.put('report:report_123', '{not json');
+
+    const fetched = await handleGetHostedReport(
+      new Request('https://chronoscope.dev/api/reports/report_123'),
+      { reports: kv, id: 'report_123' },
+    );
+
+    expect(fetched.status).toBe(500);
+    await expect(fetched.json()).resolves.toMatchObject({
+      ok: false,
+      error: 'Stored report is invalid.',
+    });
+  });
+
   it('tells the browser to fall back to hash links when report KV is absent', async () => {
     const response = await handleCreateHostedReport(
       new Request('https://chronoscope.dev/api/reports', {
@@ -160,6 +192,16 @@ describe('Cloudflare remote vantage functions', () => {
     expect(response.status).toBe(200);
     expect(response.headers.get('Content-Length')).toBe('1024');
     expect((await response.arrayBuffer()).byteLength).toBe(1024);
+  });
+
+  it('answers saturation CORS preflight requests', async () => {
+    const response = await handleSaturationRequest(
+      new Request('https://chronoscope.dev/api/vantage/saturation', { method: 'OPTIONS' }),
+      {},
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
   });
 
   it('generates saturation bytes when the optional R2 object size does not exactly match', async () => {

--- a/tests/unit/remote-vantage/functions.test.ts
+++ b/tests/unit/remote-vantage/functions.test.ts
@@ -1,0 +1,184 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  handleCreateHostedReport,
+  handleGetHostedReport,
+  handleRemoteProbe,
+  handleSaturationRequest,
+} from '../../../functions/_shared/remote-vantage';
+import type { SharePayload } from '../../../src/lib/types';
+
+class FakeKV {
+  private readonly values = new Map<string, string>();
+
+  async put(key: string, value: string): Promise<void> {
+    this.values.set(key, value);
+  }
+
+  async get(key: string): Promise<string | null> {
+    return this.values.get(key) ?? null;
+  }
+}
+
+const sharePayload: SharePayload = {
+  v: 2,
+  mode: 'results',
+  endpoints: [{ url: 'https://example.com', enabled: true }],
+  settings: {
+    timeout: 5000,
+    delay: 0,
+    burstRounds: 10,
+    monitorDelay: 1000,
+    cap: 100,
+    corsMode: 'no-cors',
+  },
+  report: {
+    createdAt: 1778352000000,
+    healthThreshold: 120,
+    corsMode: 'no-cors',
+    roundCount: 10,
+    totalSampleCount: 10,
+    keptSampleCount: 10,
+    truncated: false,
+  },
+  results: [{ samples: [{ round: 1, latency: 42, status: 'ok' }] }],
+};
+
+describe('Cloudflare remote vantage functions', () => {
+  it('probes public targets from the edge and returns bounded evidence', async () => {
+    const fetcher = vi.fn(async () => new Response('ok', {
+      status: 200,
+      headers: {
+        'content-type': 'text/plain',
+        server: 'origin',
+      },
+    }));
+    const request = new Request('https://chronoscope.dev/api/vantage/probe', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        targets: [{ id: 'ep-1', label: 'Origin', url: 'https://example.com/probe' }],
+      }),
+    });
+
+    const response = await handleRemoteProbe(request, {
+      cf: { colo: 'IAD', country: 'US', city: 'Ashburn' },
+      fetcher,
+      now: () => 1778352000000,
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(payload).toMatchObject({
+      ok: true,
+      edge: { colo: 'IAD', country: 'US', city: 'Ashburn' },
+      results: [{
+        endpointId: 'ep-1',
+        label: 'Origin',
+        url: 'https://example.com/probe',
+        ok: true,
+        status: 200,
+        verdict: 'reachable',
+      }],
+    });
+    expect(payload.results[0].headers).toEqual({
+      'content-type': 'text/plain',
+      server: 'origin',
+    });
+  });
+
+  it('rejects non-public probe URLs before fetching', async () => {
+    const fetcher = vi.fn();
+    const request = new Request('https://chronoscope.dev/api/vantage/probe', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        targets: [{ id: 'ep-1', label: 'Router', url: 'http://127.0.0.1:8080' }],
+      }),
+    });
+
+    const response = await handleRemoteProbe(request, { fetcher });
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toContain('public http(s)');
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it('stores and retrieves hosted reports when KV is bound', async () => {
+    const kv = new FakeKV();
+    const createRequest = new Request('https://chronoscope.dev/api/reports', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ payload: sharePayload }),
+    });
+
+    const created = await handleCreateHostedReport(createRequest, {
+      reports: kv,
+      idFactory: () => 'report_123',
+      now: () => 1778352000000,
+    });
+    const createdPayload = await created.json();
+    expect(created.status).toBe(201);
+    expect(createdPayload).toMatchObject({
+      ok: true,
+      id: 'report_123',
+      url: 'https://chronoscope.dev/r/report_123',
+    });
+
+    const fetched = await handleGetHostedReport(
+      new Request('https://chronoscope.dev/api/reports/report_123'),
+      { reports: kv, id: 'report_123' },
+    );
+    await expect(fetched.json()).resolves.toEqual({ ok: true, payload: sharePayload });
+  });
+
+  it('tells the browser to fall back to hash links when report KV is absent', async () => {
+    const response = await handleCreateHostedReport(
+      new Request('https://chronoscope.dev/api/reports', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ payload: sharePayload }),
+      }),
+      {},
+    );
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      fallback: 'hash',
+    });
+    expect(response.status).toBe(503);
+  });
+
+  it('serves a bounded saturation stream for bufferbloat checks', async () => {
+    const response = await handleSaturationRequest(
+      new Request('https://chronoscope.dev/api/vantage/saturation?bytes=1024'),
+      {},
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Length')).toBe('1024');
+    expect((await response.arrayBuffer()).byteLength).toBe(1024);
+  });
+
+  it('generates saturation bytes when the optional R2 object size does not exactly match', async () => {
+    const largerObject = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(2048));
+        controller.close();
+      },
+    });
+    const response = await handleSaturationRequest(
+      new Request('https://chronoscope.dev/api/vantage/saturation?bytes=1024'),
+      {
+        bucket: {
+          get: vi.fn(async () => ({ body: largerObject, size: 2048 })),
+        },
+      },
+    );
+
+    expect(response.headers.get('Content-Length')).toBe('1024');
+    expect((await response.arrayBuffer()).byteLength).toBe(1024);
+  });
+});

--- a/tests/unit/remote-vantage/functions.test.ts
+++ b/tests/unit/remote-vantage/functions.test.ts
@@ -12,12 +12,13 @@ import type { SharePayload } from '../../../src/lib/types';
 class FakeKV {
   private readonly values = new Map<string, string>();
 
-  async put(key: string, value: string): Promise<void> {
+  put(key: string, value: string): Promise<void> {
     this.values.set(key, value);
+    return Promise.resolve();
   }
 
-  async get(key: string): Promise<string | null> {
-    return this.values.get(key) ?? null;
+  get(key: string): Promise<string | null> {
+    return Promise.resolve(this.values.get(key) ?? null);
   }
 }
 
@@ -47,13 +48,13 @@ const sharePayload: SharePayload = {
 
 describe('Cloudflare remote vantage functions', () => {
   it('probes public targets from the edge and returns bounded evidence', async () => {
-    const fetcher = vi.fn(async () => new Response('ok', {
+    const fetcher = vi.fn(() => Promise.resolve(new Response('ok', {
       status: 200,
       headers: {
         'content-type': 'text/plain',
         server: 'origin',
       },
-    }));
+    })));
     const request = new Request('https://chronoscope.dev/api/vantage/probe', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -215,7 +216,7 @@ describe('Cloudflare remote vantage functions', () => {
       new Request('https://chronoscope.dev/api/vantage/saturation?bytes=1024'),
       {
         bucket: {
-          get: vi.fn(async () => ({ body: largerObject, size: 2048 })),
+          get: vi.fn(() => Promise.resolve({ body: largerObject, size: 2048 })),
         },
       },
     );

--- a/tests/unit/remote-vantage/insight.test.ts
+++ b/tests/unit/remote-vantage/insight.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { buildRemoteVantageInsight } from '../../../src/lib/remote-vantage/insight';
+import type { Endpoint, EndpointStatistics } from '../../../src/lib/types';
+import type { RemoteVantageProbeResponse } from '../../../src/lib/remote-vantage/types';
+
+const endpoint: Endpoint = {
+  id: 'ep-1',
+  label: 'API',
+  url: 'https://api.example.com',
+  enabled: true,
+  color: '#67e8f9',
+};
+
+const slowStats: EndpointStatistics = {
+  endpointId: 'ep-1',
+  sampleCount: 30,
+  p50: 280,
+  p95: 340,
+  p99: 390,
+  p25: 260,
+  p75: 300,
+  p90: 320,
+  min: 220,
+  max: 420,
+  stddev: 24,
+  ci95: { lower: 270, upper: 290, margin: 10 },
+  connectionReuseDelta: null,
+  lossPercent: 0,
+  ready: true,
+};
+
+function remote(overrides: Partial<RemoteVantageProbeResponse['results'][number]>): RemoteVantageProbeResponse {
+  return {
+    ok: true,
+    generatedAt: 1778352000000,
+    edge: {
+      colo: 'IAD',
+      country: 'US',
+      city: 'Ashburn',
+      region: 'Virginia',
+    },
+    results: [{
+      endpointId: 'ep-1',
+      label: 'API',
+      url: 'https://api.example.com',
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      durationMs: 48,
+      checkedAt: 1778352000000,
+      verdict: 'reachable',
+      headers: {},
+      ...overrides,
+    }],
+  };
+}
+
+describe('buildRemoteVantageInsight', () => {
+  it('calls out local-path suspicion when the browser is slow but Cloudflare is fast', () => {
+    const insight = buildRemoteVantageInsight({
+      endpoint,
+      stats: slowStats,
+      threshold: 120,
+      probe: remote({ durationMs: 48, verdict: 'reachable' }),
+    });
+
+    expect(insight.status).toBe('local-path');
+    expect(insight.headline).toContain('Cloudflare reaches API normally');
+    expect(insight.detail).toContain('browser path');
+  });
+
+  it('calls out shared outside trouble when both local and remote vantage are slow', () => {
+    const insight = buildRemoteVantageInsight({
+      endpoint,
+      stats: slowStats,
+      threshold: 120,
+      probe: remote({ durationMs: 410, verdict: 'slow' }),
+    });
+
+    expect(insight.status).toBe('remote-confirms');
+    expect(insight.headline).toContain('also slow from Cloudflare');
+  });
+
+  it('returns a setup state before a remote probe exists', () => {
+    const insight = buildRemoteVantageInsight({
+      endpoint,
+      stats: slowStats,
+      threshold: 120,
+      probe: null,
+    });
+
+    expect(insight.status).toBe('unavailable');
+    expect(insight.action).toContain('Run a remote check');
+  });
+});

--- a/tests/unit/remote-vantage/insight.test.ts
+++ b/tests/unit/remote-vantage/insight.test.ts
@@ -81,6 +81,18 @@ describe('buildRemoteVantageInsight', () => {
     expect(insight.headline).toContain('also slow from Cloudflare');
   });
 
+  it('does not call the outside vantage healthy when only the remote side is slow', () => {
+    const insight = buildRemoteVantageInsight({
+      endpoint,
+      stats: { ...slowStats, p50: 80 },
+      threshold: 120,
+      probe: remote({ durationMs: 410, verdict: 'slow' }),
+    });
+
+    expect(insight.status).toBe('remote-slow-only');
+    expect(insight.detail).toContain('outside edge path');
+  });
+
   it('returns a setup state before a remote probe exists', () => {
     const insight = buildRemoteVantageInsight({
       endpoint,

--- a/tests/unit/share/hosted-report-router.test.ts
+++ b/tests/unit/share/hosted-report-router.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { initHostedReportRouter } from '../../../src/lib/share/hash-router';
+import { endpointStore } from '../../../src/lib/stores/endpoints';
+import { measurementStore } from '../../../src/lib/stores/measurements';
+import { remoteVantageStore } from '../../../src/lib/stores/remote-vantage';
+import { settingsStore } from '../../../src/lib/stores/settings';
+import { uiStore } from '../../../src/lib/stores/ui';
+import type { SharePayload } from '../../../src/lib/types';
+
+function hostedPayload(): SharePayload {
+  return {
+    v: 2,
+    mode: 'results',
+    endpoints: [{ url: 'https://edge.example.com', enabled: true }],
+    settings: {
+      timeout: 5000,
+      delay: 0,
+      burstRounds: 10,
+      monitorDelay: 1000,
+      cap: 100,
+      corsMode: 'no-cors',
+    },
+    report: {
+      createdAt: 1778352000000,
+      healthThreshold: 120,
+      corsMode: 'no-cors',
+      roundCount: 1,
+      totalSampleCount: 1,
+      keptSampleCount: 1,
+      truncated: false,
+    },
+    remoteVantage: {
+      generatedAt: 1778352000500,
+      edge: { colo: 'IAD', country: 'US', city: 'Ashburn' },
+      results: [{
+        endpointId: 'shared-ep-0',
+        label: 'Edge',
+        url: 'https://edge.example.com',
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        durationMs: 37,
+        checkedAt: 1778352000500,
+        verdict: 'reachable',
+        headers: { 'content-type': 'text/plain' },
+      }],
+    },
+    results: [{ samples: [{ round: 1, latency: 42, status: 'ok' }] }],
+  };
+}
+
+beforeEach(() => {
+  endpointStore.setEndpoints([]);
+  measurementStore.reset();
+  remoteVantageStore.reset();
+  settingsStore.reset();
+  uiStore.reset();
+  history.replaceState(null, '', '/');
+});
+
+describe('initHostedReportRouter', () => {
+  it('loads /r/:id reports from the Cloudflare report API', async () => {
+    history.replaceState(null, '', '/r/report_123');
+    const fetcher = vi.fn(async () => new Response(JSON.stringify({
+      ok: true,
+      payload: hostedPayload(),
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    await expect(initHostedReportRouter(fetcher)).resolves.toBe('results');
+
+    expect(fetcher).toHaveBeenCalledWith('/api/reports/report_123', { method: 'GET' });
+    expect(get(endpointStore).map((endpoint) => endpoint.url)).toEqual(['https://edge.example.com']);
+    expect(get(uiStore).sharedReportMode).toBe(true);
+    expect(get(measurementStore).roundCounter).toBe(1);
+    expect(get(remoteVantageStore).lastProbe).toMatchObject({
+      ok: true,
+      edge: { colo: 'IAD', country: 'US', city: 'Ashburn' },
+      results: [{ url: 'https://edge.example.com', durationMs: 37 }],
+    });
+    expect(window.location.pathname).toBe('/');
+  });
+
+  it('does nothing for normal app paths', async () => {
+    history.replaceState(null, '', '/');
+    const fetcher = vi.fn();
+
+    await expect(initHostedReportRouter(fetcher)).resolves.toBeNull();
+
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/share/hosted-report-router.test.ts
+++ b/tests/unit/share/hosted-report-router.test.ts
@@ -62,13 +62,13 @@ beforeEach(() => {
 describe('initHostedReportRouter', () => {
   it('loads /r/:id reports from the Cloudflare report API', async () => {
     history.replaceState(null, '', '/r/report_123');
-    const fetcher = vi.fn(async () => new Response(JSON.stringify({
+    const fetcher = vi.fn(() => Promise.resolve(new Response(JSON.stringify({
       ok: true,
       payload: hostedPayload(),
     }), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
-    }));
+    })));
 
     await expect(initHostedReportRouter(fetcher)).resolves.toBe('results');
 

--- a/tests/unit/share/share-payload-builder-remote.test.ts
+++ b/tests/unit/share/share-payload-builder-remote.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { buildResultsSharePayload } from '../../../src/lib/share/share-payload-builder';
+import type { Endpoint, MeasurementState, Settings } from '../../../src/lib/types';
+import type { RemoteVantageProbeResponse } from '../../../src/lib/remote-vantage/types';
+
+const endpoint: Endpoint = {
+  id: 'ep-1',
+  label: 'API',
+  url: 'https://api.example.com',
+  enabled: true,
+  color: '#67e8f9',
+};
+
+const settings: Settings = {
+  timeout: 5000,
+  delay: 0,
+  burstRounds: 10,
+  monitorDelay: 1000,
+  cap: 100,
+  corsMode: 'no-cors',
+  healthThreshold: 120,
+};
+
+const measurements = {
+  lifecycle: 'completed',
+  epoch: 1,
+  roundCounter: 1,
+  endpoints: {
+    'ep-1': {
+      endpointId: 'ep-1',
+      samples: [{ round: 1, latency: 80, status: 'ok', timestamp: 1778352000000 }],
+      lastLatency: 80,
+      lastStatus: 'ok',
+      lastErrorMessage: null,
+      tierLevel: 1,
+    },
+  },
+  startedAt: 1778351999000,
+  stoppedAt: 1778352001000,
+  freezeEvents: [],
+  errorCount: 0,
+  timeoutCount: 0,
+} as unknown as MeasurementState;
+
+const remoteProbe: RemoteVantageProbeResponse = {
+  ok: true,
+  generatedAt: 1778352000500,
+  edge: { colo: 'IAD', country: 'US' },
+  results: [{
+    endpointId: 'ep-1',
+    label: 'API',
+    url: 'https://api.example.com',
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    durationMs: 41,
+    checkedAt: 1778352000500,
+    verdict: 'reachable',
+    headers: { 'content-type': 'text/plain' },
+  }],
+};
+
+describe('buildResultsSharePayload remote vantage snapshot', () => {
+  it('embeds outside-vantage evidence without the transport-only ok flag', () => {
+    const built = buildResultsSharePayload(
+      [endpoint],
+      settings,
+      measurements,
+      8000,
+      1778352000000,
+      {},
+      remoteProbe,
+    );
+
+    expect(built.payload.remoteVantage).toMatchObject({
+      generatedAt: 1778352000500,
+      edge: { colo: 'IAD', country: 'US' },
+      results: [{ endpointId: 'ep-1', durationMs: 41, verdict: 'reachable' }],
+    });
+    expect('ok' in (built.payload.remoteVantage as Record<string, unknown>)).toBe(false);
+  });
+});

--- a/tests/unit/share/share-payload-rejects-unknown-keys.test.ts
+++ b/tests/unit/share/share-payload-rejects-unknown-keys.test.ts
@@ -86,6 +86,34 @@ describe('validateSharePayload: top-level unknown key rejection', () => {
     expect(decodeSharePayload(encoded)).toBeNull();
   });
 
+  it('rejects unbounded delay values', () => {
+    const payload = {
+      v: 1,
+      mode: 'config',
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 60001, cap: MAX_CAP, corsMode: 'no-cors' as const },
+    };
+    const encoded = encodeSharePayload(payload as never);
+    expect(decodeSharePayload(encoded)).toBeNull();
+  });
+
+  it('rejects unknown result object keys', () => {
+    const payload = {
+      v: 1,
+      mode: 'results',
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'no-cors' as const },
+      results: [
+        {
+          samples: [{ round: 0, latency: 42, status: 'ok' as const }],
+          extra: 'injected',
+        },
+      ],
+    };
+    const encoded = encodeSharePayload(payload as never);
+    expect(decodeSharePayload(encoded)).toBeNull();
+  });
+
   it('accepts { v, mode, endpoints, settings } (config mode baseline)', () => {
     const payload: SharePayload = {
       v: 1,

--- a/tests/unit/share/share-payload-rejects-unknown-keys.test.ts
+++ b/tests/unit/share/share-payload-rejects-unknown-keys.test.ts
@@ -4,7 +4,7 @@
 // harvesting, prototype-pollution surface, future round-trip footgun) at both
 // the top level and per-entry level. The validator must reject any payload
 // that contains keys outside the declared allowlists:
-//   - Top-level:  { v, mode, endpoints, settings, results }
+//   - Top-level:  { v, mode, endpoints, settings, results, report, remoteVantage }
 //   - Per-entry:  { url, enabled }
 //
 // Uses the encodeSharePayload / decodeSharePayload round-trip so the full
@@ -111,6 +111,81 @@ describe('validateSharePayload: top-level unknown key rejection', () => {
     };
     const encoded = encodeSharePayload(payload);
     expect(decodeSharePayload(encoded)).not.toBeNull();
+  });
+
+  it('accepts a bounded remoteVantage snapshot in v2 results mode', () => {
+    const payload: SharePayload = {
+      v: 2,
+      mode: 'results',
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'no-cors' },
+      report: {
+        createdAt: 1778352000000,
+        healthThreshold: 120,
+        corsMode: 'no-cors',
+        roundCount: 1,
+        totalSampleCount: 1,
+        keptSampleCount: 1,
+        truncated: false,
+      },
+      remoteVantage: {
+        generatedAt: 1778352000500,
+        edge: { colo: 'IAD', country: 'US' },
+        results: [{
+          endpointId: 'ep-1',
+          label: 'Example',
+          url: 'https://example.com',
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          durationMs: 42,
+          checkedAt: 1778352000500,
+          verdict: 'reachable',
+          headers: { 'content-type': 'text/html' },
+        }],
+      },
+      results: [{ samples: [{ round: 0, latency: 42, status: 'ok' }] }],
+    };
+    const encoded = encodeSharePayload(payload);
+    expect(decodeSharePayload(encoded)).not.toBeNull();
+  });
+
+  it('rejects unknown remoteVantage nested keys', () => {
+    const payload = {
+      v: 2,
+      mode: 'results',
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'no-cors' as const },
+      report: {
+        createdAt: 1778352000000,
+        healthThreshold: 120,
+        corsMode: 'no-cors' as const,
+        roundCount: 1,
+        totalSampleCount: 1,
+        keptSampleCount: 1,
+        truncated: false,
+      },
+      remoteVantage: {
+        generatedAt: 1778352000500,
+        edge: { colo: 'IAD' },
+        injected: true,
+        results: [{
+          endpointId: 'ep-1',
+          label: 'Example',
+          url: 'https://example.com',
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          durationMs: 42,
+          checkedAt: 1778352000500,
+          verdict: 'reachable' as const,
+          headers: {},
+        }],
+      },
+      results: [{ samples: [{ round: 0, latency: 42, status: 'ok' as const }] }],
+    };
+    const encoded = encodeSharePayload(payload as never);
+    expect(decodeSharePayload(encoded)).toBeNull();
   });
 });
 

--- a/tests/unit/stores/remote-vantage.test.ts
+++ b/tests/unit/stores/remote-vantage.test.ts
@@ -25,7 +25,7 @@ describe('remoteVantageStore', () => {
   it('runs remote probes only for enabled endpoints and stores edge evidence', async () => {
     const client: RemoteVantageClient = {
       checkHealth: vi.fn(),
-      runProbe: vi.fn(async () => ({
+      runProbe: vi.fn(() => Promise.resolve({
         ok: true,
         generatedAt: 1778352000000,
         edge: { colo: 'IAD', country: 'US' },
@@ -64,7 +64,7 @@ describe('remoteVantageStore', () => {
     const client: RemoteVantageClient = {
       checkHealth: vi.fn(),
       runProbe: vi.fn(),
-      createHostedReport: vi.fn(async () => ({
+      createHostedReport: vi.fn(() => Promise.resolve({
         ok: false,
         fallback: 'hash',
         error: 'Report persistence is not configured.',

--- a/tests/unit/stores/remote-vantage.test.ts
+++ b/tests/unit/stores/remote-vantage.test.ts
@@ -1,0 +1,84 @@
+import { get } from 'svelte/store';
+import { describe, expect, it, vi } from 'vitest';
+import { createRemoteVantageStore } from '../../../src/lib/stores/remote-vantage';
+import type { RemoteVantageClient } from '../../../src/lib/remote-vantage/client';
+import type { Endpoint } from '../../../src/lib/types';
+
+const endpoints: Endpoint[] = [
+  {
+    id: 'ep-1',
+    label: 'API',
+    url: 'https://api.example.com',
+    enabled: true,
+    color: '#67e8f9',
+  },
+  {
+    id: 'ep-2',
+    label: 'Disabled',
+    url: 'https://disabled.example.com',
+    enabled: false,
+    color: '#f9a8d4',
+  },
+];
+
+describe('remoteVantageStore', () => {
+  it('runs remote probes only for enabled endpoints and stores edge evidence', async () => {
+    const client: RemoteVantageClient = {
+      checkHealth: vi.fn(),
+      runProbe: vi.fn(async () => ({
+        ok: true,
+        generatedAt: 1778352000000,
+        edge: { colo: 'IAD', country: 'US' },
+        results: [{
+          endpointId: 'ep-1',
+          label: 'API',
+          url: 'https://api.example.com',
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          durationMs: 44,
+          checkedAt: 1778352000000,
+          verdict: 'reachable',
+          headers: {},
+        }],
+      })),
+      createHostedReport: vi.fn(),
+      loadHostedReport: vi.fn(),
+    };
+    const store = createRemoteVantageStore(client);
+
+    await store.runProbe(endpoints);
+
+    expect(client.runProbe).toHaveBeenCalledWith({
+      targets: [{ id: 'ep-1', label: 'API', url: 'https://api.example.com' }],
+    });
+    expect(get(store)).toMatchObject({
+      status: 'connected',
+      lastProbe: {
+        edge: { colo: 'IAD', country: 'US' },
+      },
+    });
+  });
+
+  it('falls back to hash sharing when hosted report persistence is unavailable', async () => {
+    const client: RemoteVantageClient = {
+      checkHealth: vi.fn(),
+      runProbe: vi.fn(),
+      createHostedReport: vi.fn(async () => ({
+        ok: false,
+        fallback: 'hash',
+        error: 'Report persistence is not configured.',
+      })),
+      loadHostedReport: vi.fn(),
+    };
+    const store = createRemoteVantageStore(client);
+
+    await expect(store.createHostedReport({ v: 1, mode: 'config', endpoints: [], settings: {
+      timeout: 5000,
+      delay: 0,
+      cap: 10,
+      corsMode: 'no-cors',
+    } })).resolves.toBeNull();
+    expect(get(store).hostedReportFallback).toBe('hash');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds Cloudflare Pages Functions for remote edge probes, hosted report storage, health, and saturation downloads.
- Adds browser remote-vantage client/store logic and fuses remote evidence into Diagnose and Report views.
- Preserves bounded remote-vantage evidence in shared results and supports KV-backed `/r/:id` report permalinks.

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build
- npm run test:visual
- Browser smoke: mocked Cloudflare probe renders in Diagnose
- Browser smoke: mocked `/r/:id` hosted report restores remote evidence

## Deployment Notes
- Requires `CHRONOSCOPE_REPORTS` KV binding for hosted reports.
- Optional `CHRONOSCOPE_SATURATION` R2 binding can serve exact-size saturation objects; otherwise the function generates bounded bytes.
