### PR TITLE
[codex] Keep cockpit views within viewport

### DIFF
--- a/src/lib/components/CausalVerdictStrip.svelte
+++ b/src/lib/components/CausalVerdictStrip.svelte
@@ -450,4 +450,38 @@
       padding: 6px 10px;
     }
   }
+
+  @media (max-height: 900px) and (min-width: 768px) {
+    .verdict.hero {
+      padding: 12px 18px;
+      gap: 10px 18px;
+    }
+    .verdict.hero .verdict-extra {
+      display: none;
+    }
+    .verdict.hero .verdict-metrics {
+      padding-top: 8px;
+    }
+  }
+
+  @media (max-width: 767px) and (max-height: 860px) {
+    .verdict.hero {
+      padding: 8px 10px;
+      gap: 6px;
+    }
+    .verdict.hero .verdict-headline {
+      font-size: var(--ts-lg);
+    }
+    .verdict.hero .verdict-explanation,
+    .verdict.hero .verdict-context {
+      display: none;
+    }
+    .verdict-metrics {
+      gap: 8px 12px;
+      padding-top: 4px;
+    }
+    .verdict-metric-num {
+      font-size: var(--ts-md);
+    }
+  }
 </style>

--- a/src/lib/components/ChronographDial.svelte
+++ b/src/lib/components/ChronographDial.svelte
@@ -779,4 +779,18 @@
   @media (max-width: 375px) {
     .dial { max-width: min(300px, 86vw); }
   }
+  @media (max-width: 767px) and (max-height: 860px) {
+    .dial-wrap { padding: 4px 0; }
+    .dial { max-width: min(300px, 82vw); }
+  }
+  @media (max-width: 375px) and (max-height: 860px) {
+    .dial { max-width: min(280px, 80vw); }
+  }
+  @media (max-width: 767px) and (max-height: 760px) {
+    .dial-wrap { padding: 2px 0; }
+    .dial { max-width: min(270px, 78vw); }
+  }
+  @media (max-width: 375px) and (max-height: 760px) {
+    .dial { max-width: min(260px, 76vw); }
+  }
 </style>

--- a/src/lib/components/OverviewView.svelte
+++ b/src/lib/components/OverviewView.svelte
@@ -335,7 +335,11 @@
           {p99Across}
         />
       </div>
-      <div class="overview-right" data-subtab={$uiStore.overviewSubtab}>
+      <div
+        class="overview-right"
+        data-has-events={events.length > 0 ? 'true' : 'false'}
+        data-subtab={$uiStore.overviewSubtab}
+      >
         <div class="overview-subtab-strip">
           <OverviewSubtabStrip
             selected={$uiStore.overviewSubtab}
