### PR TITLE
Align status dial with diagnostic verdict

### DIFF
--- a/src/lib/components/ChronographDial.svelte
+++ b/src/lib/components/ChronographDial.svelte
@@ -183,8 +183,8 @@
 
   // ── 60s quality trace (Dial v2) ────────────────────────────────────────────
   // Sparkline inside the face, below the score + verdict. Score 100 at top,
-  // 0 at bottom. Hidden when history is too short — calibrating label shows
-  // instead. Geometry matches view-overview-v2.jsx QualityTraceMini: 160 px
+  // 0 at bottom. Hidden when history is too short; the score and verdict strip
+  // still carry the current state. Geometry matches view-overview-v2.jsx QualityTraceMini: 160 px
   // wide, 22 px tall, centered at cy+74.
   const TRACE_X = CX - 80;
   const TRACE_Y = CY + 63;
@@ -378,7 +378,9 @@
 
   // ── Accessibility label ────────────────────────────────────────────────────
   const ariaLabel = $derived.by(() => {
-    const scorePart = score == null ? 'no data' : `${score} percent healthy`;
+    const scorePart = score == null
+      ? 'no status score yet'
+      : `${verdictStyle.label}, status score ${score} out of 100`;
     const medianPart = liveMedian == null ? 'unknown median' : `median ${Math.round(liveMedian)} milliseconds`;
     const countPart = `${endpointCount} endpoint${endpointCount === 1 ? '' : 's'} monitored`;
     const bandPart = bandLabel === null
@@ -518,8 +520,9 @@
       {/if}
 
       <!-- 8. Center readouts — health score with an explicit label. The old
-           QUALITY kicker was ambiguous; HEALTH SCORE distinguishes the 0-100
-           number from latency milliseconds while the LIVE line carries ms.
+           QUALITY kicker was ambiguous; STATUS SCORE distinguishes the 0-100
+           number from latency milliseconds while avoiding a "percent healthy"
+           claim that can contradict the diagnostic narrative.
            the cy+22 verdict collided with the hand needle. Verdict text is
            now carried as a tspan in the merged strip at cy+108 (see step 8b
            below, which is painted AFTER the hand). -->
@@ -530,7 +533,7 @@
             fill="var(--t3)"
             letter-spacing="0.16em"
             aria-hidden="true"
-      >HEALTH SCORE</text>
+      >STATUS SCORE</text>
       <text x={CX} y={CY - 6} text-anchor="middle" font-size="100" font-weight="200"
             fill="var(--t1)" font-family={tokens.typography.sans.fontFamily}
             style="letter-spacing: 0; font-variant-numeric: tabular-nums;">{scoreDisplay}</text>
@@ -549,14 +552,6 @@
             opacity="0.9"
           />
         </g>
-      {:else if scoreHistory && scoreHistory.length > 0}
-        <text
-          x={CX} y={TRACE_Y + TRACE_H / 2 + 4}
-          text-anchor="middle" font-size="9"
-          font-family={tokens.typography.mono.fontFamily}
-          fill="var(--t4)" letter-spacing="0.18em"
-          aria-hidden="true"
-        >CALIBRATING</text>
       {/if}
 
       <!-- (The merged verdict + LIVE + band strip that used to live here has

--- a/src/lib/components/OverviewView.svelte
+++ b/src/lib/components/OverviewView.svelte
@@ -14,6 +14,7 @@
   import { uiStore } from '$lib/stores/ui';
   import { networkQualityStore, monitoredEndpointsStore } from '$lib/stores/derived';
   import { buildDiagnosticNarrative, type DiagnosticNarrative } from '$lib/utils/diagnostic-narrative';
+  import { diagnosticAlignedScore } from '$lib/utils/classify';
   import { buildHistoryBaselineInsight, type HistoryBaselineInsight } from '$lib/utils/history-baseline';
   import type { VerdictRow } from '$lib/utils/verdict';
   import { tokens } from '$lib/tokens';
@@ -42,7 +43,7 @@
   const measurements = $derived($measurementStore);
   const history = $derived($historyStore);
   const threshold = $derived(settings.healthThreshold);
-  const score = $derived($networkQualityStore);
+  const rawScore = $derived($networkQualityStore);
   const paused = $derived(
     measurements.lifecycle === 'stopped' || measurements.lifecycle === 'completed',
   );
@@ -111,22 +112,9 @@
     return out;
   });
 
-  // Score history ring buffer — one entry per round, max 60 entries. Driven
-  // by roundCounter changes; append on every round. Svelte 5 $state arrays
-  // are proxied, so push/shift notify subscribers directly — no re-assignment
-  // needed.
   const HISTORY_MAX = 60;
   let scoreHistory = $state<number[]>([]);
   let lastSeenRound = -1;
-  $effect(() => {
-    const round = measurements.roundCounter;
-    if (round === lastSeenRound) return;
-    lastSeenRound = round;
-    // Only append when we have a valid score for this round.
-    if (score === null) return;
-    scoreHistory.push(score);
-    while (scoreHistory.length > HISTORY_MAX) scoreHistory.shift();
-  });
 
   // Event ring buffer — threshold crossings + p95 shifts. Per-endpoint
   // prev-state map tracks the comparison baseline across ticks.
@@ -237,6 +225,19 @@
     samplesByEndpoint,
     monitoredEndpointCount: monitored.length,
   }));
