### PR TITLE
Clarify clustered distribution empty state

### DIFF
--- a/src/lib/components/DiagnoseView.svelte
+++ b/src/lib/components/DiagnoseView.svelte
@@ -14,7 +14,7 @@
   import { buildRemoteVantageInsight } from '$lib/remote-vantage/insight';
   import { describeTimingVisibility, type DiagnosticConfidence } from '$lib/utils/diagnostic-narrative';
   import { phaseHypothesis, PHASE_LABELS, type PhaseBreakdown, type Tier2Phase } from '$lib/utils/verdict';
-  import { buildHistogram, buildCorrelation } from '$lib/utils/diagnose-stats';
+  import { buildDistributionEmptyMessage, buildHistogram, buildCorrelation } from '$lib/utils/diagnose-stats';
   import { fmt, compactUrlLabel, axisEdgeLabel, binLabel } from '$lib/utils/format';
   import { selectInvestigationEndpointId } from '$lib/utils/status-intent';
   import { tokens } from '$lib/tokens';
@@ -132,6 +132,10 @@
     return m.samples.toArray().slice(-50);
   });
   const histogram = $derived(buildHistogram(focusedAllSamples));
+  const distributionEmptyMessage = $derived(buildDistributionEmptyMessage(
+    focusedAllSamples,
+    settings.healthThreshold,
+  ));
 
   // p50 / p95 / spread — recompute locally so the histogram and the readout
   // share a single source of truth (focusedStats may use a different window).
@@ -356,7 +360,7 @@
           {/if}
         </div>
       {:else}
-        <p class="distro-empty">Need at least 2 samples with different latencies before a distribution chart is meaningful. Run for a few more rounds.</p>
+        <p class="distro-empty">{distributionEmptyMessage}</p>
       {/if}
     </section>
 

--- a/src/lib/utils/diagnose-stats.ts
+++ b/src/lib/utils/diagnose-stats.ts
@@ -32,6 +32,24 @@ export interface Histogram {
   readonly total: number;
 }
 
+function successfulLatencies(samples: readonly MeasurementSample[]): number[] {
+  const oks: number[] = [];
+  for (const s of samples) {
+    if (s.status === 'ok' && Number.isFinite(s.latency) && s.latency >= 0) {
+      oks.push(s.latency);
+    }
+  }
+  return oks;
+}
+
+function plural(count: number, singular: string, pluralForm = `${singular}s`): string {
+  return count === 1 ? singular : pluralForm;
+}
+
+function fmtMs(ms: number): string {
+  return `${Math.round(ms)} ms`;
+}
+
 // Fixed 1-2-5 log-spaced bin edges. There are 11 bins total:
 //   bin 0:  (-∞, 2)       fromMs=0, toMs=2         "<2 ms"
 //   bin 1:  [2, 5)        fromMs=2, toMs=5          "2–5 ms"
@@ -68,12 +86,7 @@ const ALL_BINS: ReadonlyArray<{ readonly fromMs: number; readonly toMs: number }
  * is true, so the naive `typeof s.latency === 'number'` guard is insufficient.
  */
 export function buildHistogram(samples: readonly MeasurementSample[]): Histogram {
-  const oks: number[] = [];
-  for (const s of samples) {
-    if (s.status === 'ok' && Number.isFinite(s.latency) && s.latency >= 0) {
-      oks.push(s.latency);
-    }
-  }
+  const oks = successfulLatencies(samples);
 
   if (oks.length < 2) return { bins: [], maxCount: 0, total: oks.length };
 
@@ -125,6 +138,25 @@ export function buildHistogram(samples: readonly MeasurementSample[]): Histogram
   for (const b of bins) if (b.count > maxCount) maxCount = b.count;
 
   return { bins, maxCount, total: oks.length };
+}
+
+export function buildDistributionEmptyMessage(
+  samples: readonly MeasurementSample[],
+  thresholdMs: number | null = null,
+): string {
+  const oks = successfulLatencies(samples);
+  if (oks.length === 0) return 'Waiting for successful checks.';
+  if (oks.length < 2) return 'Need at least 2 successful checks to chart spread.';
+
+  const center = median(oks);
+  const countLabel = `${oks.length} ${plural(oks.length, 'check')}`;
+  const threshold = typeof thresholdMs === 'number' && Number.isFinite(thresholdMs)
+    ? thresholdMs
+    : null;
+  const thresholdText = threshold !== null && center > threshold
+    ? `, above your ${fmtMs(threshold)} threshold`
+    : '';
+  return `${countLabel} clustered near ${fmtMs(center)}${thresholdText}. No spread to chart.`;
 }
 
 // ── Cross-endpoint correlation ───────────────────────────────────────────────

--- a/tests/unit/utils/diagnose-stats.test.ts
+++ b/tests/unit/utils/diagnose-stats.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { buildHistogram, buildCorrelation } from '../../../src/lib/utils/diagnose-stats';
+import {
+  buildDistributionEmptyMessage,
+  buildHistogram,
+  buildCorrelation,
+} from '../../../src/lib/utils/diagnose-stats';
 import type { MeasurementSample } from '../../../src/lib/types';
 
 // Test factories matched to the actual MeasurementSample shape:
@@ -205,6 +209,28 @@ describe('buildHistogram() — 1-2-5 log-bin schema', () => {
     expect(result.total).toBe(51);
   });
 
+});
+
+describe('buildDistributionEmptyMessage()', () => {
+  it('uses compact clustered copy when many checks have no meaningful spread and are above threshold', () => {
+    const samples = Array.from({ length: 35 }, (_, i) => okSample(i + 1, 240));
+    expect(buildDistributionEmptyMessage(samples, 120)).toBe(
+      '35 checks clustered near 240 ms, above your 120 ms threshold. No spread to chart.',
+    );
+  });
+
+  it('uses compact clustered copy without threshold language when the cluster is within threshold', () => {
+    const samples = Array.from({ length: 12 }, (_, i) => okSample(i + 1, 45));
+    expect(buildDistributionEmptyMessage(samples, 120)).toBe(
+      '12 checks clustered near 45 ms. No spread to chart.',
+    );
+  });
+
+  it('keeps sparse-data copy short and accurate', () => {
+    expect(buildDistributionEmptyMessage([okSample(1, 45)], 120)).toBe(
+      'Need at least 2 successful checks to chart spread.',
+    );
+  });
 });
 
 describe('buildCorrelation', () => {


### PR DESCRIPTION
## Summary
- replace Diagnose's generic distribution empty state with concise clustered-data copy
- include threshold context when the clustered latency is above the user's health threshold
- add unit coverage for above-threshold clusters, within-threshold clusters, and sparse data

## Verification
- npm test -- tests/unit/utils/diagnose-stats.test.ts
- npm run typecheck
- npm run lint
- npm run build
- rendered Playwright shared-report check: Distribution shows '35 checks clustered near 240 ms, above your 120 ms threshold. No spread to chart.' with no old 'run more' copy and no console errors
- npx playwright test tests/visual/ac-verification.spec.ts -g "Investigate tab auto-selects"
- npm test