### PR TITLE
[codex] Add executable report triage evidence

### DIFF
--- a/src/lib/components/ReportView.svelte
+++ b/src/lib/components/ReportView.svelte
@@ -8,17 +8,21 @@
   import { settingsStore } from '$lib/stores/settings';
   import { statisticsStore } from '$lib/stores/statistics';
   import { uiStore } from '$lib/stores/ui';
+  import { companionStore } from '$lib/stores/companion';
   import { remoteVantageStore } from '$lib/stores/remote-vantage';
   import { buildShareURL } from '$lib/share/share-manager';
   import { buildResultsSharePayload, MAX_SHARE_URL_CHARS } from '$lib/share/share-payload-builder';
   import { buildDiagnosticReport, formatReportMetric } from '$lib/utils/diagnostic-report';
+  import { buildEvidenceTrail } from '$lib/utils/evidence-trail';
   import { buildHistoryBaselineInsight } from '$lib/utils/history-baseline';
   import { tokens } from '$lib/tokens';
+  import type { DiagnosticTriageAction } from '$lib/utils/diagnostic-narrative';
 
   const endpoints = $derived($endpointStore);
   const measurements = $derived($measurementStore);
   const history = $derived($historyStore);
   const remoteVantage = $derived($remoteVantageStore);
+  const companion = $derived($companionStore);
   const settings = $derived($settingsStore);
   const stats = $derived($statisticsStore);
   const context = $derived($uiStore.sharedReportContext);
@@ -44,10 +48,24 @@
       .filter((comparison) => comparison.status !== 'unready')
       .slice(0, 4),
   );
+  const evidenceTrail = $derived(buildEvidenceTrail({
+    report,
+    remoteVantage,
+    companion,
+  }));
+  const remoteBusy = $derived(remoteVantage.status === 'checking' || remoteVantage.status === 'probing');
+  const companionBusy = $derived(companion.status === 'checking' || companion.status === 'probing');
 
   let copiedSummary = $state(false);
   let copiedLink = $state(false);
   let copyError = $state<'summary' | 'link' | null>(null);
+  let browserVisibilityPanel = $state<HTMLElement | null>(null);
+
+  interface TriageOutcome {
+    readonly label: string;
+    readonly tone: 'good' | 'watch' | 'bad' | 'neutral';
+    readonly disabled?: boolean;
+  }
 
   function resetCopyState(): void {
     copiedSummary = false;
@@ -120,21 +138,109 @@
     });
   }
 