+  const score = $derived(diagnosticAlignedScore(rawScore, diagnosticNarrative.severity));
+  // Score history ring buffer — one entry per round, max 60 entries. Driven by
+  // roundCounter changes and aligned to the diagnostic narrative so the trace
+  // never trends "healthy" while the answer says the run needs attention.
+  $effect(() => {
+    const round = measurements.roundCounter;
+    if (round === lastSeenRound) return;
+    lastSeenRound = round;
+    // Only append when we have a valid score for this round.
+    if (score === null) return;
+    scoreHistory.push(score);
+    while (scoreHistory.length > HISTORY_MAX) scoreHistory.shift();
+  });
   const historyBaselineInsight: HistoryBaselineInsight = $derived(buildHistoryBaselineInsight({
     endpoints: monitored,
     stats,

--- a/src/lib/utils/classify.ts
+++ b/src/lib/utils/classify.ts
@@ -94,6 +94,27 @@ export function networkQuality(
   return Math.round(total / ready.length);
 }
 
+export type DiagnosticScoreSeverity = 'healthy' | 'watch' | 'degraded';
+
+/**
+ * Align the Overview dial's status score with the diagnostic narrative.
+ *
+ * `networkQuality()` is an average across ready endpoints, so two fast sites
+ * can otherwise outvote one clearly slow site and make the dial say "healthy"
+ * while the diagnostic answer says "this needs attention." The diagnostic
+ * narrative is the user-facing source of truth: sparse/watch states withhold
+ * the score, and degraded states cannot display in the healthy bucket.
+ */
+export function diagnosticAlignedScore(
+  score: number | null,
+  severity: DiagnosticScoreSeverity,
+): number | null {
+  if (score === null) return null;
+  if (severity === 'watch') return null;
+  if (severity === 'degraded') return Math.min(score, 79);
+  return score;
+}
+
 export type OverviewVerdict = 'unknown' | 'healthy' | 'degraded' | 'unhealthy';
 
 interface VerdictStyle {
@@ -124,4 +145,3 @@ export const VERDICT_STYLES: Record<OverviewVerdict, VerdictStyle> = {
   degraded:  { color: 'var(--accent-amber)', glow: 'var(--accent-amber-glow)', label: 'Degraded',         kicker: 'DEGRADED' },
   unhealthy: { color: 'var(--accent-pink)',  glow: 'var(--accent-pink-glow)',  label: 'Unhealthy',        kicker: 'CRITICAL' },
 };
-

--- a/tests/unit/classify.test.ts
+++ b/tests/unit/classify.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   classify,
+  diagnosticAlignedScore,
   networkQuality,
   overviewVerdict,
   HEALTH_STYLES,
@@ -91,6 +92,29 @@ describe('networkQuality()', () => {
     const healthy  = makeStats({ endpointId: 'a', p50: 10, p95: 30 });
     const pending  = makeStats({ endpointId: 'b', ready: false });
     expect(networkQuality([healthy, pending], 120)).toBe(100);
+  });
+});
+
+describe('diagnosticAlignedScore()', () => {
+  it('caps an averaged healthy-looking score when the diagnostic narrative found a degraded condition', () => {
+    expect(diagnosticAlignedScore(87, 'degraded')).toBe(79);
+  });
+
+  it('does not inflate an already unhealthy score while aligning a degraded diagnosis', () => {
+    expect(diagnosticAlignedScore(20, 'degraded')).toBe(20);
+  });
+
+  it('preserves scores for healthy diagnostics', () => {
+    expect(diagnosticAlignedScore(87, 'healthy')).toBe(87);
+  });
+
+  it('withholds the dial score while the diagnostic narrative is still in watch mode', () => {
+    expect(diagnosticAlignedScore(100, 'watch')).toBeNull();
+  });
+
+  it('preserves null when the aggregate score is not ready', () => {
+    expect(diagnosticAlignedScore(null, 'healthy')).toBeNull();
+    expect(diagnosticAlignedScore(null, 'degraded')).toBeNull();
   });
 });
 

--- a/tests/unit/components/ChronographDial.test.ts
+++ b/tests/unit/components/ChronographDial.test.ts
@@ -258,6 +258,15 @@ describe('ChronographDial — overlap polish · verdict+LIVE merged strip', () =
     expect(tspans).toHaveLength(2); // verdict + live-median only
   });
 
+  it('does not show CALIBRATING once a score is available, even before the trace has enough points', () => {
+    const { container } = render(ChronographDial, {
+      props: { ...baseProps, score: 79, scoreHistory: [79] },
+    });
+    const allText = Array.from(container.querySelectorAll('text'));
+    const calibratingText = allText.find(t => t.textContent?.trim() === 'CALIBRATING');
+    expect(calibratingText).toBeUndefined();
+  });
+
   it('merged strip is painted AFTER the hand group (so it sits on top)', () => {
     // DOM order inside the SVG matters for painting: later = on top.
     const { container } = render(ChronographDial, { props: withBand });


### PR DESCRIPTION
## Summary
- align the Overview dial score to the diagnostic narrative so degraded runs cannot display as healthy
- rename the central readout to Status Score and remove the stale Calibrating fallback once a score exists
- add unit coverage for score alignment and the short-history dial state

## Verification
- npm test -- tests/unit/classify.test.ts tests/unit/components/ChronographDial.test.ts
- npm run typecheck
- npm run lint
- npm test
- npm run build
- local Playwright snapshot check: one slow endpoint + two fast endpoints shows STATUS SCORE 79 / DEGRADED and no HEALTHY · LIVE or CALIBRATING