### PR TITLE
Tighten trust hierarchy copy

### DIFF
--- a/src/lib/components/CausalVerdictStrip.svelte
+++ b/src/lib/components/CausalVerdictStrip.svelte
@@ -107,7 +107,7 @@
     {/if}
   </div>
   {#if diagnosis.kind !== 'collecting'}
-    <p class="verdict-explanation">{diagnosis.confidenceReason}</p>
+    <p class="verdict-explanation">{diagnosis.supportingSummary}</p>
   {:else if suppressionMessage}
     <p class="verdict-explanation verdict-suppression">{suppressionMessage}</p>
   {/if}

--- a/src/lib/components/ReportView.svelte
+++ b/src/lib/components/ReportView.svelte
@@ -143,7 +143,7 @@
         title={report.diagnosis.confidenceReason}
       >{report.diagnosis.confidenceLabel}</span>
     </div>
-    <p class="report-lede">{report.diagnosis.safeSummary}</p>
+    <p class="report-lede">{report.diagnosis.supportingSummary}</p>
 
     <div class="report-actions" aria-label="Report actions">
       <button type="button" class="action action-primary" onclick={handleInteractive}>

--- a/src/lib/utils/diagnostic-narrative.ts
+++ b/src/lib/utils/diagnostic-narrative.ts
@@ -94,6 +94,7 @@ export interface DiagnosticNarrative {
   readonly claims: readonly DiagnosticClaim[];
   readonly primaryValidation: PrimaryValidationAction;
   readonly safeSummary: string;
+  readonly supportingSummary: string;
   readonly snapshotEligibility: SnapshotEligibility;
   readonly explanation: string;
   readonly evidence: readonly DiagnosticEvidence[];
@@ -656,6 +657,59 @@ function safeSummaryFor(claim: DiagnosticClaim, confidenceReasonText: string): s
   return `This browser test: ${claim.text} (${claim.strength} confidence; ${confidenceReasonText})`;
 }
 
+function timingSummaryFor(timingVisibility: TimingVisibility): string {
+  switch (timingVisibility.level) {
+    case 'none':
+      return 'no successful timing yet';
+    case 'total-only':
+      return 'total timing only';
+    case 'mixed':
+      return `${timingVisibility.phaseSampleCount}/${timingVisibility.okSampleCount} checks show detailed timing`;
+    case 'phase':
+      return 'detailed timing visible';
+  }
+}
+
+function sampleScopeFor(
+  rows: readonly VerdictRow[],
+  monitoredEndpointCount: number,
+  readiness: ReturnType<typeof sampleReadiness>,
+): string {
+  if (rows.length === 0) {
+    return monitoredEndpointCount === 0
+      ? 'no enabled sites'
+      : `waiting for checks across ${monitoredEndpointCount} ${plural(monitoredEndpointCount, 'site')}`;
+  }
+
+  if (rows.length < monitoredEndpointCount) {
+    return `${rows.length}/${monitoredEndpointCount} ${plural(monitoredEndpointCount, 'site')} ready`;
+  }
+
+  return `${readiness.minSamples}+ successful checks across ${rows.length} ${plural(rows.length, 'site')}`;
+}
+
+function supportingSummaryFor(input: {
+  readonly kind: DiagnosticKind;
+  readonly confidence: DiagnosticConfidence;
+  readonly rows: readonly VerdictRow[];
+  readonly monitoredEndpointCount: number;
+  readonly timingVisibility: TimingVisibility;
+  readonly readiness: ReturnType<typeof sampleReadiness>;
+}): string {
+  const { kind, confidence, rows, monitoredEndpointCount, timingVisibility, readiness } = input;
+  const sampleScope = sampleScopeFor(rows, monitoredEndpointCount, readiness);
+
+  if (kind === 'collecting') {
+    return `Collecting: ${sampleScope}.`;
+  }
+
+  if (kind === 'healthy' && confidence === 'high' && readiness.allEnabledMature) {
+    return `Clean browser-visible run: ${sampleScope}.`;
+  }
+
+  return `Evidence: ${sampleScope}; ${timingSummaryFor(timingVisibility)}.`;
+}
+
 export function buildDiagnosticNarrative(input: DiagnosticInput): DiagnosticNarrative {
   const verdict = computeCausalVerdict(input.rows, input.threshold);
   const samples = allSamples(input.samplesByEndpoint);
@@ -718,6 +772,14 @@ export function buildDiagnosticNarrative(input: DiagnosticInput): DiagnosticNarr
     claims: [primaryAnswer],
     primaryValidation,
     safeSummary: safeSummaryFor(primaryAnswer, confidenceReasonText),
+    supportingSummary: supportingSummaryFor({
+      kind,
+      confidence,
+      rows: input.rows,
+      monitoredEndpointCount: input.monitoredEndpointCount,
+      timingVisibility,
+      readiness,
+    }),
     snapshotEligibility,
     explanation: primaryAnswer.text,
     evidence,

--- a/src/lib/utils/diagnostic-report.ts
+++ b/src/lib/utils/diagnostic-report.ts
@@ -165,7 +165,7 @@ function buildCopySummary(report: Omit<DiagnosticReport, 'copySummary'>): string
 
   return [
     `Chronoscope diagnostic report: ${report.diagnosis.primaryAnswer.text} (${report.diagnosis.confidenceLabel}).`,
-    report.diagnosis.safeSummary,
+    `Trust: ${report.diagnosis.supportingSummary}`,
     slowLine,
     `Evidence: ${report.keptSampleCount} samples kept across ${report.endpointRows.length} endpoints; threshold ${fmtMs(report.threshold)}; browser visibility: ${visibility.headline}.`,
     limitation ? `Caveat: ${limitation.detail}` : '',

--- a/tests/unit/user-facing-copy-safety.test.ts
+++ b/tests/unit/user-facing-copy-safety.test.ts
@@ -13,6 +13,11 @@ const forbiddenClaims: readonly RegExp[] = [
   /pointing toward your .*?(ISP|VPN|WiFi|Wi-Fi|local network)/i,
   /origin, CDN, or DNS path is the likely source/i,
   /endpoint, CDN, or a broad upstream path is implicated/i,
+  /perfect internet/i,
+  /best connection/i,
+  /ISP is clean/i,
+  /No network issue exists/i,
+  /inside the current thresholds/i,
 ];
 
 function sourceFiles(dir: string): string[] {

--- a/tests/unit/utils/diagnostic-narrative.test.ts
+++ b/tests/unit/utils/diagnostic-narrative.test.ts
@@ -134,6 +134,7 @@ describe('buildDiagnosticNarrative', () => {
     expect(narrative.snapshotEligibility.eligible).toBe(true);
     expect(narrative.primaryValidation.id).toBe('share-snapshot');
     expect(narrative.safeSummary).toContain('This browser test: This test looks healthy.');
+    expect(narrative.supportingSummary).toBe('Clean browser-visible run: 35+ successful checks across 3 sites.');
   });
 
   it('explains isolated endpoint slowness with evidence-labeled endpoint and next validation step', () => {
@@ -162,6 +163,7 @@ describe('buildDiagnosticNarrative', () => {
     expect(narrative.primaryValidation.id).toBe('explain-browser-visibility');
     expect(narrative.evidence.some((item) => item.label === 'Site to inspect' && item.value === 'API')).toBe(true);
     expect(narrative.safeSummary).not.toMatch(/likely (source|site|network|your network)/i);
+    expect(narrative.supportingSummary).toBe('Evidence: 18+ successful checks across 3 sites; total timing only.');
     expect(narrative.nextSteps.join(' ')).toContain('Open Investigate');
   });
 
@@ -295,5 +297,72 @@ describe('buildDiagnosticNarrative', () => {
         multipleSlow.primaryAnswer.text,
       ].join(' '),
     ).not.toMatch(/elevated|browser-visible|root-cause|likely/i);
+  });
+
+  it('keeps the trust matrix concise and evidence-scoped across common scenarios', () => {
+    const scenarios = [
+      buildDiagnosticNarrative({
+        rows: [],
+        threshold: 120,
+        corsMode: 'no-cors',
+        samplesByEndpoint: {},
+        monitoredEndpointCount: 3,
+      }),
+      buildDiagnosticNarrative({
+        rows: [
+          row('api', { p50: 240, sampleCount: 18 }, 'API'),
+          row('google', { p50: 45, sampleCount: 18 }, 'Google'),
+          row('cloudflare', { p50: 38, sampleCount: 18 }, 'Cloudflare'),
+        ],
+        threshold: 120,
+        corsMode: 'no-cors',
+        samplesByEndpoint: {
+          api: samples(18, 240),
+          google: samples(18, 45),
+          cloudflare: samples(18, 38),
+        },
+        monitoredEndpointCount: 3,
+      }),
+      buildDiagnosticNarrative({
+        rows: [
+          row('google', { p50: 220, tier2Averages: { dnsLookup: 120, tcpConnect: 5, tlsHandshake: 5, ttfb: 10, contentTransfer: 10 } }),
+          row('cloudflare', { p50: 210, tier2Averages: { dnsLookup: 120, tcpConnect: 5, tlsHandshake: 5, ttfb: 10, contentTransfer: 10 } }),
+          row('aws', { p50: 40, tier2Averages: tier2 }),
+        ],
+        threshold: 120,
+        corsMode: 'cors',
+        samplesByEndpoint: {
+          google: samples(35, 220, true),
+          cloudflare: samples(35, 210, true),
+          aws: samples(35, 40, true),
+        },
+        monitoredEndpointCount: 3,
+      }),
+      buildDiagnosticNarrative({
+        rows: [
+          row('google', { lossPercent: 2, sampleCount: 18 }),
+          row('cloudflare', { lossPercent: 2, sampleCount: 18 }),
+        ],
+        threshold: 120,
+        corsMode: 'no-cors',
+        samplesByEndpoint: {
+          google: samples(18, 50),
+          cloudflare: samples(18, 55),
+        },
+        monitoredEndpointCount: 2,
+      }),
+    ];
+
+    for (const narrative of scenarios) {
+      const { supportingSummary } = narrative;
+      expect(supportingSummary).toBeTruthy();
+      expect(supportingSummary!.length).toBeLessThanOrEqual(120);
+      expect([
+        narrative.primaryAnswer.text,
+        supportingSummary,
+        narrative.primaryValidation.reason,
+        narrative.safeSummary,
+      ].join(' ')).not.toMatch(/perfect internet|best connection|ISP is clean|No network issue exists|root cause|likely (?:that site|your network|source)/i);
+    }
   });
 });

--- a/tests/unit/utils/diagnostic-report.test.ts
+++ b/tests/unit/utils/diagnostic-report.test.ts
@@ -140,6 +140,9 @@ describe('buildDiagnosticReport', () => {
     expect(report.copySummary).not.toMatch(/likely (affected|source|site|network|your network)/i);
     expect(report.copySummary).not.toContain(report.diagnosis.verdict.headline);
     expect(report.copySummary).toContain(report.diagnosis.primaryAnswer.text);
+    expect(report.copySummary).toContain('Trust: Evidence: 30+ successful checks across 3 sites; total timing only.');
+    expect(report.copySummary.match(new RegExp(report.diagnosis.primaryAnswer.text, 'g'))).toHaveLength(1);
+    expect(report.copySummary).not.toMatch(/This browser test: .*This browser test:/s);
   });
 
   it('falls back to local defaults for legacy contexts without threshold metadata', () => {

--- a/tests/visual/ac-verification.spec.ts
+++ b/tests/visual/ac-verification.spec.ts
@@ -294,10 +294,10 @@ test.describe('Acceptance criteria verification', () => {
     await page.waitForSelector('#chronoscope-root');
 
     await expect(page.getByText('Shared diagnostic report').first()).toBeVisible();
-    await expect(page.getByRole('heading', { name: /Only api\.example\.com looks slow/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /api\.example\.com is slower than the others in this test/i })).toBeVisible();
     await expect(page.getByText(/medium confidence|high confidence/i)).toBeVisible();
     await expect(page.getByRole('button', { name: /Open Interactive Analysis/i })).toBeVisible();
-    await expect(page.getByRole('table', { name: /Endpoint report table/i })).toContainText('likely source');
+    await expect(page.getByRole('table', { name: /Endpoint report table/i })).toContainText('inspect');
     await expect(page.getByText(/Timing-Allow-Origin/i)).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- Add a concise `supportingSummary` from the diagnostic narrative model for Status and shared reports.
- Replace duplicated report lede/copy-summary text with a short evidence-scoped Trust line.
- Expand copy-safety and trust-matrix coverage, and update the shared-report visual assertion away from old unsupported root-cause wording.

## Verification
- npm run typecheck
- npm run lint
- npm run build
- npm test
- npx playwright test tests/visual/ac-verification.spec.ts -g "shared result link opens as a diagnostic report"
- Rendered QA with local Playwright: desktop/mobile shared report + desktop Status, no console errors, no horizontal overflow, compact trust line visible.

## Browser QA note
- Attempted the in-app Browser path first, but no active Codex browser pane was available, so rendered QA used the repo Playwright runtime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated diagnostic report summaries and verdict messages with revised narrative text
  * Modified how confidence and trust information is presented in diagnostic reports
  * Improved report formatting, table content, and shared diagnostic copy text
  * Refined messaging to better communicate diagnostic findings and results clarity

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xaedyn/chronoscope/pull/114)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->