### PR TITLE
[codex] Fix remote vantage edge fetch binding

### DIFF
--- a/functions/_shared/remote-vantage.ts
+++ b/functions/_shared/remote-vantage.ts
@@ -264,7 +264,7 @@ export async function handleRemoteProbe(request: Request, options: RemoteProbeOp
   try {
     const body = await parseBody(request);
     const parsed: RemoteVantageProbeRequest = { targets: parseTargets(body) };
-    const fetcher = options.fetcher ?? fetch;
+    const fetcher = options.fetcher ?? globalThis.fetch.bind(globalThis);
     const now = options.now ?? Date.now;
     const results = await Promise.all(parsed.targets.map((target) => probeTarget(target, { fetcher, now })));
     const payload: RemoteVantageProbeResponse = {

--- a/tests/unit/remote-vantage/functions.test.ts
+++ b/tests/unit/remote-vantage/functions.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   handleCreateHostedReport,
   handleGetHostedReport,
@@ -47,6 +47,10 @@ const sharePayload: SharePayload = {
 };
 
 describe('Cloudflare remote vantage functions', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('probes public targets from the edge and returns bounded evidence', async () => {
     const fetcher = vi.fn(() => Promise.resolve(new Response('ok', {
       status: 200,
@@ -87,6 +91,33 @@ describe('Cloudflare remote vantage functions', () => {
     expect(payload.results[0].headers).toEqual({
       'content-type': 'text/plain',
       server: 'origin',
+    });
+  });
+
+  it('preserves the global fetch receiver when no fetcher is injected', async () => {
+    const fetcher = vi.fn(function fetchWithRequiredReceiver(this: unknown) {
+      if (this !== globalThis) {
+        throw new TypeError('Illegal invocation');
+      }
+      return Promise.resolve(new Response('ok', { status: 200 }));
+    });
+    vi.stubGlobal('fetch', fetcher);
+    const request = new Request('https://chronoscope.dev/api/vantage/probe', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        targets: [{ id: 'ep-1', label: 'Origin', url: 'https://example.com/probe' }],
+      }),
+    });
+
+    const response = await handleRemoteProbe(request, { now: () => 1778352000000 });
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.results[0]).toMatchObject({
+      ok: true,
+      status: 200,
+      verdict: 'reachable',
     });
   });
 


### PR DESCRIPTION
## Summary
- bind Cloudflare Pages' global `fetch` before passing it through the remote-vantage probe pipeline
- add a regression test that fails when `fetch` is called with the wrong receiver

## Verification
- npm test -- tests/unit/remote-vantage/functions.test.ts
- npm run typecheck
- npm run lint
- npm test
- npm run build

## Notes
A live smoke test against the deployed #95 build reproduced Cloudflare's `Illegal invocation` error from `/api/vantage/probe`. The fix keeps injected test fetchers unchanged while binding the default edge fetch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved HTTP fetch handling in remote vantage functionality to ensure proper context binding in all environments.

* **Tests**
  * Enhanced test coverage for remote vantage functionality with improved global mocking cleanup.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xaedyn/chronoscope/pull/96)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->