### PR TITLE
[codex] Clarify total-only diagnostic samples

### DIFF
--- a/src/lib/components/DiagnoseView.svelte
+++ b/src/lib/components/DiagnoseView.svelte
@@ -74,6 +74,7 @@
   const phaseTotal = $derived(
     phases === null ? 0 : phases.dns + phases.tcp + phases.tls + phases.ttfb + phases.transfer,
   );
+  const hasVisiblePhases = $derived(phases !== null && phaseTotal > 0);
   const hypothesis = $derived(phases === null ? null : phaseHypothesis(phases));
 
   // ── Segments with computed widths for the hero bar ───────────────────────
@@ -188,18 +189,21 @@
     return `${distroStats.n} focused samples with ${comparatorCount} comparison endpoints.`;
   });
 
-  interface SampleRow { round: number; total: number; segs: { phase: Tier2Phase; pctWidth: number; color: string; }[]; status: 'ok' | 'timeout' | 'error' | 'no-tier2'; }
+  interface SampleRow { round: number; total: number; segs: { phase: Tier2Phase; pctWidth: number; color: string; }[]; status: 'ok' | 'timeout' | 'error' | 'phase-unavailable'; }
   const sampleRows: readonly SampleRow[] = $derived.by(() => {
     return recentSamples.map((s) => {
       if (s.status !== 'ok') {
         return { round: s.round, total: s.latency ?? 0, segs: [], status: s.status };
       }
       const t2 = s.tier2;
-      if (!t2) {
-        return { round: s.round, total: s.latency, segs: [], status: 'no-tier2' as const };
+      if (!t2 || s.timingFallback) {
+        return { round: s.round, total: s.latency, segs: [], status: 'phase-unavailable' as const };
       }
       const total = t2.dnsLookup + t2.tcpConnect + t2.tlsHandshake + t2.ttfb + t2.contentTransfer;
-      const segs = total <= 0 ? [] : PHASE_ORDER.map((phase) => {
+      if (total <= 0) {
+        return { round: s.round, total: s.latency, segs: [], status: 'phase-unavailable' as const };
+      }
+      const segs = PHASE_ORDER.map((phase) => {
         const ms = phase === 'dns' ? t2.dnsLookup
                  : phase === 'tcp' ? t2.tcpConnect
                  : phase === 'tls' ? t2.tlsHandshake
@@ -226,7 +230,7 @@
 
   // ── Accessibility summary for the hero bar ────────────────────────────────
   const heroAria = $derived(
-    phases === null
+    phases === null || !hasVisiblePhases
       ? 'Request waterfall — no tier-2 data available.'
       : `Request waterfall for ${focusedEndpoint?.label ?? 'focused endpoint'} at ${mode.toUpperCase()}: ${segments.map((s) => `${PHASE_LABELS[s.phase]} ${Math.round(s.ms)} ms`).join(', ')}. Total ${Math.round(phaseTotal)} ms.`
   );
@@ -466,32 +470,42 @@
             onclick={() => handleSelectMode('p95')}
           >P95</button>
         </div>
-        <div class="diagnose-waterfall" role="img" aria-label={heroAria}>
-          <div class="diagnose-bar">
-            {#each segments as seg (seg.phase)}
-              <div
-                class="diagnose-bar-seg"
-                class:dominant={seg.dominant}
-                style:width="{seg.pctWidth}%"
-                style:background={seg.color}
-              >
-                {#if seg.pctWidth >= 8}
-                  <span class="diagnose-bar-label" style:color={tokens.color.tier2.labelText}>
-                    {seg.short} · {fmt(seg.ms)}<span class="diagnose-bar-ms">ms</span>
-                  </span>
-                {/if}
-              </div>
-            {/each}
+        {#if hasVisiblePhases}
+          <div class="diagnose-waterfall" role="img" aria-label={heroAria}>
+            <div class="diagnose-bar">
+              {#each segments as seg (seg.phase)}
+                <div
+                  class="diagnose-bar-seg"
+                  class:dominant={seg.dominant}
+                  style:width="{seg.pctWidth}%"
+                  style:background={seg.color}
+                >
+                  {#if seg.pctWidth >= 8}
+                    <span class="diagnose-bar-label" style:color={tokens.color.tier2.labelText}>
+                      {seg.short} · {fmt(seg.ms)}<span class="diagnose-bar-ms">ms</span>
+                    </span>
+                  {/if}
+                </div>
+              {/each}
+            </div>
+            <div class="diagnose-bar-scale">
+              {#each segments as seg (seg.phase)}
+                <span class="diagnose-bar-tick" style:flex="{seg.pctWidth}">
+                  <span class="diagnose-bar-tick-label">{seg.short}</span>
+                </span>
+              {/each}
+            </div>
           </div>
-          <div class="diagnose-bar-scale">
-            {#each segments as seg (seg.phase)}
-              <span class="diagnose-bar-tick" style:flex="{seg.pctWidth}">
-                <span class="diagnose-bar-tick-label">{seg.short}</span>
-              </span>
-            {/each}
+        {:else}
+          <div class="phase-unavailable-card" role="note" aria-label="Phase timing unavailable">
+            <p class="phase-unavailable-title">Phase timing unavailable</p>
+            <p class="phase-unavailable-detail">{timingVisibility.detail}</p>
+            {#if timingVisibility.action}
+              <p class="phase-unavailable-action">{timingVisibility.action}</p>
+            {/if}
           </div>
-        </div>
-        {#if hypothesis}
+        {/if}
+        {#if hypothesis && hasVisiblePhases}
           <ul class="diagnose-evidence">
             {#each segments as seg (seg.phase)}
               <li class="diagnose-evidence-row" class:dominant={seg.dominant}>
@@ -530,8 +544,8 @@
                       {#each row.segs as seg (seg.phase)}
                         <span class="diagnose-sample-seg" style:width="{seg.pctWidth}%" style:background={seg.color} aria-hidden="true"></span>
                       {/each}
-                    {:else if row.status === 'no-tier2'}
-                      <span class="diagnose-sample-neutral" aria-label="No tier-2 breakdown available"></span>
+                    {:else if row.status === 'phase-unavailable'}
+                      <span class="diagnose-sample-neutral diagnose-sample-total-only" aria-label="Phase timing unavailable">TOTAL ONLY</span>
                     {:else if row.status === 'timeout'}
                       <span class="diagnose-sample-timeout" aria-label="Timeout">TIMEOUT</span>
                     {:else}
@@ -954,6 +968,34 @@
     padding: 1px 4px;
     border-radius: 3px;
   }
+  .phase-unavailable-card {
+    border: 1px solid rgba(103, 232, 249, 0.16);
+    border-radius: 10px;
+    background: rgba(103, 232, 249, 0.055);
+    padding: 14px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .phase-unavailable-title {
+    margin: 0;
+    color: var(--t1);
+    font-family: var(--sans);
+    font-size: var(--ts-base);
+    font-weight: 500;
+  }
+  .phase-unavailable-detail,
+  .phase-unavailable-action {
+    margin: 0;
+    color: var(--t2);
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    line-height: 1.55;
+    letter-spacing: 0.01em;
+  }
+  .phase-unavailable-action {
+    color: var(--accent-cyan);
+  }
   .diagnose-title {
     margin: 0;
     font-size: var(--ts-2xl);
@@ -1196,6 +1238,15 @@
     display: block;
     width: 100%; height: 100%;
     background: var(--t5, rgba(255, 255, 255, 0.07));
+  }
+  .diagnose-sample-total-only {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--t2);
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-label);
   }
   .diagnose-sample-timeout {
     display: flex;

--- a/tests/unit/components/diagnose-view.test.ts
+++ b/tests/unit/components/diagnose-view.test.ts
@@ -5,6 +5,7 @@ import DiagnoseView from '../../../src/lib/components/DiagnoseView.svelte';
 import { endpointStore } from '../../../src/lib/stores/endpoints';
 import { measurementStore } from '../../../src/lib/stores/measurements';
 import { remoteVantageStore } from '../../../src/lib/stores/remote-vantage';
+import { settingsStore } from '../../../src/lib/stores/settings';
 import { resetStatisticsCache } from '../../../src/lib/stores/statistics';
 import { uiStore } from '../../../src/lib/stores/ui';
 import type { Endpoint, MeasurementSample, MeasurementState } from '../../../src/lib/types';
@@ -25,6 +26,24 @@ function samples(latency: number): MeasurementSample[] {
     latency,
     status: 'ok' as const,
     timestamp: index + 1,
+  }));
+}
+
+function opaqueFallbackSamples(latency: number): MeasurementSample[] {
+  return Array.from({ length: 12 }, (_, index) => ({
+    round: index + 1,
+    latency,
+    status: 'ok' as const,
+    timestamp: index + 1,
+    timingFallback: true,
+    tier2: {
+      total: latency,
+      dnsLookup: 0,
+      tcpConnect: 0,
+      tlsHandshake: 0,
+      ttfb: 0,
+      contentTransfer: 0,
+    },
   }));
 }
 
@@ -55,6 +74,33 @@ function seedReadySamples(latencies: Record<string, number>): void {
   } satisfies MeasurementState);
 }
 
+function seedSamplesByEndpoint(samplesByEndpoint: Record<string, MeasurementSample[]>): void {
+  const endpoints: Parameters<typeof measurementStore.loadSnapshot>[0]['endpoints'] = {};
+  for (const [endpointId, endpointSamples] of Object.entries(samplesByEndpoint)) {
+    const last = endpointSamples.at(-1);
+    endpoints[endpointId] = {
+      endpointId,
+      tierLevel: 1,
+      lastLatency: last?.latency ?? null,
+      lastStatus: last?.status ?? null,
+      lastErrorMessage: last?.errorMessage ?? null,
+      samples: endpointSamples,
+    };
+  }
+
+  measurementStore.loadSnapshot({
+    lifecycle: 'completed',
+    epoch: 1,
+    roundCounter: 12,
+    startedAt: null,
+    stoppedAt: null,
+    freezeEvents: [],
+    errorCount: 0,
+    timeoutCount: 0,
+    endpoints,
+  } satisfies MeasurementState);
+}
+
 describe('DiagnoseView investigation focus', () => {
   beforeEach(() => {
     cleanup();
@@ -62,6 +108,7 @@ describe('DiagnoseView investigation focus', () => {
     measurementStore.reset();
     resetStatisticsCache();
     remoteVantageStore.reset();
+    settingsStore.reset();
     uiStore.reset();
   });
 
@@ -114,5 +161,24 @@ describe('DiagnoseView investigation focus', () => {
 
     expect(getByText(/choosing the best endpoint to investigate/i)).toBeTruthy();
     expect(queryByText(/pick an endpoint from the left rail/i)).toBeNull();
+  });
+
+  it('labels opaque no-cors fallback samples as total-only instead of errors', async () => {
+    endpointStore.setEndpoints([endpoint('api', 'API')]);
+    seedSamplesByEndpoint({ api: opaqueFallbackSamples(80) });
+    settingsStore.update(current => ({ ...current, corsMode: 'no-cors' }));
+    uiStore.setActiveView('diagnose');
+    uiStore.setFocusedEndpoint('api');
+
+    const { getAllByText, getByText, queryByText } = render(DiagnoseView);
+
+    await waitFor(() => {
+      expect(get(uiStore).focusedEndpointId).toBe('api');
+    });
+
+    expect(queryByText('ERROR')).toBeNull();
+    expect(getByText(/phase timing unavailable/i)).toBeTruthy();
+    expect(getAllByText(/total only/i).length).toBeGreaterThan(0);
+    expect(getAllByText('80 ms').length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

- show total-only/opaque browser samples as TOTAL ONLY instead of ERROR
- keep the real fallback latency in the recent-sample table
- replace empty advanced phase waterfalls with clear Timing-Allow-Origin/no-cors guidance

## Validation
- npm run test -- tests/unit/components/diagnose-view.test.ts
- npm run test -- tests/unit/components/diagnose-view.test.ts tests/unit/utils/diagnostic-narrative.test.ts
- npm run lint
- npm run typecheck
- npm run build










