### PR TITLE
[codex] Move CI actions to Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
     name: Type check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .node-version
           cache: npm
@@ -30,8 +30,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .node-version
           cache: npm
@@ -42,8 +42,8 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .node-version
           cache: npm
@@ -54,14 +54,14 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .node-version
           cache: npm
       - run: npm ci
       - run: npm run build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: dist
           path: dist/
@@ -76,15 +76,15 @@ jobs:
       contents: read
       deployments: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .node-version
           cache: npm
       - run: npm ci
       - run: npm run build
-      - uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist --project-name chronoscope
+      - name: Deploy to Cloudflare Pages
+        run: npx --yes wrangler@4.90.0 pages deploy dist --project-name chronoscope
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
- Upgrades official GitHub Actions wrappers to Node24-backed major versions: checkout/setup-node/upload-artifact v6.
- Removes the Cloudflare Wrangler action wrapper that still declares `runs.using: node20`.
- Uses a pinned Wrangler CLI command for Pages deploy so the deploy remains reproducible without adding Wrangler to every CI job dependency install.

## Validation
- npm run typecheck
- npm run lint
- npm run build
- npm test
- ruby YAML parse of .github/workflows/ci.yml
- git diff --check
- Confirmed no `@v4`, `node20`, or `cloudflare/wrangler-action` references remain in the workflow
- Confirmed `wrangler@4.90.0` resolves locally with install scripts suppressed

## Notes
- A direct local `npx wrangler@4.90.0 --version` on this Mac attempted to run `sharp` install scripts and failed native-package setup. The workflow runs the pinned CLI on Ubuntu during deploy, which is the environment that matters for this change.
- Existing untracked screenshot files were intentionally left out of this PR.