@@ -379,6 +383,7 @@
 <style>
   .overview {
     flex: 1;
+    height: 100%;
     display: flex;
     flex-direction: column;
     padding: 12px 24px 16px;
@@ -393,7 +398,9 @@
     display: flex;
     flex-direction: column;
     gap: 14px;
+    height: 100%;
     min-height: 0;
+    overflow: hidden;
   }
 
   /* Verdict-first Status: answer on top, live dial as the left instrument,
@@ -403,11 +410,13 @@
      centered 1440 box. */
   .overview-grid {
     width: 100%;
+    flex: 1 1 auto;
     display: grid;
     grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
     gap: 20px;
     align-items: start;
     min-height: 0;
+    overflow: hidden;
   }
   /* container-type lets the dial size against this column's actual width via
      `cqi`, so it grows with the column on wide viewports without having to
@@ -443,11 +452,25 @@
     .overview {
       padding: 8px 12px;
       overflow-x: hidden;
-      overflow-y: auto;
-      -webkit-overflow-scrolling: touch;
+      overflow-y: hidden;
     }
     .status-shell { gap: 10px; }
-    .overview-grid { grid-template-columns: 1fr; gap: 10px; }
+    .overview-grid { grid-template-columns: 1fr; gap: 10px; align-content: start; }
     .overview-left, .overview-right { gap: 8px; }
+  }
+
+  @media (max-height: 900px) and (min-width: 768px) {
+    .overview { padding-block: 10px; }
+    .status-shell { gap: 10px; }
+    .overview-grid { gap: 16px; align-items: center; }
+    .overview-right[data-has-events="false"] .card-slot--events { display: none; }
+  }
+
+  @media (max-width: 767px) and (max-height: 860px) {
+    .overview { padding-block: 6px; }
+    .status-shell,
+    .overview-grid,
+    .overview-left,
+    .overview-right { gap: 6px; }
   }
 </style>

--- a/src/lib/components/RacingStrip.svelte
+++ b/src/lib/components/RacingStrip.svelte
@@ -348,4 +348,19 @@
     .racing-track { height: 18px; }
     .racing-rows { gap: 1px; }
   }
+
+  @media (max-width: 767px) and (max-height: 860px) {
+    .racing { padding: 5px 8px; }
+    .racing-header { margin-bottom: 2px; }
+    .racing-title { font-size: var(--ts-md); }
+    .racing-axis { display: none; }
+    .racing-row {
+      min-height: 24px;
+      padding: 2px 5px;
+      gap: 6px;
+      grid-template-columns: 96px minmax(0, 1fr) max-content;
+    }
+    .racing-track { height: 16px; }
+    .racing-stats { gap: 4px; }
+  }
 </style>

--- a/tests/visual/overview-no-scroll.spec.ts
+++ b/tests/visual/overview-no-scroll.spec.ts
@@ -14,6 +14,8 @@ const VIEWPORTS = [
   { name: 'desktop-floor', width: 1366, height: 768 },
   { name: 'mobile-floor',  width: 360,  height: 780 },
   { name: 'mobile-390',    width: 390,  height: 844 },
+  { name: 'mobile-short',  width: 390,  height: 700 },
+  { name: 'iphone-se',     width: 375,  height: 667 },
   { name: 'desktop-1920',  width: 1920, height: 1080 },
   { name: 'desktop-2560',  width: 2560, height: 1440 },
 ] as const;
@@ -159,57 +161,52 @@ test.describe('Status — no scroll on first visit', () => {
     ).toEqual([]);
   });
 
-  test('status evidence remains reachable on short mobile viewports', async ({ page }) => {
+  test('status evidence stays visible without scrolling on short mobile viewports', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 667 });
     await page.goto('/');
     await page.waitForSelector('#chronoscope-root');
     await page.waitForTimeout(400);
 
+    const state = await scrollState(page);
+    expect(
+      state.docScrollH,
+      `document scrollHeight (${state.docScrollH}) > clientHeight (${state.docClientH})`,
+    ).toBeLessThanOrEqual(state.docClientH);
+    expect(
+      state.overflowingScrollers,
+      `internal scrollers with hidden content: ${JSON.stringify(state.overflowingScrollers, null, 2)}`,
+    ).toEqual([]);
+
     const reachability = await page.evaluate(() => {
       const overview = document.querySelector<HTMLElement>('.overview');
-      const shellMain = document.querySelector<HTMLElement>('main#main-content');
       const subtabStrip = document.querySelector<HTMLElement>('.overview-subtab-strip');
       const panel = document.querySelector<HTMLElement>('#overview-panel-racing');
       const docEl = document.documentElement;
-      if (!overview || !shellMain || !subtabStrip || !panel) {
+      if (!overview || !subtabStrip || !panel) {
         return {
           hasNodes: false,
-          hasScrollPath: false,
-          stripVisibleAfterScroll: false,
-          panelVisibleAfterScroll: false,
+          stripFullyVisible: false,
+          panelFullyVisible: false,
           horizontalOverflow: true,
         };
       }
 
-      const hasScrollablePath = (el: HTMLElement): boolean => {
-        const cs = getComputedStyle(el);
-        return (cs.overflowY === 'auto' || cs.overflowY === 'scroll') && el.scrollHeight > el.clientHeight;
-      };
-      const hasScrollPath = hasScrollablePath(overview) || hasScrollablePath(shellMain);
-      const scroller = hasScrollablePath(overview) ? overview : hasScrollablePath(shellMain) ? shellMain : null;
-      if (scroller) scroller.scrollTop = scroller.scrollHeight;
-
       const viewportH = window.innerHeight;
       const stripRect = subtabStrip.getBoundingClientRect();
       const panelRect = panel.getBoundingClientRect();
-      const visible = (rect: DOMRect): boolean => rect.top < viewportH && rect.bottom > 0;
+      const fullyVisible = (rect: DOMRect): boolean => rect.top >= 0 && rect.bottom <= viewportH;
 
       return {
         hasNodes: true,
-        hasScrollPath,
-        stripVisibleAfterScroll: visible(stripRect),
-        panelVisibleAfterScroll: visible(panelRect),
+        stripFullyVisible: fullyVisible(stripRect),
+        panelFullyVisible: fullyVisible(panelRect),
         horizontalOverflow: docEl.scrollWidth > docEl.clientWidth,
       };
     });
 
     expect(reachability.hasNodes).toBe(true);
     expect(reachability.horizontalOverflow, 'document should not overflow horizontally').toBe(false);
-    expect(
-      reachability.hasScrollPath,
-      'short mobile Status must expose a real vertical scroll path instead of clipping hidden evidence',
-    ).toBe(true);
-    expect(reachability.stripVisibleAfterScroll, 'Status subtab strip should be reachable after scrolling').toBe(true);
-    expect(reachability.panelVisibleAfterScroll, 'Status evidence panel should be reachable after scrolling').toBe(true);
+    expect(reachability.stripFullyVisible, 'Status subtab strip should fit in the first viewport').toBe(true);
+    expect(reachability.panelFullyVisible, 'Status evidence panel should fit in the first viewport').toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Makes Status behave like a fixed-height cockpit instead of clipping or requiring internal scrolling on phone-height viewports.
- Compacts low-priority Status details at constrained heights while preserving the verdict, dial, subtab control, and per-endpoint comparison.
- Updates the no-scroll visual spec to cover short mobile sizes and assert evidence stays visible in the first viewport.

## Validation
- npm run typecheck
- npm run lint
- npm run build
- npm run test:visual -- tests/visual/overview-no-scroll.spec.ts

## Notes
- Existing untracked screenshot files in the repo root were intentionally left out of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced responsive design for devices with limited viewport height and width. Components now intelligently adjust spacing, sizing, and element visibility to ensure critical interface elements remain accessible without scrolling.

* **Tests**
  * Visual tests expanded to verify proper layout behavior across additional mobile screen resolutions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xaedyn/chronoscope/pull/99)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->