### PR TITLE
[codex] Fix status event feed contrast

### DIFF
--- a/src/lib/components/EventFeed.svelte
+++ b/src/lib/components/EventFeed.svelte
@@ -137,9 +137,8 @@
 
   .feed-rows { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 2px; }
   .feed-row {
-    /* Rank-based fade: row 0 full opacity, each older row a notch dimmer.
-       Matches v2 prototype .v2-feed-row. */
-    opacity: calc(1 - var(--rank, 0) * 0.14);
+    /* Keep rows fully opaque; recency is carried by size/weight so text stays AA. */
+    opacity: 1;
     transition: background 140ms ease, opacity 400ms ease;
     border-radius: 6px;
     /* Base type size inherited by every column. .latest bumps this one notch. */
@@ -188,7 +187,7 @@
     text-overflow: ellipsis;
   }
   .feed-action {
-    color: var(--t3);
+    color: var(--t2);
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
     overflow: hidden;

--- a/tests/visual/accessibility.spec.ts
+++ b/tests/visual/accessibility.spec.ts
@@ -62,6 +62,13 @@ async function injectSampleSpecs(page: Page, specs: readonly SampleSeedSpec[]): 
   }, specs);
 }
 
+async function bumpMeasurementRound(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const { measurementStore } = await import('/src/lib/stores/measurements.ts');
+    measurementStore.incrementRound();
+  });
+}
+
 async function seedVisibleSamples(page: Page): Promise<void> {
   const ids = await visibleEndpointIds(page);
   await injectSampleSpecs(page, ids.map((endpointId, index) => ({
@@ -70,6 +77,25 @@ async function seedVisibleSamples(page: Page): Promise<void> {
     latencyMs: 45 + index * 24,
     jitterMs: 4,
   })));
+}
+
+async function seedThresholdCrossingSamples(page: Page): Promise<void> {
+  const ids = await visibleEndpointIds(page);
+  await injectSampleSpecs(page, ids.map((endpointId, index) => ({
+    endpointId,
+    count: 4,
+    latencyMs: 40 + index * 5,
+    jitterMs: 2,
+  })));
+  await bumpMeasurementRound(page);
+  await page.waitForTimeout(100);
+  await injectSampleSpecs(page, ids.map((endpointId, index) => ({
+    endpointId,
+    count: 24,
+    latencyMs: 160 + index * 20,
+    jitterMs: 3,
+  })));
+  await bumpMeasurementRound(page);
 }
 
 test.describe('Accessibility', () => {
@@ -93,6 +119,22 @@ test.describe('Accessibility', () => {
 
     await page.getByRole('button', { name: /^Investigate/ }).click();
     await page.waitForSelector('section[aria-label="Investigate"]');
+    await expectNoAxeViolations(page);
+  });
+
+  test('no axe violations when recent threshold events are visible', async ({ page }) => {
+    test.skip((page.viewportSize()?.width ?? 0) < 700, 'Event feed contrast is covered in the desktop Status layout.');
+    await page.goto('/');
+    await page.waitForSelector('#chronoscope-root');
+    await seedThresholdCrossingSamples(page);
+
+    await expect(page.locator('.feed-row').first()).toBeVisible();
+    const opacities = await page.locator('.feed-row').evaluateAll((rows) => (
+      rows.map((row) => Number(getComputedStyle(row).opacity))
+    ));
+    for (const opacity of opacities) {
+      expect(opacity).toBeGreaterThanOrEqual(0.95);
+    }
     await expectNoAxeViolations(page);
   });
 


### PR DESCRIPTION
## Summary
- remove opacity-based dimming from recent event rows so older threshold events remain readable
- raise event action text to the accessible secondary text token
- add a visual accessibility regression for Status when threshold events are visible

## Validation
- npm run test:visual -- tests/visual/accessibility.spec.ts -g "threshold events"
- npm run test:visual -- tests/visual/accessibility.spec.ts
- npm run lint
- npm run typecheck
- npm run build

## Context
The final production audit found Status axe color-contrast failures on dimmed recent-event rows after real threshold crossings. This patch fixes the root cause and pins the state.