### PR TITLE
[codex] Add remote proof loop

### DIFF
--- a/src/lib/components/DiagnoseView.svelte
+++ b/src/lib/components/DiagnoseView.svelte
@@ -230,7 +230,7 @@
   }
 
   async function handleRemoteCheck(): Promise<void> {
-    await remoteVantageStore.runProbe(monitored);
+    await remoteVantageStore.runProbe(focusedEndpoint ? [focusedEndpoint] : monitored);
   }
 
   // ── Accessibility summary for the hero bar ────────────────────────────────

--- a/src/lib/components/ReportView.svelte
+++ b/src/lib/components/ReportView.svelte
@@ -15,6 +15,7 @@
   import { buildDiagnosticReport, formatReportMetric } from '$lib/utils/diagnostic-report';
   import { buildEvidenceTrail } from '$lib/utils/evidence-trail';
   import { buildHistoryBaselineInsight } from '$lib/utils/history-baseline';
+  import { buildProofActionState, summarizeLocalProof, summarizeRemoteProof } from '$lib/utils/proof-flow';
   import { tokens } from '$lib/tokens';
   import type { DiagnosticTriageAction } from '$lib/utils/diagnostic-narrative';
 
@@ -199,25 +200,28 @@
   }
 
   function remoteOutcome(): TriageOutcome {
-    if (remoteBusy) return { label: 'Running', tone: 'watch', disabled: true };
-    if (remoteVantage.lastProbe) {
-      const hasProblem = remoteVantage.lastProbe.results.some((result) => (
-        result.verdict === 'slow' ||
-        result.verdict === 'http-error' ||
-        result.verdict === 'unreachable'
-      ));
-      return { label: 'Captured', tone: hasProblem ? 'bad' : 'good' };
-    }
-    if (remoteVantage.error) return { label: 'Failed', tone: 'watch' };
-    return { label: 'Not run', tone: 'neutral' };
+    const state = buildProofActionState({
+      kind: 'remote',
+      status: remoteVantage.status,
+      hasProof: Boolean(remoteVantage.lastProbe),
+      hasError: Boolean(remoteVantage.error),
+    });
+    if (remoteBusy || !remoteVantage.lastProbe) return state;
+    return { ...state, tone: summarizeRemoteProof(remoteVantage.lastProbe).tone };
   }
 
   function localAgentOutcome(): TriageOutcome {
-    if (companionBusy) return { label: 'Running', tone: 'watch', disabled: true };
-    if (companion.lastProbe) return { label: 'Captured', tone: companion.lastProbe.ok ? 'good' : 'watch' };
-    if (companion.status === 'connected') return { label: 'Ready', tone: 'neutral' };
-    if (companion.error) return { label: 'Needs setup', tone: 'watch' };
-    return { label: 'Not run', tone: 'neutral' };
+    const state = buildProofActionState({
+      kind: 'local',
+      status: companion.status,
+      hasProof: Boolean(companion.lastProbe),
+      hasError: Boolean(companion.error),
+    });
+    if (companionBusy || !companion.lastProbe) {
+      if (companion.status === 'connected') return { label: 'Ready', tone: 'neutral' };
+      return state;
+    }
+    return { ...state, tone: summarizeLocalProof(companion.lastProbe).tone };
   }
 
   function triageOutcome(action: DiagnosticTriageAction): TriageOutcome {

--- a/src/lib/components/ReportView.svelte
+++ b/src/lib/components/ReportView.svelte
@@ -216,6 +216,7 @@
       status: companion.status,
       hasProof: Boolean(companion.lastProbe),
       hasError: Boolean(companion.error),
+      hasSecret: companion.hasSecret,
     });
     if (companionBusy || !companion.lastProbe) {
       if (companion.status === 'connected') return { label: 'Ready', tone: 'neutral' };

--- a/src/lib/remote-vantage/insight.ts
+++ b/src/lib/remote-vantage/insight.ts
@@ -76,9 +76,9 @@ export function buildRemoteVantageInsight(input: RemoteVantageInsightInput): Rem
   if (browserSlow && !remoteSlow) {
     return {
       status: 'local-path',
-      headline: `Cloudflare reaches ${label} normally`,
-      detail: `${edge} reached it in ${fmtMs(result.durationMs)} while your browser-visible path has p50 ${fmtMs(browserP50 ?? 0)}.`,
-      action: 'Use the local companion agent or another network to narrow the local path.',
+      headline: `This outside check reached ${label} within threshold`,
+      detail: `${edge} measured ${fmtMs(result.durationMs)} while your browser p50 measured ${fmtMs(browserP50 ?? 0)}.`,
+      action: 'Use the local companion agent or another network to add local-path evidence.',
       edgeLabel: edge,
       result,
     };
@@ -87,7 +87,7 @@ export function buildRemoteVantageInsight(input: RemoteVantageInsightInput): Rem
   if (browserSlow && remoteSlow) {
     return {
       status: 'remote-confirms',
-      headline: `${label} is also slow from Cloudflare`,
+      headline: `${label} was also slow from Cloudflare`,
       detail: `${edge} took ${fmtMs(result.durationMs)} and your browser p50 is ${fmtMs(browserP50 ?? 0)}; both vantage points observed elevated latency.`,
       action: 'Share the report with the service owner; it now contains outside-vantage evidence.',
       edgeLabel: edge,
@@ -99,8 +99,8 @@ export function buildRemoteVantageInsight(input: RemoteVantageInsightInput): Rem
     return {
       status: 'remote-slow-only',
       headline: `${label} is slow from ${edge}, but not your browser`,
-      detail: `${edge} took ${fmtMs(result.durationMs)}${browserP50 !== null ? ` while your browser p50 is ${fmtMs(browserP50)}` : ''}, suggesting the outside edge path or origin may be inconsistent right now.`,
-      action: 'Run the check again or compare another outside vantage before drawing a local-path conclusion.',
+      detail: `Only the outside check was elevated in this snapshot${browserP50 !== null ? `; your browser p50 measured ${fmtMs(browserP50)}` : ''}.`,
+      action: 'Run the check again or compare another outside vantage before deciding what to inspect next.',
       edgeLabel: edge,
       result,
     };
@@ -108,8 +108,8 @@ export function buildRemoteVantageInsight(input: RemoteVantageInsightInput): Rem
 
   return {
     status: 'remote-normal',
-    headline: `${edge} reaches ${label} in ${fmtMs(result.durationMs)}`,
-    detail: 'The outside vantage is currently healthy for this endpoint.',
+    headline: `This outside check reached ${label} in ${fmtMs(result.durationMs)}`,
+    detail: 'This outside check was within threshold for this endpoint.',
     action: 'Keep the check available for intermittent issues or include it in a support report.',
     edgeLabel: edge,
     result,

--- a/src/lib/utils/evidence-trail.ts
+++ b/src/lib/utils/evidence-trail.ts
@@ -1,6 +1,7 @@
 import type { CompanionState } from '../stores/companion';
 import type { RemoteVantageState } from '../stores/remote-vantage';
 import type { DiagnosticReport } from './diagnostic-report';
+import { summarizeLocalProof, summarizeRemoteProof } from './proof-flow';
 
 export type EvidenceTrailTone = 'good' | 'watch' | 'bad' | 'neutral';
 
@@ -74,21 +75,17 @@ function confidenceStatus(confidence: DiagnosticReport['diagnosis']['confidence'
 
 function remoteTrail(remoteVantage: EvidenceTrailInput['remoteVantage']): EvidenceTrailItem {
   if (remoteVantage.lastProbe) {
-    const results = remoteVantage.lastProbe.results;
-    const problemCount = results.filter((result) => (
-      result.verdict === 'slow' ||
-      result.verdict === 'http-error' ||
-      result.verdict === 'unreachable'
-    )).length;
+    const summary = summarizeRemoteProof(remoteVantage.lastProbe);
+    const hasProblem = summary.tone === 'bad';
     const edge = edgeLabel(remoteVantage.lastProbe.edge);
     return {
       id: 'outside-check',
       source: 'Outside check',
-      fact: truncateFact(problemCount > 0
-        ? `${problemCount}/${results.length} ${plural(results.length, 'endpoint')} were slow or failed from ${edge}`
-        : `Cloudflare reached ${results.length} ${plural(results.length, 'endpoint')} without slow or failed results`),
-      status: 'Captured',
-      tone: problemCount > 0 ? 'bad' : 'good',
+      fact: truncateFact(hasProblem
+        ? summary.text.replace('from Cloudflare', `from ${edge}`)
+        : summary.text),
+      status: summary.status,
+      tone: summary.tone,
       detail: `Checked from ${edge}.`,
     };
   }
@@ -125,12 +122,13 @@ function remoteTrail(remoteVantage: EvidenceTrailInput['remoteVantage']): Eviden
 
 function companionTrail(companion: EvidenceTrailInput['companion']): EvidenceTrailItem {
   if (companion.lastProbe) {
+    const summary = summarizeLocalProof(companion.lastProbe);
     return {
       id: 'local-agent',
       source: 'Local agent',
-      fact: truncateFact(`${companion.lastProbe.targetHost}: ${companion.lastProbe.summary}`),
-      status: 'Captured',
-      tone: companion.lastProbe.ok ? 'good' : 'watch',
+      fact: truncateFact(summary.text),
+      status: summary.status,
+      tone: summary.tone,
     };
   }
 

--- a/src/lib/utils/proof-flow.ts
+++ b/src/lib/utils/proof-flow.ts
@@ -40,6 +40,12 @@ function plural(count: number, singular: string, pluralForm = `${singular}s`): s
   return count === 1 ? singular : pluralForm;
 }
 
+function countPhrase(count: number, total: number, singular: string): string {
+  return total === 1
+    ? `${count}/${total} ${singular}`
+    : `${count} of ${total} ${plural(total, singular)}`;
+}
+
 export function summarizeRemoteProof(probe: RemoteVantageProbeResponse | null): ProofSummary {
   if (!probe) {
     return {
@@ -57,9 +63,10 @@ export function summarizeRemoteProof(probe: RemoteVantageProbeResponse | null): 
   const endpointLabel = plural(probe.results.length, 'endpoint');
 
   if (problemCount > 0) {
+    const verb = problemCount === 1 ? 'was' : 'were';
     return {
       status: 'Captured',
-      text: `${problemCount}/${probe.results.length} ${endpointLabel} were slow or failed from Cloudflare`,
+      text: `${countPhrase(problemCount, probe.results.length, 'endpoint')} ${verb} slow or failed from Cloudflare`,
       tone: 'bad',
     };
   }
@@ -92,6 +99,7 @@ export function buildProofActionState(input: {
   readonly status: RemoteVantageStatus | CompanionStatus;
   readonly hasProof: boolean;
   readonly hasError: boolean;
+  readonly hasSecret?: boolean;
 }): ProofActionState {
   if (input.status === 'checking' || input.status === 'probing') {
     return { label: 'Running', tone: 'watch', disabled: true };
@@ -99,7 +107,9 @@ export function buildProofActionState(input: {
   if (input.hasProof) return { label: 'Captured', tone: 'good', disabled: false };
   if (input.hasError) {
     return {
-      label: input.kind === 'local' ? 'Needs setup' : 'Failed',
+      label: input.kind === 'local'
+        ? (input.hasSecret ? 'Needs check' : 'Needs setup')
+        : 'Failed',
       tone: 'watch',
       disabled: false,
     };

--- a/src/lib/utils/proof-flow.ts
+++ b/src/lib/utils/proof-flow.ts
@@ -1,0 +1,108 @@
+import type { CompanionProbeResponse } from '../companion/protocol';
+import type { RemoteVantageProbeResponse } from '../remote-vantage/types';
+import type { CompanionStatus } from '../stores/companion';
+import type { RemoteVantageStatus } from '../stores/remote-vantage';
+import type { EvidenceTrailTone } from './evidence-trail';
+
+export type ProofKind = 'remote' | 'local';
+
+export interface ProofSummary {
+  readonly status: string;
+  readonly text: string;
+  readonly tone: EvidenceTrailTone;
+  readonly detail?: string;
+}
+
+export interface ProofActionState {
+  readonly label: string;
+  readonly tone: EvidenceTrailTone;
+  readonly disabled: boolean;
+}
+
+export function isProofStale(input: {
+  readonly reportCreatedAt: number | null;
+  readonly proofGeneratedAt: number | null;
+}): boolean {
+  return input.reportCreatedAt !== null &&
+    input.proofGeneratedAt !== null &&
+    input.proofGeneratedAt < input.reportCreatedAt;
+}
+
+export function proofFreshnessLabel(input: {
+  readonly reportCreatedAt: number | null;
+  readonly proofGeneratedAt: number | null;
+}): string {
+  if (input.proofGeneratedAt === null) return 'Not run';
+  return isProofStale(input) ? 'Stale' : 'Fresh';
+}
+
+function plural(count: number, singular: string, pluralForm = `${singular}s`): string {
+  return count === 1 ? singular : pluralForm;
+}
+
+export function summarizeRemoteProof(probe: RemoteVantageProbeResponse | null): ProofSummary {
+  if (!probe) {
+    return {
+      status: 'Not run',
+      text: 'No Cloudflare outside check captured.',
+      tone: 'neutral',
+    };
+  }
+
+  const problemCount = probe.results.filter((result) => (
+    result.verdict === 'slow' ||
+    result.verdict === 'http-error' ||
+    result.verdict === 'unreachable'
+  )).length;
+  const endpointLabel = plural(probe.results.length, 'endpoint');
+
+  if (problemCount > 0) {
+    return {
+      status: 'Captured',
+      text: `${problemCount}/${probe.results.length} ${endpointLabel} were slow or failed from Cloudflare`,
+      tone: 'bad',
+    };
+  }
+
+  return {
+    status: 'Captured',
+    text: `Cloudflare reached ${probe.results.length} ${endpointLabel} without slow or failed results`,
+    tone: 'good',
+  };
+}
+
+export function summarizeLocalProof(probe: CompanionProbeResponse | null): ProofSummary {
+  if (!probe) {
+    return {
+      status: 'Not run',
+      text: 'No local agent probe captured.',
+      tone: 'neutral',
+    };
+  }
+
+  return {
+    status: 'Captured',
+    text: `${probe.targetHost}: ${probe.summary}`,
+    tone: probe.ok ? 'good' : 'watch',
+  };
+}
+
+export function buildProofActionState(input: {
+  readonly kind: ProofKind;
+  readonly status: RemoteVantageStatus | CompanionStatus;
+  readonly hasProof: boolean;
+  readonly hasError: boolean;
+}): ProofActionState {
+  if (input.status === 'checking' || input.status === 'probing') {
+    return { label: 'Running', tone: 'watch', disabled: true };
+  }
+  if (input.hasProof) return { label: 'Captured', tone: 'good', disabled: false };
+  if (input.hasError) {
+    return {
+      label: input.kind === 'local' ? 'Needs setup' : 'Failed',
+      tone: 'watch',
+      disabled: false,
+    };
+  }
+  return { label: 'Not run', tone: 'neutral', disabled: false };
+}

--- a/tests/unit/components/diagnose-view.test.ts
+++ b/tests/unit/components/diagnose-view.test.ts
@@ -1,6 +1,6 @@
-import { cleanup, render, waitFor } from '@testing-library/svelte';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import DiagnoseView from '../../../src/lib/components/DiagnoseView.svelte';
 import { endpointStore } from '../../../src/lib/stores/endpoints';
 import { measurementStore } from '../../../src/lib/stores/measurements';
@@ -114,6 +114,7 @@ describe('DiagnoseView investigation focus', () => {
 
   afterEach(() => {
     cleanup();
+    vi.restoreAllMocks();
   });
 
   it('auto-selects the helper-selected endpoint on direct investigate entry', async () => {
@@ -180,5 +181,22 @@ describe('DiagnoseView investigation focus', () => {
     expect(getByText(/phase timing unavailable/i)).toBeTruthy();
     expect(getAllByText(/total only/i).length).toBeGreaterThan(0);
     expect(getAllByText('80 ms').length).toBeGreaterThan(0);
+  });
+
+  it('runs an outside check for the focused endpoint from Investigate', async () => {
+    const api = endpoint('api', 'API');
+    const cdn = endpoint('cdn', 'CDN');
+    endpointStore.setEndpoints([api, cdn]);
+    seedReadySamples({ api: 260, cdn: 45 });
+    uiStore.setActiveView('diagnose');
+    uiStore.setFocusedEndpoint('api');
+    const runProbe = vi.spyOn(remoteVantageStore, 'runProbe').mockResolvedValue(null);
+    const { getByRole } = render(DiagnoseView);
+
+    await fireEvent.click(getByRole('button', { name: /check from cloudflare/i }));
+
+    await waitFor(() => {
+      expect(runProbe).toHaveBeenCalledWith([api]);
+    });
   });
 });

--- a/tests/unit/components/report-view-actions.test.ts
+++ b/tests/unit/components/report-view-actions.test.ts
@@ -7,13 +7,45 @@ import { measurementStore } from '../../../src/lib/stores/measurements';
 import { resetStatisticsCache } from '../../../src/lib/stores/statistics';
 import { uiStore } from '../../../src/lib/stores/ui';
 import type { Endpoint, MeasurementSample, MeasurementState } from '../../../src/lib/types';
+import type { RemoteVantageState } from '../../../src/lib/stores/remote-vantage';
 
-const mocks = vi.hoisted(() => ({
-  historyUnsubscribe: vi.fn(),
-  remoteUnsubscribe: vi.fn(),
-  runProbe: vi.fn(),
-  createHostedReport: vi.fn<() => Promise<null>>().mockResolvedValue(null),
-}));
+const mocks = vi.hoisted(() => {
+  const remoteSubscribers = new Set<(state: RemoteVantageState) => void>();
+  let remoteState = {
+    status: 'idle',
+    health: null,
+    lastProbe: null,
+    hostedReport: null,
+    hostedReportFallback: null,
+    error: null,
+  } as RemoteVantageState;
+  const remoteUnsubscribe = vi.fn();
+
+  return {
+    historyUnsubscribe: vi.fn(),
+    remoteUnsubscribe,
+    runProbe: vi.fn(),
+    createHostedReport: vi.fn<() => Promise<null>>().mockResolvedValue(null),
+    get remoteState(): RemoteVantageState {
+      return remoteState;
+    },
+    clearRemoteSubscribers(): void {
+      remoteSubscribers.clear();
+    },
+    setRemoteState(update: Partial<RemoteVantageState>): void {
+      remoteState = { ...remoteState, ...update };
+      for (const subscriber of remoteSubscribers) subscriber(remoteState);
+    },
+    subscribeRemote(run: (state: RemoteVantageState) => void): () => void {
+      remoteSubscribers.add(run);
+      run(remoteState);
+      return () => {
+        remoteSubscribers.delete(run);
+        remoteUnsubscribe();
+      };
+    },
+  };
+});
 
 vi.mock('$lib/stores/history', () => ({
   historyStore: {
@@ -26,10 +58,7 @@ vi.mock('$lib/stores/history', () => ({
 
 vi.mock('$lib/stores/remote-vantage', () => ({
   remoteVantageStore: {
-    subscribe(run: (state: { status: 'idle'; lastProbe: null; error: null }) => void): () => void {
-      run({ status: 'idle', lastProbe: null, error: null });
-      return mocks.remoteUnsubscribe;
-    },
+    subscribe: mocks.subscribeRemote,
     runProbe: mocks.runProbe,
     createHostedReport: mocks.createHostedReport,
   },
@@ -110,6 +139,15 @@ describe('ReportView triage actions', () => {
     measurementStore.reset();
     resetStatisticsCache();
     uiStore.reset();
+    mocks.clearRemoteSubscribers();
+    mocks.setRemoteState({
+      status: 'idle',
+      health: null,
+      lastProbe: null,
+      hostedReport: null,
+      hostedReportFallback: null,
+      error: null,
+    });
     Object.defineProperty(Element.prototype, 'scrollIntoView', {
       configurable: true,
       value: vi.fn(),
@@ -141,6 +179,42 @@ describe('ReportView triage actions', () => {
     await waitFor(() => {
       expect(mocks.runProbe).toHaveBeenCalledWith(endpoints);
     });
+  });
+
+  it('shows captured outside proof after a remote check resolves', async () => {
+    const endpoints = seedIsolatedReport();
+    mocks.runProbe.mockImplementation(() => {
+      mocks.setRemoteState({
+        status: 'connected',
+        lastProbe: {
+          ok: true,
+          generatedAt: 1778352005000,
+          edge: { colo: 'IAD', city: 'Ashburn', country: 'US' },
+          results: endpoints.map((ep) => ({
+            endpointId: ep.id,
+            label: ep.label,
+            url: ep.url,
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            durationMs: ep.id === 'api' ? 310 : 45,
+            checkedAt: 1778352005000,
+            verdict: ep.id === 'api' ? 'slow' : 'reachable',
+            headers: {},
+          })),
+        },
+      });
+      return Promise.resolve(mocks.remoteState.lastProbe);
+    });
+    const { getByRole, findAllByText } = render(ReportView);
+
+    await fireEvent.click(getByRole('button', { name: /run outside check/i }));
+
+    await waitFor(() => {
+      expect(mocks.runProbe).toHaveBeenCalledWith(endpoints);
+    });
+    expect((await findAllByText('Captured')).length).toBeGreaterThan(0);
+    expect(await findAllByText(/1\/3 endpoints were slow or failed/i)).toHaveLength(1);
   });
 
   it('scrolls to browser visibility from the triage card', async () => {

--- a/tests/unit/components/report-view-actions.test.ts
+++ b/tests/unit/components/report-view-actions.test.ts
@@ -214,7 +214,7 @@ describe('ReportView triage actions', () => {
       expect(mocks.runProbe).toHaveBeenCalledWith(endpoints);
     });
     expect((await findAllByText('Captured')).length).toBeGreaterThan(0);
-    expect(await findAllByText(/1\/3 endpoints were slow or failed/i)).toHaveLength(1);
+    expect(await findAllByText(/1 of 3 endpoints was slow or failed/i)).toHaveLength(1);
   });
 
   it('scrolls to browser visibility from the triage card', async () => {

--- a/tests/unit/remote-vantage/insight.test.ts
+++ b/tests/unit/remote-vantage/insight.test.ts
@@ -55,6 +55,10 @@ function remote(overrides: Partial<RemoteVantageProbeResponse['results'][number]
   };
 }
 
+function insightCopy(input: ReturnType<typeof buildRemoteVantageInsight>): string {
+  return [input.headline, input.detail, input.action].join(' ');
+}
+
 describe('buildRemoteVantageInsight', () => {
   it('calls out local-path suspicion when the browser is slow but Cloudflare is fast', () => {
     const insight = buildRemoteVantageInsight({
@@ -65,8 +69,8 @@ describe('buildRemoteVantageInsight', () => {
     });
 
     expect(insight.status).toBe('local-path');
-    expect(insight.headline).toContain('Cloudflare reaches API normally');
-    expect(insight.detail).toContain('browser-visible path');
+    expect(insight.headline).toContain('outside check reached API within threshold');
+    expect(insight.detail).toContain('browser p50 measured');
     expect(insight.detail).not.toMatch(/ISP|VPN|WiFi|local network/i);
   });
 
@@ -79,7 +83,7 @@ describe('buildRemoteVantageInsight', () => {
     });
 
     expect(insight.status).toBe('remote-confirms');
-    expect(insight.headline).toContain('also slow from Cloudflare');
+    expect(insight.headline).toContain('was also slow from Cloudflare');
     expect(insight.detail).not.toMatch(/implicated|likely/i);
   });
 
@@ -92,7 +96,7 @@ describe('buildRemoteVantageInsight', () => {
     });
 
     expect(insight.status).toBe('remote-slow-only');
-    expect(insight.detail).toContain('outside edge path');
+    expect(insight.detail).toContain('Only the outside check was elevated');
     expect(insight.action).not.toMatch(/blaming|likely/i);
   });
 
@@ -119,5 +123,40 @@ describe('buildRemoteVantageInsight', () => {
     expect(insight.status).toBe('remote-error');
     expect(insight.action).not.toMatch(/likely source/i);
     expect(insight.action).toContain('outside-vantage evidence');
+  });
+
+  it('keeps all outside-check states free of root-cause and overconfident wording', () => {
+    const states = [
+      buildRemoteVantageInsight({
+        endpoint,
+        stats: slowStats,
+        threshold: 120,
+        probe: remote({ durationMs: 48, verdict: 'reachable' }),
+      }),
+      buildRemoteVantageInsight({
+        endpoint,
+        stats: slowStats,
+        threshold: 120,
+        probe: remote({ durationMs: 410, verdict: 'slow' }),
+      }),
+      buildRemoteVantageInsight({
+        endpoint,
+        stats: { ...slowStats, p50: 80 },
+        threshold: 120,
+        probe: remote({ durationMs: 410, verdict: 'slow' }),
+      }),
+      buildRemoteVantageInsight({
+        endpoint,
+        stats: { ...slowStats, p50: 80 },
+        threshold: 120,
+        probe: remote({ durationMs: 48, verdict: 'reachable' }),
+      }),
+    ];
+
+    for (const insight of states) {
+      expect(insightCopy(insight)).not.toMatch(/origin|cause|likely|healthy|local network|ISP|VPN/i);
+      expect(insightCopy(insight)).not.toMatch(/reaches .* normally/i);
+      expect(insightCopy(insight)).not.toMatch(/outside edge path/i);
+    }
   });
 });

--- a/tests/unit/remote-vantage/insight.test.ts
+++ b/tests/unit/remote-vantage/insight.test.ts
@@ -151,6 +151,12 @@ describe('buildRemoteVantageInsight', () => {
         threshold: 120,
         probe: remote({ durationMs: 48, verdict: 'reachable' }),
       }),
+      buildRemoteVantageInsight({
+        endpoint,
+        stats: slowStats,
+        threshold: 120,
+        probe: remote({ ok: false, status: null, verdict: 'unreachable', durationMs: 5000 }),
+      }),
     ];
 
     for (const insight of states) {

--- a/tests/unit/utils/evidence-trail.test.ts
+++ b/tests/unit/utils/evidence-trail.test.ts
@@ -240,7 +240,7 @@ describe('buildEvidenceTrail', () => {
     expect(trail.find((item) => item.id === 'outside-check')).toMatchObject({
       status: 'Captured',
       tone: 'bad',
-      fact: '1/2 endpoints were slow or failed from IAD / Ashburn / US',
+      fact: '1 of 2 endpoints was slow or failed from IAD / Ashburn / US',
     });
     expect(trail.find((item) => item.id === 'local-agent')).toMatchObject({
       status: 'Captured',

--- a/tests/unit/utils/proof-flow.test.ts
+++ b/tests/unit/utils/proof-flow.test.ts
@@ -25,6 +25,15 @@ const cleanProbe: RemoteVantageProbeResponse = {
   }],
 };
 
+const slowProbe: RemoteVantageProbeResponse = {
+  ...cleanProbe,
+  results: [{
+    ...cleanProbe.results[0],
+    durationMs: 310,
+    verdict: 'slow',
+  }],
+};
+
 describe('proof-flow', () => {
   it('marks proof as stale when a report is newer than the captured proof', () => {
     expect(isProofStale({ reportCreatedAt: 2000, proofGeneratedAt: 1000 })).toBe(true);
@@ -42,6 +51,11 @@ describe('proof-flow', () => {
       tone: 'good',
       status: 'Captured',
       text: 'Cloudflare reached 1 endpoint without slow or failed results',
+    });
+    expect(summarizeRemoteProof(slowProbe)).toMatchObject({
+      tone: 'bad',
+      status: 'Captured',
+      text: '1/1 endpoint was slow or failed from Cloudflare',
     });
   });
 
@@ -63,6 +77,28 @@ describe('proof-flow', () => {
       hasError: true,
     })).toMatchObject({
       label: 'Failed',
+      disabled: false,
+      tone: 'watch',
+    });
+    expect(buildProofActionState({
+      kind: 'local',
+      status: 'error',
+      hasProof: false,
+      hasError: true,
+      hasSecret: false,
+    })).toMatchObject({
+      label: 'Needs setup',
+      disabled: false,
+      tone: 'watch',
+    });
+    expect(buildProofActionState({
+      kind: 'local',
+      status: 'error',
+      hasProof: false,
+      hasError: true,
+      hasSecret: true,
+    })).toMatchObject({
+      label: 'Needs check',
       disabled: false,
       tone: 'watch',
     });

--- a/tests/unit/utils/proof-flow.test.ts
+++ b/tests/unit/utils/proof-flow.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildProofActionState,
+  isProofStale,
+  proofFreshnessLabel,
+  summarizeRemoteProof,
+} from '../../../src/lib/utils/proof-flow';
+import type { RemoteVantageProbeResponse } from '../../../src/lib/remote-vantage/types';
+
+const cleanProbe: RemoteVantageProbeResponse = {
+  ok: true,
+  generatedAt: 1778352005000,
+  edge: { colo: 'IAD', city: 'Ashburn', country: 'US' },
+  results: [{
+    endpointId: 'api',
+    label: 'API',
+    url: 'https://api.example.com',
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    durationMs: 42,
+    checkedAt: 1778352005000,
+    verdict: 'reachable',
+    headers: {},
+  }],
+};
+
+describe('proof-flow', () => {
+  it('marks proof as stale when a report is newer than the captured proof', () => {
+    expect(isProofStale({ reportCreatedAt: 2000, proofGeneratedAt: 1000 })).toBe(true);
+    expect(isProofStale({ reportCreatedAt: 1000, proofGeneratedAt: 2000 })).toBe(false);
+  });
+
+  it('uses compact freshness labels', () => {
+    expect(proofFreshnessLabel({ reportCreatedAt: 2000, proofGeneratedAt: 1000 })).toBe('Stale');
+    expect(proofFreshnessLabel({ reportCreatedAt: 1000, proofGeneratedAt: 2000 })).toBe('Fresh');
+    expect(proofFreshnessLabel({ reportCreatedAt: 1000, proofGeneratedAt: null })).toBe('Not run');
+  });
+
+  it('summarizes outside proof without causal overclaiming', () => {
+    expect(summarizeRemoteProof(cleanProbe)).toMatchObject({
+      tone: 'good',
+      status: 'Captured',
+      text: 'Cloudflare reached 1 endpoint without slow or failed results',
+    });
+  });
+
+  it('maps running and failed actions to visible card states', () => {
+    expect(buildProofActionState({
+      kind: 'remote',
+      status: 'probing',
+      hasProof: false,
+      hasError: false,
+    })).toMatchObject({
+      label: 'Running',
+      disabled: true,
+      tone: 'watch',
+    });
+    expect(buildProofActionState({
+      kind: 'remote',
+      status: 'error',
+      hasProof: false,
+      hasError: true,
+    })).toMatchObject({
+      label: 'Failed',
+      disabled: false,
+      tone: 'watch',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a shared proof-flow contract for outside and local proof states across report actions and the evidence trail.
- Runs Cloudflare outside checks against the focused Investigate endpoint when one is selected.
- Tightens outside-check language so it reports measured facts without overclaiming root cause.

## Test Plan
- npm run typecheck
- npm run lint
- npm test
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote check now targets only the currently focused endpoint when one is selected.

* **Refactor**
  * Centralized proof summarization and action-state logic; unified messaging across diagnostic views and evidence trails.

* **Bug Fixes**
  * Tweaked user-facing insight and evidence wording for clarity and consistency.

* **Tests**
  * Expanded and updated unit tests to cover proof-flow logic, remote checks, and UI outcomes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xaedyn/chronoscope/pull/119)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->