-  function handleInteractive(): void {
+  function openInteractive(targetEndpointId = report.diagnosis.verdict.worstEpId): void {
     uiStore.setSharedReportMode(false);
-    const target = report.diagnosis.verdict.worstEpId;
-    if (target) {
-      uiStore.setFocusedEndpoint(target);
+    if (targetEndpointId) {
+      uiStore.setFocusedEndpoint(targetEndpointId);
       uiStore.setActiveView('diagnose');
     } else {
       uiStore.setActiveView('overview');
     }
   }
 
+  function handleInteractive(): void {
+    openInteractive();
+  }
+
   function handleRunOwn(): void {
     uiStore.clearSharedView();
     uiStore.setAutoStartSuppressionReason(null);
     measurementStore.reset();
+  }
+
+  function scrollToBrowserVisibility(): void {
+    browserVisibilityPanel?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    browserVisibilityPanel?.focus({ preventScroll: true });
+  }
+
+  function openSettingsWorkflow(action: DiagnosticTriageAction): void {
+    if (action.endpointId) uiStore.setFocusedEndpoint(action.endpointId);
+    if (!get(uiStore).showSettings) uiStore.toggleSettings();
+  }
+
+  function openShareWorkflow(): void {
+    if (!get(uiStore).showShare) uiStore.toggleShare();
+  }
+
+  async function handleTriageAction(action: DiagnosticTriageAction): Promise<void> {
+    switch (action.id) {
+      case 'review-browser-visibility':
+        scrollToBrowserVisibility();
+        return;
+      case 'open-investigate':
+        openInteractive(action.endpointId);
+        return;
+      case 'run-remote-check':
+        await remoteVantageStore.runProbe(get(endpointStore));
+        return;
+      case 'run-local-agent':
+        openSettingsWorkflow(action);
+        return;
+      case 'share-support-report':
+      case 'share-snapshot':
+      case 'compare-another-network':
+        openShareWorkflow();
+        return;
+      case 'collect-more-samples':
+      case 'keep-running':
+        handleRunOwn();
+        return;
+    }
+  }
+
+  function remoteOutcome(): TriageOutcome {
+    if (remoteBusy) return { label: 'Running', tone: 'watch', disabled: true };
+    if (remoteVantage.lastProbe) {
+      const hasProblem = remoteVantage.lastProbe.results.some((result) => (
+        result.verdict === 'slow' ||
+        result.verdict === 'http-error' ||
+        result.verdict === 'unreachable'
+      ));
+      return { label: 'Captured', tone: hasProblem ? 'bad' : 'good' };
+    }
+    if (remoteVantage.error) return { label: 'Failed', tone: 'watch' };
+    return { label: 'Not run', tone: 'neutral' };
+  }
+
+  function localAgentOutcome(): TriageOutcome {
+    if (companionBusy) return { label: 'Running', tone: 'watch', disabled: true };
+    if (companion.lastProbe) return { label: 'Captured', tone: companion.lastProbe.ok ? 'good' : 'watch' };
+    if (companion.status === 'connected') return { label: 'Ready', tone: 'neutral' };
+    if (companion.error) return { label: 'Needs setup', tone: 'watch' };
+    return { label: 'Not run', tone: 'neutral' };
+  }
+
+  function triageOutcome(action: DiagnosticTriageAction): TriageOutcome {
+    switch (action.id) {
+      case 'review-browser-visibility':
+        return { label: report.diagnosis.timingVisibility.level === 'phase' ? 'Detailed' : 'Review', tone: 'neutral' };
+      case 'open-investigate':
+        return { label: action.endpointId ? 'Ready' : 'No target', tone: action.endpointId ? 'good' : 'watch' };
+      case 'run-remote-check':
+        return remoteOutcome();
+      case 'run-local-agent':
+        return localAgentOutcome();
+      case 'share-support-report':
+      case 'share-snapshot':
+        if (copiedLink) return { label: 'Link copied', tone: 'good' };
+        if (copyError === 'link') return { label: 'Copy failed', tone: 'watch' };
+        return { label: 'Share', tone: 'neutral' };
+      case 'compare-another-network':
+        return { label: 'Share config', tone: 'neutral' };
+      case 'collect-more-samples':
+      case 'keep-running':
+        return { label: 'Run locally', tone: 'neutral' };
+    }
   }
 </script>
 
@@ -198,17 +304,41 @@
     </div>
   </section>
 
+  <section class="evidence-trail" aria-label="Evidence trail">
+    <div class="section-kicker">Evidence trail</div>
+    <div class="trail-list">
+      {#each evidenceTrail as item (item.id)}
+        <article class="trail-item" class:good={item.tone === 'good'} class:watch={item.tone === 'watch'} class:bad={item.tone === 'bad'}>
+          <div class="trail-source">{item.source}</div>
+          <p>{item.fact}</p>
+          <span>{item.status}</span>
+        </article>
+      {/each}
+    </div>
+  </section>
+
   <section class="next-steps" aria-label="Recommended next steps">
     <div class="section-kicker">What to try next</div>
     <div class="triage-grid">
       {#each report.diagnosis.triageActions as action, i (action.id)}
+        {@const outcome = triageOutcome(action)}
         <article class="triage-card">
           <div class="triage-index">{i + 1}</div>
-          <div>
-            <h2>{action.label}</h2>
+          <div class="triage-body">
+            <div class="triage-head">
+              <h2>{action.label}</h2>
+              <span class="triage-status" class:good={outcome.tone === 'good'} class:watch={outcome.tone === 'watch'} class:bad={outcome.tone === 'bad'}>{outcome.label}</span>
+            </div>
             <p class="triage-action">{action.action}</p>
             <p>{action.why}</p>
             <p class="triage-watch"><strong>Watch for:</strong> {action.watchFor}</p>
+            <button
+              type="button"
+              class="triage-button"
+              disabled={outcome.disabled}
+              aria-disabled={outcome.disabled}
+              onclick={() => handleTriageAction(action)}
+            >{action.label}</button>
           </div>
         </article>
       {/each}
@@ -231,7 +361,12 @@
       </div>
     </section>
 
-    <section class="report-panel" aria-label="Browser visibility">
+    <section
+      class="report-panel"
+      aria-label="Browser visibility"
+      bind:this={browserVisibilityPanel}
+      tabindex="-1"
+    >
       <div class="section-kicker">Browser visibility</div>
       <h2>{report.diagnosis.timingVisibility.headline}</h2>
       <p>{report.diagnosis.timingVisibility.detail}</p>
@@ -456,6 +591,68 @@
     font-variant-numeric: tabular-nums;
   }
 
+  .evidence-trail {
+    margin-bottom: 18px;
+    border: 1px solid var(--border-mid);
+    border-radius: 8px;
+    background: rgba(12,10,20,.58);
+    padding: 14px;
+  }
+  .trail-list {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 8px;
+    margin-top: 10px;
+  }
+  .trail-item {
+    min-width: 0;
+    display: grid;
+    grid-template-rows: auto minmax(42px, auto) auto;
+    gap: 6px;
+    padding: 10px;
+    border: 1px solid rgba(255,255,255,.07);
+    border-radius: 7px;
+    background: rgba(255,255,255,.03);
+  }
+  .trail-item.good {
+    border-color: rgba(74,222,128,.18);
+    background: rgba(74,222,128,.045);
+  }
+  .trail-item.watch {
+    border-color: rgba(251,191,36,.18);
+    background: rgba(251,191,36,.045);
+  }
+  .trail-item.bad {
+    border-color: rgba(249,168,212,.2);
+    background: rgba(249,168,212,.05);
+  }
+  .trail-source {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--t3);
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    text-transform: uppercase;
+  }
+  .trail-item p {
+    margin: 0;
+    color: var(--t2);
+    font-size: var(--ts-sm);
+    line-height: 1.35;
+  }
+  .trail-item span {
+    justify-self: start;
+    padding: 3px 7px;
+    border: 1px solid rgba(255,255,255,.1);
+    border-radius: 999px;
+    color: var(--t3);
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    white-space: nowrap;
+  }
+
   .report-grid {
     display: grid;
     grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
@@ -676,6 +873,19 @@
     border: 1px solid rgba(255,255,255,.07);
     background: rgba(255,255,255,.035);
   }
+  .triage-body {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+  .triage-head {
+    min-width: 0;
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 10px;
+  }
   .triage-index {
     width: 24px;
     height: 24px;
@@ -693,6 +903,31 @@
     margin-top: 0;
     font-size: var(--ts-base);
   }
+  .triage-status {
+    flex: 0 0 auto;
+    padding: 3px 7px;
+    border-radius: 999px;
+    border: 1px solid rgba(255,255,255,.1);
+    color: var(--t3);
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    white-space: nowrap;
+  }
+  .triage-status.good {
+    color: var(--accent-green);
+    border-color: rgba(74,222,128,.25);
+    background: rgba(74,222,128,.07);
+  }
+  .triage-status.watch {
+    color: var(--accent-amber);
+    border-color: rgba(251,191,36,.25);
+    background: rgba(251,191,36,.07);
+  }
+  .triage-status.bad {
+    color: var(--accent-pink);
+    border-color: rgba(249,168,212,.28);
+    background: rgba(249,168,212,.08);
+  }
   .triage-card p {
     margin: 6px 0 0;
     color: var(--t3);
@@ -703,6 +938,32 @@
   }
   .triage-watch strong {
     color: var(--t2);
+  }
+  .triage-button {
+    align-self: flex-start;
+    min-height: 34px;
+    margin-top: 12px;
+    border-radius: 7px;
+    border: 1px solid rgba(103,232,249,.24);
+    background: rgba(103,232,249,.07);
+    color: var(--accent-cyan);
+    padding: 0 11px;
+    font-family: var(--sans);
+    font-size: var(--ts-sm);
+    cursor: pointer;
+  }
+  .triage-button:hover:not(:disabled) {
+    border-color: rgba(103,232,249,.42);
+    color: var(--t1);
+  }
+  .triage-button:disabled {
+    cursor: not-allowed;
+    opacity: .55;
+  }
+
+  [aria-label="Browser visibility"]:focus {
+    outline: 1px solid rgba(103,232,249,.45);
+    outline-offset: 3px;
   }
 
   @media (max-width: 900px) {
@@ -716,6 +977,9 @@
     .report-strip,
     .report-grid {
       grid-template-columns: 1fr;
+    }
+    .trail-list {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
     .evidence-grid {
       grid-template-columns: 1fr;
@@ -740,6 +1004,15 @@
       flex-direction: column;
     }
     .action {
+      width: 100%;
+    }
+    .trail-list {
+      grid-template-columns: 1fr;
+    }
+    .triage-head {
+      flex-direction: column;
+    }
+    .triage-button {
       width: 100%;
     }
     h1 {

--- a/src/lib/utils/evidence-trail.ts
+++ b/src/lib/utils/evidence-trail.ts
@@ -1,0 +1,210 @@
+import type { CompanionState } from '../stores/companion';
+import type { RemoteVantageState } from '../stores/remote-vantage';
+import type { DiagnosticReport } from './diagnostic-report';
+
+export type EvidenceTrailTone = 'good' | 'watch' | 'bad' | 'neutral';
+
+export interface EvidenceTrailItem {
+  readonly id:
+    | 'browser-run'
+    | 'current-answer'
+    | 'browser-visibility'
+    | 'outside-check'
+    | 'local-agent';
+  readonly source: string;
+  readonly fact: string;
+  readonly status: string;
+  readonly tone: EvidenceTrailTone;
+  readonly detail?: string;
+}
+
+interface EvidenceTrailInput {
+  readonly report: DiagnosticReport;
+  readonly remoteVantage: Pick<RemoteVantageState, 'status' | 'lastProbe' | 'error'>;
+  readonly companion: Pick<CompanionState, 'status' | 'lastProbe' | 'error' | 'hasSecret'>;
+}
+
+const MAX_FACT_LENGTH = 96;
+
+function truncateFact(text: string): string {
+  if (text.length <= MAX_FACT_LENGTH) return text;
+  return `${text.slice(0, MAX_FACT_LENGTH - 1).trimEnd()}...`;
+}
+
+function plural(count: number, singular: string, pluralForm = `${singular}s`): string {
+  return count === 1 ? singular : pluralForm;
+}
+
+function edgeLabel(edge: { readonly colo?: string; readonly city?: string; readonly country?: string }): string {
+  const parts = [edge.colo, edge.city, edge.country].filter(Boolean);
+  return parts.length > 0 ? parts.join(' / ') : 'Cloudflare edge';
+}
+
+function statusToneForSeverity(severity: DiagnosticReport['diagnosis']['severity']): EvidenceTrailTone {
+  switch (severity) {
+    case 'healthy':
+      return 'good';
+    case 'degraded':
+      return 'bad';
+    case 'watch':
+      return 'watch';
+  }
+}
+
+function visibilityStatus(level: DiagnosticReport['diagnosis']['timingVisibility']['level']): string {
+  switch (level) {
+    case 'phase':
+      return 'Detailed';
+    case 'mixed':
+      return 'Partial';
+    case 'total-only':
+      return 'Total only';
+    case 'none':
+      return 'Waiting';
+  }
+}
+
+function visibilityTone(level: DiagnosticReport['diagnosis']['timingVisibility']['level']): EvidenceTrailTone {
+  return level === 'phase' ? 'good' : level === 'none' ? 'watch' : 'neutral';
+}
+
+function confidenceStatus(confidence: DiagnosticReport['diagnosis']['confidence']): string {
+  return confidence.charAt(0).toUpperCase() + confidence.slice(1);
+}
+
+function remoteTrail(remoteVantage: EvidenceTrailInput['remoteVantage']): EvidenceTrailItem {
+  if (remoteVantage.lastProbe) {
+    const results = remoteVantage.lastProbe.results;
+    const problemCount = results.filter((result) => (
+      result.verdict === 'slow' ||
+      result.verdict === 'http-error' ||
+      result.verdict === 'unreachable'
+    )).length;
+    const edge = edgeLabel(remoteVantage.lastProbe.edge);
+    return {
+      id: 'outside-check',
+      source: 'Outside check',
+      fact: truncateFact(problemCount > 0
+        ? `${problemCount}/${results.length} ${plural(results.length, 'endpoint')} were slow or failed from ${edge}`
+        : `Cloudflare reached ${results.length} ${plural(results.length, 'endpoint')} without slow or failed results`),
+      status: 'Captured',
+      tone: problemCount > 0 ? 'bad' : 'good',
+      detail: `Checked from ${edge}.`,
+    };
+  }
+
+  if (remoteVantage.status === 'probing' || remoteVantage.status === 'checking') {
+    return {
+      id: 'outside-check',
+      source: 'Outside check',
+      fact: 'Cloudflare outside check is running now.',
+      status: 'Running',
+      tone: 'watch',
+    };
+  }
+
+  if (remoteVantage.error) {
+    return {
+      id: 'outside-check',
+      source: 'Outside check',
+      fact: 'Outside check did not complete.',
+      status: 'Failed',
+      tone: 'watch',
+      detail: truncateFact(remoteVantage.error),
+    };
+  }
+
+  return {
+    id: 'outside-check',
+    source: 'Outside check',
+    fact: 'No Cloudflare outside check captured.',
+    status: 'Not run',
+    tone: 'neutral',
+  };
+}
+
+function companionTrail(companion: EvidenceTrailInput['companion']): EvidenceTrailItem {
+  if (companion.lastProbe) {
+    return {
+      id: 'local-agent',
+      source: 'Local agent',
+      fact: truncateFact(`${companion.lastProbe.targetHost}: ${companion.lastProbe.summary}`),
+      status: 'Captured',
+      tone: companion.lastProbe.ok ? 'good' : 'watch',
+    };
+  }
+
+  if (companion.status === 'probing' || companion.status === 'checking') {
+    return {
+      id: 'local-agent',
+      source: 'Local agent',
+      fact: 'Local agent probe is running now.',
+      status: 'Running',
+      tone: 'watch',
+    };
+  }
+
+  if (companion.status === 'connected') {
+    return {
+      id: 'local-agent',
+      source: 'Local agent',
+      fact: 'Local agent connected; no probe captured in this report.',
+      status: 'Ready',
+      tone: 'neutral',
+    };
+  }
+
+  if (companion.error) {
+    return {
+      id: 'local-agent',
+      source: 'Local agent',
+      fact: 'Local agent proof is not captured.',
+      status: companion.hasSecret ? 'Needs check' : 'Needs setup',
+      tone: 'watch',
+      detail: truncateFact(companion.error),
+    };
+  }
+
+  return {
+    id: 'local-agent',
+    source: 'Local agent',
+    fact: 'No local agent probe captured.',
+    status: 'Not run',
+    tone: 'neutral',
+  };
+}
+
+export function buildEvidenceTrail(input: EvidenceTrailInput): EvidenceTrailItem[] {
+  const { report } = input;
+  const enabledRows = report.endpointRows.filter((row) => row.enabled);
+  const sampleStatus = report.keptSampleCount > 0 ? 'Measured' : 'Collecting';
+  const sampleTone: EvidenceTrailTone = report.keptSampleCount > 0 ? 'good' : 'watch';
+
+  return [
+    {
+      id: 'browser-run',
+      source: 'Browser test',
+      fact: truncateFact(`${report.keptSampleCount} ${plural(report.keptSampleCount, 'sample')} kept across ${enabledRows.length} enabled ${plural(enabledRows.length, 'site')}`),
+      status: sampleStatus,
+      tone: sampleTone,
+    },
+    {
+      id: 'current-answer',
+      source: 'Current answer',
+      fact: truncateFact(report.diagnosis.primaryAnswer.text),
+      status: confidenceStatus(report.diagnosis.confidence),
+      tone: statusToneForSeverity(report.diagnosis.severity),
+      detail: truncateFact(report.diagnosis.confidenceReason),
+    },
+    {
+      id: 'browser-visibility',
+      source: 'Browser visibility',
+      fact: truncateFact(report.diagnosis.timingVisibility.headline),
+      status: visibilityStatus(report.diagnosis.timingVisibility.level),
+      tone: visibilityTone(report.diagnosis.timingVisibility.level),
+      detail: truncateFact(report.diagnosis.timingVisibility.detail),
+    },
+    remoteTrail(input.remoteVantage),
+    companionTrail(input.companion),
+  ];
+}

--- a/tests/unit/components/report-view-actions.test.ts
+++ b/tests/unit/components/report-view-actions.test.ts
@@ -1,0 +1,157 @@
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ReportView from '../../../src/lib/components/ReportView.svelte';
+import { endpointStore } from '../../../src/lib/stores/endpoints';
+import { measurementStore } from '../../../src/lib/stores/measurements';
+import { resetStatisticsCache } from '../../../src/lib/stores/statistics';
+import { uiStore } from '../../../src/lib/stores/ui';
+import type { Endpoint, MeasurementSample, MeasurementState } from '../../../src/lib/types';
+
+const mocks = vi.hoisted(() => ({
+  historyUnsubscribe: vi.fn(),
+  remoteUnsubscribe: vi.fn(),
+  runProbe: vi.fn(),
+  createHostedReport: vi.fn<() => Promise<null>>().mockResolvedValue(null),
+}));
+
+vi.mock('$lib/stores/history', () => ({
+  historyStore: {
+    subscribe(run: (state: { sessions: readonly unknown[] }) => void): () => void {
+      run({ sessions: [] });
+      return mocks.historyUnsubscribe;
+    },
+  },
+}));
+
+vi.mock('$lib/stores/remote-vantage', () => ({
+  remoteVantageStore: {
+    subscribe(run: (state: { status: 'idle'; lastProbe: null; error: null }) => void): () => void {
+      run({ status: 'idle', lastProbe: null, error: null });
+      return mocks.remoteUnsubscribe;
+    },
+    runProbe: mocks.runProbe,
+    createHostedReport: mocks.createHostedReport,
+  },
+}));
+
+function endpoint(id: string, label = id): Endpoint {
+  return {
+    id,
+    label,
+    url: `https://${id}.example.com`,
+    enabled: true,
+    color: '#67e8f9',
+  };
+}
+
+function samples(latency: number): MeasurementSample[] {
+  return Array.from({ length: 35 }, (_, index) => ({
+    round: index + 1,
+    latency,
+    status: 'ok' as const,
+    timestamp: index + 1,
+  }));
+}
+
+function seedIsolatedReport(): Endpoint[] {
+  const endpoints = [
+    endpoint('api', 'API'),
+    endpoint('google', 'Google'),
+    endpoint('cloudflare', 'Cloudflare'),
+  ];
+  endpointStore.setEndpoints(endpoints);
+  measurementStore.loadSnapshot({
+    lifecycle: 'completed',
+    epoch: 1,
+    roundCounter: 35,
+    startedAt: null,
+    stoppedAt: null,
+    freezeEvents: [],
+    errorCount: 0,
+    timeoutCount: 0,
+    endpoints: {
+      api: {
+        endpointId: 'api',
+        tierLevel: 1,
+        lastLatency: 240,
+        lastStatus: 'ok',
+        lastErrorMessage: null,
+        samples: samples(240),
+      },
+      google: {
+        endpointId: 'google',
+        tierLevel: 1,
+        lastLatency: 45,
+        lastStatus: 'ok',
+        lastErrorMessage: null,
+        samples: samples(45),
+      },
+      cloudflare: {
+        endpointId: 'cloudflare',
+        tierLevel: 1,
+        lastLatency: 38,
+        lastStatus: 'ok',
+        lastErrorMessage: null,
+        samples: samples(38),
+      },
+    },
+  } satisfies MeasurementState);
+  uiStore.setSharedView(true);
+  uiStore.setSharedReportMode(true);
+  return endpoints;
+}
+
+describe('ReportView triage actions', () => {
+  beforeEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    endpointStore.setEndpoints([]);
+    measurementStore.reset();
+    resetStatisticsCache();
+    uiStore.reset();
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('opens Investigate on the implicated endpoint from the triage card', async () => {
+    seedIsolatedReport();
+    const { getByRole } = render(ReportView);
+
+    await fireEvent.click(getByRole('button', { name: /inspect slow moments/i }));
+
+    expect(get(uiStore).sharedReportMode).toBe(false);
+    expect(get(uiStore).activeView).toBe('diagnose');
+    expect(get(uiStore).focusedEndpointId).toBe('api');
+  });
+
+  it('runs the Cloudflare outside check from the triage card', async () => {
+    const endpoints = seedIsolatedReport();
+    mocks.runProbe.mockResolvedValue(null);
+    const { getByRole } = render(ReportView);
+
+    await fireEvent.click(getByRole('button', { name: /run outside check/i }));
+
+    await waitFor(() => {
+      expect(mocks.runProbe).toHaveBeenCalledWith(endpoints);
+    });
+  });
+
+  it('scrolls to browser visibility from the triage card', async () => {
+    seedIsolatedReport();
+    const { getByRole } = render(ReportView);
+
+    await fireEvent.click(getByRole('button', { name: /check visibility/i }));
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'start',
+    });
+  });
+});

--- a/tests/unit/utils/evidence-trail.test.ts
+++ b/tests/unit/utils/evidence-trail.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from 'vitest';
+import { buildEvidenceTrail } from '../../../src/lib/utils/evidence-trail';
+import { buildDiagnosticReport } from '../../../src/lib/utils/diagnostic-report';
+import { DEFAULT_SETTINGS } from '../../../src/lib/types';
+import type {
+  Endpoint,
+  EndpointStatistics,
+  MeasurementSample,
+  MeasurementState,
+  SampleBuffer,
+  SharedReportContext,
+} from '../../../src/lib/types';
+import type { CompanionState } from '../../../src/lib/stores/companion';
+import type { RemoteVantageState } from '../../../src/lib/stores/remote-vantage';
+
+function endpoint(id: string, label = id): Endpoint {
+  return {
+    id,
+    label,
+    url: `https://${id}.example.test`,
+    enabled: true,
+    color: '#67e8f9',
+  };
+}
+
+function stats(over: Partial<EndpointStatistics> = {}): EndpointStatistics {
+  return {
+    endpointId: over.endpointId ?? 'ep',
+    sampleCount: 35,
+    p50: 50,
+    p95: 70,
+    p99: 90,
+    p25: 40,
+    p75: 60,
+    p90: 65,
+    min: 35,
+    max: 95,
+    stddev: 5,
+    ci95: { lower: 45, upper: 55, margin: 5 },
+    connectionReuseDelta: null,
+    lossPercent: 0,
+    ready: true,
+    ...over,
+  };
+}
+
+function ok(round: number, latency = 50): MeasurementSample {
+  return {
+    round,
+    latency,
+    status: 'ok',
+    timestamp: 0,
+  };
+}
+
+function buffer(samples: readonly MeasurementSample[]): SampleBuffer {
+  return {
+    length: samples.length,
+    tailIndex: samples.length,
+    at: (index: number) => samples[index],
+    filter: samples.filter.bind(samples),
+    map: samples.map.bind(samples),
+    find: samples.find.bind(samples),
+    reduce: samples.reduce.bind(samples) as SampleBuffer['reduce'],
+    slice: samples.slice.bind(samples),
+    forEach: samples.forEach.bind(samples),
+    toArray: () => [...samples],
+    [Symbol.iterator]: samples[Symbol.iterator].bind(samples),
+  } as SampleBuffer;
+}
+
+function measurementState(samplesByEndpoint: Record<string, readonly MeasurementSample[]>): MeasurementState {
+  const endpoints: MeasurementState['endpoints'] = {};
+  for (const [endpointId, samples] of Object.entries(samplesByEndpoint)) {
+    const last = samples.at(-1);
+    endpoints[endpointId] = {
+      endpointId,
+      samples: buffer(samples),
+      lastLatency: last?.latency ?? null,
+      lastStatus: last?.status ?? null,
+      lastErrorMessage: null,
+      tierLevel: 1,
+    };
+  }
+  return {
+    lifecycle: 'completed',
+    epoch: 1,
+    roundCounter: 35,
+    endpoints,
+    startedAt: null,
+    stoppedAt: null,
+    freezeEvents: [],
+    errorCount: 0,
+    timeoutCount: 0,
+  };
+}
+
+const context: SharedReportContext = {
+  createdAt: 1778352000000,
+  healthThreshold: 120,
+  corsMode: 'no-cors',
+  roundCount: 35,
+  totalSampleCount: 105,
+  keptSampleCount: 105,
+  truncated: false,
+  sourceVersion: 2,
+};
+
+const emptyRemote: RemoteVantageState = {
+  status: 'idle',
+  health: null,
+  lastProbe: null,
+  hostedReport: null,
+  hostedReportFallback: null,
+  error: null,
+};
+
+const emptyCompanion: CompanionState = {
+  baseUrl: 'http://127.0.0.1:47317',
+  hasSecret: false,
+  status: 'idle',
+  version: null,
+  capabilities: null,
+  lastProbe: null,
+  history: [],
+  error: null,
+};
+
+function isolatedReport() {
+  const endpoints = [
+    endpoint('api', 'API'),
+    endpoint('google', 'Google'),
+    endpoint('cloudflare', 'Cloudflare'),
+  ];
+
+  return buildDiagnosticReport({
+    endpoints,
+    stats: {
+      api: stats({ endpointId: 'api', p50: 240, p95: 280 }),
+      google: stats({ endpointId: 'google', p50: 45, p95: 60 }),
+      cloudflare: stats({ endpointId: 'cloudflare', p50: 38, p95: 55 }),
+    },
+    measurements: measurementState({
+      api: Array.from({ length: 35 }, (_, i) => ok(i + 1, 240)),
+      google: Array.from({ length: 35 }, (_, i) => ok(i + 1, 45)),
+      cloudflare: Array.from({ length: 35 }, (_, i) => ok(i + 1, 38)),
+    }),
+    settings: DEFAULT_SETTINGS,
+    context,
+  });
+}
+
+describe('buildEvidenceTrail', () => {
+  it('builds a compact proof receipt without speculative language', () => {
+    const trail = buildEvidenceTrail({
+      report: isolatedReport(),
+      remoteVantage: emptyRemote,
+      companion: emptyCompanion,
+    });
+
+    expect(trail).toHaveLength(5);
+    expect(trail.map((item) => item.id)).toEqual([
+      'browser-run',
+      'current-answer',
+      'browser-visibility',
+      'outside-check',
+      'local-agent',
+    ]);
+    expect(trail.find((item) => item.id === 'browser-run')).toMatchObject({
+      source: 'Browser test',
+      status: 'Measured',
+      tone: 'good',
+    });
+    expect(trail.find((item) => item.id === 'outside-check')).toMatchObject({
+      source: 'Outside check',
+      status: 'Not run',
+      tone: 'neutral',
+    });
+
+    for (const item of trail) {
+      expect(item.source.length).toBeLessThanOrEqual(20);
+      expect(item.status.length).toBeLessThanOrEqual(18);
+      expect(item.fact.length).toBeLessThanOrEqual(96);
+      expect(item.fact).not.toMatch(/likely|probably|wild goose chase|router|ISP/i);
+    }
+  });
+
+  it('summarizes captured outside and local-agent evidence inline', () => {
+    const trail = buildEvidenceTrail({
+      report: isolatedReport(),
+      remoteVantage: {
+        ...emptyRemote,
+        status: 'connected',
+        lastProbe: {
+          ok: true,
+          generatedAt: 1778352000000,
+          edge: { colo: 'IAD', city: 'Ashburn', country: 'US' },
+          results: [
+            {
+              endpointId: 'api',
+              label: 'API',
+              url: 'https://api.example.test',
+              ok: true,
+              status: 200,
+              statusText: 'OK',
+              durationMs: 310,
+              checkedAt: 1778352000000,
+              verdict: 'slow',
+              headers: {},
+            },
+            {
+              endpointId: 'google',
+              label: 'Google',
+              url: 'https://google.example.test',
+              ok: true,
+              status: 200,
+              statusText: 'OK',
+              durationMs: 45,
+              checkedAt: 1778352000000,
+              verdict: 'reachable',
+              headers: {},
+            },
+          ],
+        },
+      },
+      companion: {
+        ...emptyCompanion,
+        status: 'connected',
+        lastProbe: {
+          ok: true,
+          id: 'probe-1',
+          targetHost: 'api.example.test',
+          createdAt: 1778352000000,
+          summary: 'DNS, TLS, route, and WiFi completed',
+          results: {},
+        },
+      },
+    });
+
+    expect(trail.find((item) => item.id === 'outside-check')).toMatchObject({
+      status: 'Captured',
+      tone: 'bad',
+      fact: '1/2 endpoints were slow or failed from IAD / Ashburn / US',
+    });
+    expect(trail.find((item) => item.id === 'local-agent')).toMatchObject({
+      status: 'Captured',
+      tone: 'good',
+      fact: 'api.example.test: DNS, TLS, route, and WiFi completed',
+    });
+  });
+});

--- a/tests/visual/ac-verification.spec.ts
+++ b/tests/visual/ac-verification.spec.ts
@@ -298,10 +298,15 @@ test.describe('Acceptance criteria verification', () => {
     await expect(page.getByText(/medium confidence|high confidence/i)).toBeVisible();
     await expect(page.getByRole('button', { name: /Open Interactive Analysis/i })).toBeVisible();
     await expect(page.getByRole('table', { name: /Endpoint report table/i })).toContainText('inspect');
+    await expect(page.getByRole('region', { name: /Evidence trail/i })).toContainText('Browser test');
+    await expect(page.getByRole('region', { name: /Evidence trail/i })).toContainText('Outside check');
     await expect(page.getByText(/Timing-Allow-Origin/i)).toBeVisible();
     await expect(page.getByText('What to try next')).toBeVisible();
     await expect(page.getByText('Review what the browser can and cannot see.')).toBeVisible();
     await expect(page.getByText('Run a remote check for api.example.com.')).toBeVisible();
+    await expect(page.getByRole('button', { name: /Check visibility/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Inspect slow moments/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Run outside check/i })).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds a compact evidence trail to shared diagnostic reports so measured facts, browser limits, outside checks, and local-agent proof are visible without speculation.
- Turns report triage cards into executable actions for browser visibility, Investigate, Cloudflare outside checks, local-agent setup, and share/compare workflows.
- Shows inline action outcomes and expands unit plus Playwright coverage for the new report behavior.

## Validation
- npm run typecheck
- npm run lint
- npm test -- --run
- npm run build
- npm run test:visual -- tests/visual/ac-verification.spec.ts
- Manual Playwright screenshot/overflow pass at 1440px and 375px shared-report view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Evidence trail section displaying diagnostic findings and captured probe results
  * Added triage action buttons for guided next steps (visibility checks, performance inspection, probe execution)

* **Style**
  * Enhanced styling for evidence trail cards, triage buttons, and responsive layouts

* **Tests**
  * Added test coverage for triage actions and evidence trail functionality

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xaedyn/chronoscope/pull/116)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->