### PR TITLE
[codex] Add evidence-gated triage actions

### DIFF
--- a/src/lib/components/CausalVerdictStrip.svelte
+++ b/src/lib/components/CausalVerdictStrip.svelte
@@ -36,8 +36,10 @@
   const verdict = $derived(diagnosis.verdict);
   const primaryHeadline = $derived(diagnosis.primaryAnswer.text);
   const primaryAction = $derived(diagnosis.primaryValidation);
+  const triageActions = $derived(diagnosis.triageActions ?? []);
+  const primaryTriageAction = $derived(triageActions[0] ?? null);
   const primaryLimitation = $derived(diagnosis.limitations[0] ?? null);
-  const primaryNextStep = $derived(primaryAction?.reason ?? diagnosis.nextSteps[0] ?? null);
+  const primaryNextStep = $derived(primaryTriageAction?.action ?? primaryAction?.reason ?? diagnosis.nextSteps[0] ?? null);
   const drillActionLabel = $derived(primaryAction?.endpointId === drillEndpoint?.id
     ? (primaryAction.id === 'run-remote-check' ? 'Open Investigate' : primaryAction.label)
     : 'Investigate');
@@ -171,7 +173,10 @@
         </p>
       {/if}
       {#if primaryNextStep}
-        <p class="verdict-next">
+        <p
+          class="verdict-next"
+          title={primaryTriageAction ? `${primaryTriageAction.why} ${primaryTriageAction.watchFor}` : undefined}
+        >
           <span class="verdict-extra-label">Next</span>
           <span>{primaryNextStep}</span>
         </p>

--- a/src/lib/components/ReportView.svelte
+++ b/src/lib/components/ReportView.svelte
@@ -47,21 +47,34 @@
 
   let copiedSummary = $state(false);
   let copiedLink = $state(false);
+  let copyError = $state<'summary' | 'link' | null>(null);
 
-  function copyText(text: string, onDone: () => void): void {
-    if (!navigator.clipboard) return;
+  function resetCopyState(): void {
+    copiedSummary = false;
+    copiedLink = false;
+    copyError = null;
+  }
+
+  function copyText(text: string, onDone: () => void, onError: () => void): void {
+    if (!navigator.clipboard) {
+      onError();
+      return;
+    }
     void navigator.clipboard.writeText(text).then(() => {
+      copyError = null;
       onDone();
-      setTimeout(() => {
-        copiedSummary = false;
-        copiedLink = false;
-      }, 1800);
+      setTimeout(resetCopyState, 1800);
+    }).catch(() => {
+      onError();
+      setTimeout(resetCopyState, 1800);
     });
   }
 
   function handleCopySummary(): void {
     copyText(report.copySummary, () => {
       copiedSummary = true;
+    }, () => {
+      copyError = 'summary';
     });
   }
 
@@ -102,6 +115,8 @@
       : null;
     copyText(hostedUrl ?? buildShareURL(fallbackPayload ?? builtForHostedReport.payload), () => {
       copiedLink = true;
+    }, () => {
+      copyError = 'link';
     });
   }
 
@@ -150,10 +165,10 @@
         Open Interactive Analysis
       </button>
       <button type="button" class="action" onclick={handleCopySummary}>
-        {copiedSummary ? 'Summary Copied' : 'Copy Summary'}
+        {copyError === 'summary' ? 'Copy Failed' : copiedSummary ? 'Summary Copied' : 'Copy Summary'}
       </button>
       <button type="button" class="action" onclick={handleCopyLink}>
-        {copiedLink ? 'Link Copied' : 'Copy Report Link'}
+        {copyError === 'link' ? 'Copy Failed' : copiedLink ? 'Link Copied' : 'Copy Report Link'}
       </button>
       <button type="button" class="action" onclick={handleRunOwn}>
         Run Your Own Test
@@ -180,6 +195,23 @@
       <span class="metric-label">Timing mode</span>
       <strong>{report.corsMode}</strong>
       <span class="metric-note">{report.corsModeSource === 'shared' ? 'from sender' : report.corsModeSource === 'payload-settings' ? 'legacy link' : 'local default'}</span>
+    </div>
+  </section>
+
+  <section class="next-steps" aria-label="Recommended next steps">
+    <div class="section-kicker">What to try next</div>
+    <div class="triage-grid">
+      {#each report.diagnosis.triageActions as action, i (action.id)}
+        <article class="triage-card">
+          <div class="triage-index">{i + 1}</div>
+          <div>
+            <h2>{action.label}</h2>
+            <p class="triage-action">{action.action}</p>
+            <p>{action.why}</p>
+            <p class="triage-watch"><strong>Watch for:</strong> {action.watchFor}</p>
+          </div>
+        </article>
+      {/each}
     </div>
   </section>
 
@@ -297,14 +329,6 @@
     </div>
   </section>
 
-  <section class="next-steps" aria-label="Recommended next steps">
-    <div class="section-kicker">Recommended next steps</div>
-    <ol>
-      {#each report.diagnosis.nextSteps as step, i (`${i}-${step}`)}
-        <li>{step}</li>
-      {/each}
-    </ol>
-  </section>
 </section>
 
 <style>
@@ -445,6 +469,9 @@
     border-radius: 8px;
     background: rgba(12,10,20,.58);
     padding: 16px;
+  }
+  .next-steps {
+    margin-bottom: 18px;
   }
 
   .evidence-grid {
@@ -633,14 +660,49 @@
   .status-pill.loss { color: var(--accent-amber); border-color: rgba(251,191,36,.28); background: rgba(251,191,36,.08); }
   .status-pill.muted { opacity: .75; }
 
-  .next-steps ol {
-    margin: 12px 0 0;
-    padding-left: 22px;
-    color: var(--t2);
-    line-height: 1.6;
+  .triage-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+    margin-top: 12px;
   }
-  .next-steps li + li {
-    margin-top: 6px;
+  .triage-card {
+    min-width: 0;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 10px;
+    padding: 12px;
+    border-radius: 7px;
+    border: 1px solid rgba(255,255,255,.07);
+    background: rgba(255,255,255,.035);
+  }
+  .triage-index {
+    width: 24px;
+    height: 24px;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid rgba(103,232,249,.25);
+    color: var(--accent-cyan);
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    font-variant-numeric: tabular-nums;
+  }
+  .triage-card h2 {
+    margin-top: 0;
+    font-size: var(--ts-base);
+  }
+  .triage-card p {
+    margin: 6px 0 0;
+    color: var(--t3);
+    line-height: 1.45;
+  }
+  .triage-action {
+    color: var(--t1) !important;
+  }
+  .triage-watch strong {
+    color: var(--t2);
   }
 
   @media (max-width: 900px) {
@@ -659,6 +721,9 @@
       grid-template-columns: 1fr;
     }
     .baseline-list {
+      grid-template-columns: 1fr;
+    }
+    .triage-grid {
       grid-template-columns: 1fr;
     }
     .endpoint-table {

--- a/src/lib/utils/diagnostic-narrative.ts
+++ b/src/lib/utils/diagnostic-narrative.ts
@@ -54,6 +54,27 @@ export interface PrimaryValidationAction {
   readonly endpointId?: string;
 }
 
+export type DiagnosticTriageActionId =
+  | 'collect-more-samples'
+  | 'review-browser-visibility'
+  | 'open-investigate'
+  | 'run-remote-check'
+  | 'compare-another-network'
+  | 'run-local-agent'
+  | 'share-support-report'
+  | 'share-snapshot'
+  | 'keep-running';
+
+export interface DiagnosticTriageAction {
+  readonly id: DiagnosticTriageActionId;
+  readonly label: string;
+  readonly action: string;
+  readonly why: string;
+  readonly watchFor: string;
+  readonly requiredEvidence: readonly DiagnosticEvidenceGate[];
+  readonly endpointId?: string;
+}
+
 export interface SnapshotEligibility {
   readonly eligible: boolean;
   readonly reason: string;
@@ -99,6 +120,7 @@ export interface DiagnosticNarrative {
   readonly explanation: string;
   readonly evidence: readonly DiagnosticEvidence[];
   readonly limitations: readonly DiagnosticLimitation[];
+  readonly triageActions: readonly DiagnosticTriageAction[];
   readonly nextSteps: readonly string[];
   readonly timingVisibility: TimingVisibility;
 }
@@ -490,6 +512,182 @@ function nextStepsFor(kind: DiagnosticKind, verdict: Verdict, rows: readonly Ver
   }
 }
 
+function browserVisibilityAction(timingVisibility: TimingVisibility): DiagnosticTriageAction | null {
+  if (timingVisibility.level !== 'total-only' && timingVisibility.level !== 'mixed') return null;
+  return {
+    id: 'review-browser-visibility',
+    label: 'Check visibility',
+    action: 'Review what the browser can and cannot see.',
+    why: 'Chronoscope can compare total load time, but the browser hides DNS, TCP, TLS, server, or transfer detail for some sites.',
+    watchFor: 'If detailed timing appears, the next test can be stronger; otherwise treat this as a timing comparison.',
+    requiredEvidence: ['total-timing'],
+  };
+}
+
+function endpointLabelFor(verdict: Verdict, rows: readonly VerdictRow[]): string {
+  return rows.find((row) => row.ep.id === verdict.worstEpId)?.ep.label ?? 'the slow site';
+}
+
+function triageActionsFor(input: {
+  readonly kind: DiagnosticKind;
+  readonly verdict: Verdict;
+  readonly rows: readonly VerdictRow[];
+  readonly timingVisibility: TimingVisibility;
+  readonly primaryAnswer: DiagnosticClaim;
+}): readonly DiagnosticTriageAction[] {
+  const { kind, verdict, rows, timingVisibility, primaryAnswer } = input;
+  const visibility = browserVisibilityAction(timingVisibility);
+  const endpointLabel = endpointLabelFor(verdict, rows);
+  const endpointId = verdict.worstEpId;
+
+  if (kind === 'collecting') {
+    return [{
+      id: 'collect-more-samples',
+      label: 'Keep collecting',
+      action: 'Let the test keep running before acting on the answer.',
+      why: 'Early samples can make one site look unusual before the set has enough successful checks.',
+      watchFor: `Wait until each enabled site has at least ${MIN_ACTIONABLE_SAMPLES} successful checks.`,
+      requiredEvidence: ['sample-ready'],
+    }];
+  }
+
+  if (kind === 'healthy') {
+    return [
+      {
+        id: 'share-snapshot',
+        label: 'Share result',
+        action: 'Share this clean measured run.',
+        why: 'Every enabled site has mature checks and Chronoscope did not see slow medians or failed requests in this browser run.',
+        watchFor: 'If the issue returns later, compare the new run against this clean snapshot.',
+        requiredEvidence: ['all-enabled-ready', 'sample-mature', 'total-timing'],
+      },
+      {
+        id: 'keep-running',
+        label: 'Watch intermittent issues',
+        action: 'Keep it running if the problem comes and goes.',
+        why: 'Intermittent network symptoms often need more time before they show a repeatable pattern.',
+        watchFor: 'If one site or several sites start crossing the threshold, use the changed report instead of this clean one.',
+        requiredEvidence: ['sample-mature'],
+      },
+    ];
+  }
+
+  if (kind === 'isolated-endpoint') {
+    return [
+      ...(visibility ? [visibility] : []),
+      {
+        id: 'open-investigate',
+        label: 'Inspect slow moments',
+        action: `Open Investigate for ${endpointLabel} and compare slow moments across sites.`,
+        why: 'This checks whether the slow moments are isolated or shared.',
+        watchFor: `If only ${endpointLabel} stays slow, run the outside check before sharing; if several sites slow together, use shared-path tests.`,
+        requiredEvidence: primaryAnswer.requiredEvidence,
+        ...(endpointId ? { endpointId } : {}),
+      },
+      {
+        id: 'run-remote-check',
+        label: 'Run outside check',
+        action: `Run a remote check for ${endpointLabel}.`,
+        why: 'This separates what this browser path sees from what another network path sees.',
+        watchFor: 'If the outside check is clean while this browser is slow, compare another local network; if both are slow, share the report.',
+        requiredEvidence: ['all-enabled-ready', 'sample-actionable', 'total-timing'],
+        ...(endpointId ? { endpointId } : {}),
+      },
+      {
+        id: 'compare-another-network',
+        label: 'Compare location',
+        action: 'Try the same check from another network or device.',
+        why: 'A second local vantage shows whether the pattern follows this connection.',
+        watchFor: `If ${endpointLabel} is slow from multiple networks, the report is stronger; if it is only slow here, continue local-path checks.`,
+        requiredEvidence: ['all-enabled-ready', 'sample-actionable', 'total-timing'],
+        ...(endpointId ? { endpointId } : {}),
+      },
+    ];
+  }
+
+  if (kind === 'shared-network' || kind === 'multiple-slow') {
+    const actions: DiagnosticTriageAction[] = [
+      ...(visibility ? [visibility] : []),
+      {
+        id: 'compare-another-network',
+        label: 'Compare location',
+        action: 'Run the same set from another network.',
+        why: 'A second network shows whether the symptom follows this path.',
+        watchFor: 'If the second network is clean, deepen local-path checks; if both show the same pattern, share the measured report.',
+        requiredEvidence: primaryAnswer.requiredEvidence,
+      },
+      {
+        id: 'run-local-agent',
+        label: 'Deepen local proof',
+        action: 'Run the local agent for DNS trace, route hops, TLS, and Wi-Fi details.',
+        why: 'The browser cannot see route hops, DNS-chain, certificate, or radio details by itself.',
+        watchFor: 'hop-by-hop loss, DNS failures, certificate errors, or weak Wi-Fi signal would make the local-path case stronger.',
+        requiredEvidence: ['sample-actionable', 'local-agent'],
+      },
+      {
+        id: 'share-support-report',
+        label: 'Share measured facts',
+        action: 'Share the support report with the evidence and browser limits included.',
+        why: 'The report is useful when it separates measured facts from what Chronoscope cannot see.',
+        watchFor: 'A responder should be able to see which sites were slow, how many samples were kept, and which timing details were hidden.',
+        requiredEvidence: ['all-enabled-ready', 'sample-actionable', 'total-timing'],
+      },
+    ];
+    return actions.slice(0, 4);
+  }
+
+  if (kind === 'packet-loss') {
+    return [
+      {
+        id: 'compare-another-network',
+        label: 'Confirm failures',
+        action: 'Run longer, then compare on another network or a wired connection.',
+        why: 'Failed requests need repeatability before they point to a useful next test.',
+        watchFor: 'If failures continue across networks, share the report; if they stop on another path, deepen local checks.',
+        requiredEvidence: primaryAnswer.requiredEvidence,
+      },
+      {
+        id: 'run-local-agent',
+        label: 'Check local path',
+        action: 'Run the local agent if failures keep appearing here.',
+        why: 'Local packet loss needs OS-level route and interface evidence that the browser cannot collect.',
+        watchFor: 'Hop-by-hop loss or interface errors would make the local-path case stronger.',
+        requiredEvidence: ['sample-actionable', 'local-agent'],
+      },
+    ];
+  }
+
+  if (kind === 'jitter') {
+    return [
+      {
+        id: 'compare-another-network',
+        label: 'Compare stability',
+        action: 'Compare wired, Wi-Fi, or another network while watching jitter.',
+        why: 'Latency swings can come from local radio, congestion, or the service path, so the next test is whether they follow this connection.',
+        watchFor: 'If jitter drops on another path, continue local checks; if it follows the same site set, share the report.',
+        requiredEvidence: primaryAnswer.requiredEvidence,
+      },
+      {
+        id: 'run-local-agent',
+        label: 'Measure deeper',
+        action: 'Run the local agent to add route and Wi-Fi signal evidence.',
+        why: 'The browser can show jumping latency, but not radio quality or hop-level variation.',
+        watchFor: 'Weak signal, changing route latency, or hop-level spikes would narrow the next support conversation.',
+        requiredEvidence: ['sample-actionable', 'local-agent'],
+      },
+    ];
+  }
+
+  return [{
+    id: 'share-support-report',
+    label: 'Share measured facts',
+    action: 'Share the report after one more run confirms the same pattern.',
+    why: 'A repeated run makes unresolved slow-site evidence more useful without overstating why it happened.',
+    watchFor: 'If the same endpoints cross the threshold again, the report is stronger; if the pattern changes, keep collecting.',
+    requiredEvidence: primaryAnswer.requiredEvidence,
+  }];
+}
+
 function successfulSampleCount(samples: readonly MeasurementSample[] | undefined): number | null {
   if (samples === undefined) return null;
   return samples.filter((sample) => sample.status === 'ok').length;
@@ -760,6 +958,13 @@ export function buildDiagnosticNarrative(input: DiagnosticInput): DiagnosticNarr
     snapshotEligibility,
     readiness,
   });
+  const triageActions = triageActionsFor({
+    kind,
+    verdict,
+    rows: input.rows,
+    timingVisibility,
+    primaryAnswer,
+  });
 
   return {
     verdict,
@@ -784,6 +989,7 @@ export function buildDiagnosticNarrative(input: DiagnosticInput): DiagnosticNarr
     explanation: primaryAnswer.text,
     evidence,
     limitations: limitationsFor(kind, timingVisibility),
+    triageActions,
     nextSteps: nextStepsFor(kind, verdict, input.rows),
     timingVisibility,
   };

--- a/src/lib/utils/diagnostic-report.ts
+++ b/src/lib/utils/diagnostic-report.ts
@@ -161,7 +161,7 @@ function buildCopySummary(report: Omit<DiagnosticReport, 'copySummary'>): string
     : 'No endpoint is currently above the report threshold.';
   const visibility = report.diagnosis.timingVisibility;
   const limitation = report.diagnosis.limitations[0];
-  const nextStep = `${report.diagnosis.primaryValidation.label}: ${report.diagnosis.primaryValidation.reason}`;
+  const firstTriageAction = report.diagnosis.triageActions[0];
 
   return [
     `Chronoscope diagnostic report: ${report.diagnosis.primaryAnswer.text} (${report.diagnosis.confidenceLabel}).`,
@@ -169,7 +169,8 @@ function buildCopySummary(report: Omit<DiagnosticReport, 'copySummary'>): string
     slowLine,
     `Evidence: ${report.keptSampleCount} samples kept across ${report.endpointRows.length} endpoints; threshold ${fmtMs(report.threshold)}; browser visibility: ${visibility.headline}.`,
     limitation ? `Caveat: ${limitation.detail}` : '',
-    `Next validation: ${nextStep}`,
+    firstTriageAction ? `First next test: ${firstTriageAction.action}` : '',
+    firstTriageAction ? `Watch for: ${firstTriageAction.watchFor}` : '',
   ].filter(Boolean).join('\n');
 }
 

--- a/tests/unit/components/shared-run-own-reset.test.ts
+++ b/tests/unit/components/shared-run-own-reset.test.ts
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/svelte';
+import { fireEvent, render, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Topbar from '../../../src/lib/components/Topbar.svelte';
@@ -71,5 +71,22 @@ describe('shared run-own reset', () => {
 
     expect(get(uiStore).isSharedView).toBe(false);
     expect(get(uiStore).autoStartSuppressionReason).toBeNull();
+  });
+
+  it('ReportView Copy Summary handles clipboard rejection without claiming success', async () => {
+    const writeText = vi.fn().mockRejectedValue(new DOMException('Denied', 'NotAllowedError'));
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+    const { getByRole, queryByRole } = render(ReportView);
+
+    await fireEvent.click(getByRole('button', { name: /copy summary/i }));
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledTimes(1);
+    });
+    expect(queryByRole('button', { name: /summary copied/i })).toBeNull();
+    expect(getByRole('button', { name: /copy failed/i })).toBeTruthy();
   });
 });

