### PR TITLE
[codex] Clean up production CSP assets

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'none'; script-src 'self' https://static.cloudflareinsights.com; worker-src 'self' blob:; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; font-src https://fonts.gstatic.com; connect-src *; img-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'
+  Content-Security-Policy: default-src 'none'; script-src 'self'; script-src-elem 'self' 'unsafe-inline' https://static.cloudflareinsights.com; script-src-attr 'none'; worker-src 'self' blob:; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; font-src https://fonts.gstatic.com; connect-src *; img-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin

--- a/src/lib/components/SettingsDrawer.svelte
+++ b/src/lib/components/SettingsDrawer.svelte
@@ -909,8 +909,11 @@
     -webkit-appearance: none;
     cursor: pointer;
     padding-right: 28px;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='rgba(255,255,255,0.3)' stroke-width='1.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+    background-image:
+      linear-gradient(45deg, transparent 50%, rgba(255,255,255,.42) 50%),
+      linear-gradient(135deg, rgba(255,255,255,.42) 50%, transparent 50%);
     background-repeat: no-repeat;
-    background-position: right 8px center;
+    background-size: 6px 6px, 6px 6px;
+    background-position: right 14px center, right 8px center;
   }
 </style>

--- a/tests/unit/csp-assets.test.ts
+++ b/tests/unit/csp-assets.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { resolve } from 'path';
+
+const repoRoot = resolve(__dirname, '../..');
+
+function findSourceFilesContaining(dir: string, needle: string): string[] {
+  return readdirSync(dir).flatMap(entry => {
+    const path = resolve(dir, entry);
+    const stats = statSync(path);
+
+    if (stats.isDirectory()) return findSourceFilesContaining(path, needle);
+    if (!/\.(css|html|svelte|ts|js)$/.test(entry)) return [];
+    return readFileSync(path, 'utf-8').includes(needle) ? [path] : [];
+  });
+}
+
+describe('production CSP assets', () => {
+  const headers = readFileSync(resolve(repoRoot, 'public/_headers'), 'utf-8');
+
+  it('keeps data images out of application source', () => {
+    const offenders = findSourceFilesContaining(resolve(repoRoot, 'src'), 'data:image');
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('allows Cloudflare script elements while blocking inline event handlers', () => {
+    expect(headers).toContain("script-src-elem 'self' 'unsafe-inline' https://static.cloudflareinsights.com");
+    expect(headers).toContain("script-src-attr 'none'");
+  });
+
+  it('keeps image sources self-hosted only', () => {
+    expect(headers).toContain("img-src 'self'");
+    expect(headers).not.toContain('img-src data:');
+  });
+});


### PR DESCRIPTION
## Summary

- allow Cloudflare deployment script elements while keeping inline event handlers blocked

- remove the CSS data-URI select chevron so img-src can remain self-only
- add a CSP/static asset regression test


## Validation

- npm run test -- tests/unit/csp-assets.test.ts
- npm run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated Content Security Policy headers to refine script-source directives and restrictions.

* **Style**
  * Modified dropdown indicator styling in the settings menu using modern CSS techniques.

* **Tests**
  * Added comprehensive unit test suite validating Content Security Policy configuration and asset compliance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xaedyn/chronoscope/pull/101)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->