### PR TITLE
[codex] Fix mobile remote vantage clipping

### DIFF
--- a/src/lib/components/DiagnoseView.svelte
+++ b/src/lib/components/DiagnoseView.svelte
@@ -809,7 +809,7 @@
   .remote-evidence {
     margin: 0;
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: minmax(7.25rem, 1.2fr) minmax(4rem, 0.8fr) minmax(5rem, 1fr);
     gap: 10px;
   }
   .remote-evidence div {

--- a/tests/visual/accessibility.spec.ts
+++ b/tests/visual/accessibility.spec.ts
@@ -208,6 +208,28 @@ test.describe('Accessibility', () => {
     }
   });
 
+  test('remote vantage values fit on mobile without truncation', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/');
+    await page.waitForSelector('#chronoscope-root');
+    await seedVisibleSamples(page);
+
+    await page.getByRole('button', { name: /^Investigate/ }).click();
+    await page.waitForSelector('.remote-evidence dd');
+
+    const clippedValues = await page.locator('.remote-evidence dd').evaluateAll((elements) => {
+      return elements
+        .map((element) => ({
+          text: element.textContent?.trim(),
+          scrollWidth: element.scrollWidth,
+          clientWidth: element.clientWidth,
+        }))
+        .filter((element) => element.scrollWidth > element.clientWidth + 1);
+    });
+
+    expect(clippedValues).toEqual([]);
+  });
+
   test('skip link is keyboard-accessible', async ({ page }) => {
     await page.goto('/');
     await page.keyboard.press('Tab');


### PR DESCRIPTION
## Summary
- resize the Remote Vantage evidence columns so mobile keeps “Cloudflare edge” readable
- add a visual regression that checks remote evidence values do not truncate at the mobile viewport

## Verification
- npm run test:visual -- tests/visual/accessibility.spec.ts -g "remote vantage values"
- npm run test:visual -- tests/visual/accessibility.spec.ts
- npm run lint
- npm run typecheck
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text clipping issue in the Remote vantage evidence block on mobile devices by optimizing the layout grid.

* **Tests**
  * Added mobile viewport accessibility test to verify evidence details render without truncation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xaedyn/chronoscope/pull/108)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->