--- a/tests/unit/user-facing-copy-safety.test.ts
+++ b/tests/unit/user-facing-copy-safety.test.ts
@@ -18,6 +18,10 @@ const forbiddenClaims: readonly RegExp[] = [
   /ISP is clean/i,
   /No network issue exists/i,
   /inside the current thresholds/i,
+  /will fix/i,
+  /restart your router/i,
+  /the problem is your/i,
+  /your ISP is/i,
 ];
 
 function sourceFiles(dir: string): string[] {

--- a/tests/unit/utils/diagnostic-narrative.test.ts
+++ b/tests/unit/utils/diagnostic-narrative.test.ts
@@ -110,6 +110,12 @@ describe('buildDiagnosticNarrative', () => {
     expect(narrative.primaryAnswer.kind).toBe('measured');
     expect(narrative.primaryValidation.id).toBe('collect-more-samples');
     expect(narrative.nextSteps[0]).toContain('12 successful checks');
+    expect(narrative.triageActions[0]).toMatchObject({
+      id: 'collect-more-samples',
+      label: 'Keep collecting',
+      requiredEvidence: ['sample-ready'],
+    });
+    expect(narrative.triageActions[0].watchFor).toContain('12 successful checks');
   });
 
   it('marks healthy multi-endpoint evidence as high confidence when samples are mature', () => {
@@ -135,6 +141,9 @@ describe('buildDiagnosticNarrative', () => {
     expect(narrative.primaryValidation.id).toBe('share-snapshot');
     expect(narrative.safeSummary).toContain('This browser test: This test looks healthy.');
     expect(narrative.supportingSummary).toBe('Clean browser-visible run: 35+ successful checks across 3 sites.');
+    expect(narrative.triageActions.map((action) => action.id)).toEqual(['share-snapshot', 'keep-running']);
+    expect(narrative.triageActions[0].action).toContain('Share this clean measured run');
+    expect(narrative.triageActions[0].why).toContain('mature checks');
   });
 
   it('explains isolated endpoint slowness with evidence-labeled endpoint and next validation step', () => {
@@ -165,6 +174,18 @@ describe('buildDiagnosticNarrative', () => {
     expect(narrative.safeSummary).not.toMatch(/likely (source|site|network|your network)/i);
     expect(narrative.supportingSummary).toBe('Evidence: 18+ successful checks across 3 sites; total timing only.');
     expect(narrative.nextSteps.join(' ')).toContain('Open Investigate');
+    expect(narrative.triageActions.map((action) => action.id)).toEqual([
+      'review-browser-visibility',
+      'open-investigate',
+      'run-remote-check',
+      'compare-another-network',
+    ]);
+    expect(narrative.triageActions[0].action).toContain('Review what the browser can and cannot see');
+    expect(narrative.triageActions[1]).toMatchObject({
+      endpointId: 'api',
+      requiredEvidence: ['all-enabled-ready', 'sample-actionable', 'total-timing'],
+    });
+    expect(narrative.triageActions[2].watchFor).toContain('outside check');
   });
 
   it('adds CORS and Timing-Allow-Origin guidance when timing is total-only', () => {
@@ -238,6 +259,13 @@ describe('buildDiagnosticNarrative', () => {
     expect(narrative.primaryAnswer.text).not.toMatch(/\b(?:likely|ISP|VPN|Wi[- ]?Fi)\b/i);
     expect(narrative.primaryValidation.reason).toContain('browser');
     expect(narrative.nextSteps.join(' ')).toContain('Timing-Allow-Origin');
+    expect(narrative.triageActions.map((action) => action.id)).toEqual([
+      'compare-another-network',
+      'run-local-agent',
+      'share-support-report',
+    ]);
+    expect(narrative.triageActions[1].action).toContain('Run the local agent');
+    expect(narrative.triageActions[1].watchFor).toContain('hop-by-hop');
   });
 
   it('uses plain verdicts for failed requests, jitter, and unresolved slow sites', () => {
@@ -362,7 +390,21 @@ describe('buildDiagnosticNarrative', () => {
         supportingSummary,
         narrative.primaryValidation.reason,
         narrative.safeSummary,
+        ...narrative.triageActions.flatMap((action) => [
+          action.label,
+          action.action,
+          action.why,
+          action.watchFor,
+        ]),
       ].join(' ')).not.toMatch(/perfect internet|best connection|ISP is clean|No network issue exists|root cause|likely (?:that site|your network|source)/i);
+
+      for (const action of narrative.triageActions) {
+        expect(action.action).toBeTruthy();
+        expect(action.why).toBeTruthy();
+        expect(action.watchFor).toBeTruthy();
+        expect(action.requiredEvidence.length).toBeGreaterThan(0);
+        expect(`${action.action} ${action.why} ${action.watchFor}`).not.toMatch(/will fix|restart your router|the problem is your|your ISP is/i);
+      }
     }
   });
 });

--- a/tests/unit/utils/diagnostic-report.test.ts
+++ b/tests/unit/utils/diagnostic-report.test.ts
@@ -141,8 +141,11 @@ describe('buildDiagnosticReport', () => {
     expect(report.copySummary).not.toContain(report.diagnosis.verdict.headline);
     expect(report.copySummary).toContain(report.diagnosis.primaryAnswer.text);
     expect(report.copySummary).toContain('Trust: Evidence: 30+ successful checks across 3 sites; total timing only.');
+    expect(report.copySummary).toContain('First next test: Review what the browser can and cannot see.');
+    expect(report.copySummary).toContain('Watch for: If detailed timing appears');
     expect(report.copySummary.match(new RegExp(report.diagnosis.primaryAnswer.text, 'g'))).toHaveLength(1);
     expect(report.copySummary).not.toMatch(/This browser test: .*This browser test:/s);
+    expect(report.copySummary).not.toMatch(/will fix|restart your router|the problem is your|your ISP is/i);
   });
 
   it('falls back to local defaults for legacy contexts without threshold metadata', () => {

--- a/tests/visual/ac-verification.spec.ts
+++ b/tests/visual/ac-verification.spec.ts
@@ -299,6 +299,9 @@ test.describe('Acceptance criteria verification', () => {
     await expect(page.getByRole('button', { name: /Open Interactive Analysis/i })).toBeVisible();
     await expect(page.getByRole('table', { name: /Endpoint report table/i })).toContainText('inspect');
     await expect(page.getByText(/Timing-Allow-Origin/i)).toBeVisible();
+    await expect(page.getByText('What to try next')).toBeVisible();
+    await expect(page.getByText('Review what the browser can and cannot see.')).toBeVisible();
+    await expect(page.getByText('Run a remote check for api.example.com.')).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds structured, evidence-gated triage actions to the diagnostic narrative model.
- Surfaces those actions in shared reports before the deep evidence tables and uses the first action as the compact Status next step.
- Updates copied summaries to include the first next test and watch-for condition, and handles denied clipboard writes without claiming success.

## Validation
- npm test -- tests/unit/components/shared-run-own-reset.test.ts tests/unit/components/CausalVerdictStrip.test.ts tests/unit/utils/diagnostic-narrative.test.ts tests/unit/utils/diagnostic-report.test.ts tests/unit/user-facing-copy-safety.test.ts
- npm run typecheck
- npm run lint
- npm run build
- npm test
- npx playwright test tests/visual/ac-verification.spec.ts -g "shared result link opens as a diagnostic report"
- Local Playwright smoke against http://127.0.0.1:5173 shared report: desktop/mobile no horizontal overflow, no console errors, denied clipboard shows Copy Failed
