### PR TITLE
[codex] Add focused local proof flow

### DIFF
--- a/src/lib/components/CompanionPanel.svelte
+++ b/src/lib/components/CompanionPanel.svelte
@@ -6,9 +6,15 @@
 
   interface Props {
     agentStore?: CompanionStore;
+    title?: string;
+    idPrefix?: string;
   }
 
-  let { agentStore = companionStore }: Props = $props();
+  let {
+    agentStore = companionStore,
+    title = 'Local Companion',
+    idPrefix = 'companion',
+  }: Props = $props();
 
   let agentUrl = $state(DEFAULT_COMPANION_BASE_URL);
   let pairingToken = $state('');
@@ -29,6 +35,10 @@
       ?? null,
   );
   const defaultProbeUrl = $derived(selectedEndpoint?.url ?? '');
+  const urlId = $derived(`${idPrefix}-url`);
+  const tokenId = $derived(`${idPrefix}-token`);
+  const probeUrlId = $derived(`${idPrefix}-probe-url`);
+  const titleId = $derived(`${idPrefix}-title`);
   const hasSelectedProbe = $derived(dnsProbe || tlsProbe || routeProbe || wifiProbe);
   const isBusy = $derived(state.status === 'checking' || state.status === 'probing');
   const statusLabel = $derived(({
@@ -97,16 +107,16 @@
   }
 </script>
 
-<section class="companion-panel" aria-labelledby="companion-title">
+<section class="companion-panel" aria-labelledby={titleId}>
   <div class="companion-head">
-    <h3 id="companion-title">Local Companion</h3>
+    <h3 id={titleId}>{title}</h3>
     <span class="status-pill" data-status={state.status}>{statusLabel}</span>
   </div>
 
-  <label class="field-line" for="companion-url">
+  <label class="field-line" for={urlId}>
     <span>Agent URL</span>
     <input
-      id="companion-url"
+      id={urlId}
       class="field-input"
       type="url"
       autocomplete="off"
@@ -115,10 +125,10 @@
     />
   </label>
 
-  <label class="field-line" for="companion-token">
+  <label class="field-line" for={tokenId}>
     <span>Pairing token</span>
     <input
-      id="companion-token"
+      id={tokenId}
       class="field-input"
       type="password"
       autocomplete="off"
@@ -157,10 +167,10 @@
   {/if}
 
   <div class="probe-block">
-    <label class="field-line" for="companion-probe-url">
+    <label class="field-line" for={probeUrlId}>
       <span>Probe URL</span>
       <input
-        id="companion-probe-url"
+        id={probeUrlId}
         class="field-input"
         type="url"
         autocomplete="off"

--- a/src/lib/components/LocalProofPanel.svelte
+++ b/src/lib/components/LocalProofPanel.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+  import CompanionPanel from './CompanionPanel.svelte';
+  import { endpointStore } from '$lib/stores/endpoints';
+  import { uiStore } from '$lib/stores/ui';
+
+  interface Props {
+    onOpenSettings?: () => void;
+    onClose?: () => void;
+  }
+
+  let { onOpenSettings, onClose }: Props = $props();
+
+  const selectedEndpoint = $derived(
+    $endpointStore.find((endpoint) => endpoint.id === $uiStore.focusedEndpointId)
+      ?? $endpointStore.find((endpoint) => endpoint.enabled)
+      ?? $endpointStore[0]
+      ?? null,
+  );
+  const targetLabel = $derived(selectedEndpoint?.label ?? 'selected endpoint');
+
+  function handleOpenSettings(): void {
+    onOpenSettings?.();
+  }
+
+  function handleClose(): void {
+    onClose?.();
+  }
+</script>
+
+<section class="local-proof-panel" aria-label="Focused local proof">
+  <div class="local-proof-head">
+    <div>
+      <div class="section-kicker">Local proof</div>
+      <h2>Focused local proof for {targetLabel}</h2>
+      <p>Capture DNS, route, TLS, and Wi-Fi evidence from this computer without changing the report verdict.</p>
+    </div>
+    <button type="button" class="quiet-button" onclick={handleClose}>Hide</button>
+  </div>
+
+  <CompanionPanel title="Local companion proof" idPrefix="local-proof-companion" />
+
+  <div class="local-proof-foot">
+    <span>Full settings are still available for defaults, reset actions, and advanced setup.</span>
+    <button type="button" class="secondary-button" onclick={handleOpenSettings}>Open full settings</button>
+  </div>
+</section>
+
+<style>
+  .local-proof-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin: 0 0 18px;
+    min-width: 0;
+  }
+
+  .local-proof-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 14px;
+    min-width: 0;
+  }
+
+  .local-proof-head h2 {
+    margin: 5px 0 0;
+    font-size: var(--ts-xl);
+    letter-spacing: 0;
+  }
+
+  .local-proof-head p {
+    margin: 7px 0 0;
+    color: var(--t2);
+    line-height: 1.45;
+  }
+
+  .section-kicker {
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    color: var(--t3);
+    letter-spacing: var(--tr-label);
+    text-transform: uppercase;
+  }
+
+  .local-proof-foot {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    color: var(--t3);
+    font-size: var(--ts-sm);
+    line-height: 1.35;
+  }
+
+  .quiet-button,
+  .secondary-button {
+    flex: 0 0 auto;
+    min-height: 34px;
+    border-radius: 8px;
+    border: 1px solid var(--border-mid);
+    background: rgba(255,255,255,.025);
+    color: var(--t2);
+    padding: 0 11px;
+    font-family: var(--sans);
+    font-size: var(--ts-sm);
+    cursor: pointer;
+  }
+
+  .secondary-button {
+    color: var(--accent-cyan);
+    border-color: rgba(103,232,249,.3);
+  }
+
+  .quiet-button:hover,
+  .secondary-button:hover {
+    color: var(--t1);
+    border-color: var(--border-bright);
+  }
+
+  @media (max-width: 640px) {
+    .local-proof-head,
+    .local-proof-foot {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .quiet-button,
+    .secondary-button {
+      width: 100%;
+    }
+  }
+</style>

--- a/src/lib/components/ReportView.svelte
+++ b/src/lib/components/ReportView.svelte
@@ -10,6 +10,7 @@
   import { uiStore } from '$lib/stores/ui';
   import { companionStore } from '$lib/stores/companion';
   import { remoteVantageStore } from '$lib/stores/remote-vantage';
+  import LocalProofPanel from './LocalProofPanel.svelte';
   import { buildShareURL } from '$lib/share/share-manager';
   import { buildResultsSharePayload, MAX_SHARE_URL_CHARS } from '$lib/share/share-payload-builder';
   import { buildDiagnosticReport, formatReportMetric } from '$lib/utils/diagnostic-report';
@@ -60,6 +61,7 @@
   let copiedSummary = $state(false);
   let copiedLink = $state(false);
   let copyError = $state<'summary' | 'link' | null>(null);
+  let localProofOpen = $state(false);
   let browserVisibilityPanel = $state<HTMLElement | null>(null);
 
   interface TriageOutcome {
@@ -164,9 +166,22 @@
     browserVisibilityPanel?.focus({ preventScroll: true });
   }
 
-  function openSettingsWorkflow(action: DiagnosticTriageAction): void {
-    if (action.endpointId) uiStore.setFocusedEndpoint(action.endpointId);
+  function openFullSettings(): void {
     if (!get(uiStore).showSettings) uiStore.toggleSettings();
+  }
+
+  function localProofEndpointId(action: DiagnosticTriageAction): string | null {
+    return action.endpointId
+      ?? report.diagnosis.verdict.worstEpId
+      ?? report.endpointRows.find((row) => row.implicated)?.endpointId
+      ?? endpoints.find((endpoint) => endpoint.enabled)?.id
+      ?? endpoints[0]?.id
+      ?? null;
+  }
+
+  function openLocalProofWorkflow(action: DiagnosticTriageAction): void {
+    uiStore.setFocusedEndpoint(localProofEndpointId(action));
+    localProofOpen = true;
   }
 
   function openShareWorkflow(): void {
@@ -185,7 +200,7 @@
         await remoteVantageStore.runProbe(get(endpointStore));
         return;
       case 'run-local-agent':
-        openSettingsWorkflow(action);
+        openLocalProofWorkflow(action);
         return;
       case 'share-support-report':
       case 'share-snapshot':
@@ -349,6 +364,10 @@
       {/each}
     </div>
   </section>
+
+  {#if localProofOpen}
+    <LocalProofPanel onOpenSettings={openFullSettings} onClose={() => { localProofOpen = false; }} />
+  {/if}
 
   <div class="report-grid">
     <section class="report-panel verdict-panel" aria-label="Verdict evidence">

--- a/tests/unit/components/report-view-actions.test.ts
+++ b/tests/unit/components/report-view-actions.test.ts
@@ -131,6 +131,54 @@ function seedIsolatedReport(): Endpoint[] {
   return endpoints;
 }
 
+function seedSharedNetworkReport(): Endpoint[] {
+  const endpoints = [
+    endpoint('api', 'API'),
+    endpoint('google', 'Google'),
+    endpoint('cloudflare', 'Cloudflare'),
+  ];
+  endpointStore.setEndpoints(endpoints);
+  measurementStore.loadSnapshot({
+    lifecycle: 'completed',
+    epoch: 1,
+    roundCounter: 35,
+    startedAt: null,
+    stoppedAt: null,
+    freezeEvents: [],
+    errorCount: 0,
+    timeoutCount: 0,
+    endpoints: {
+      api: {
+        endpointId: 'api',
+        tierLevel: 1,
+        lastLatency: 260,
+        lastStatus: 'ok',
+        lastErrorMessage: null,
+        samples: samples(260),
+      },
+      google: {
+        endpointId: 'google',
+        tierLevel: 1,
+        lastLatency: 180,
+        lastStatus: 'ok',
+        lastErrorMessage: null,
+        samples: samples(180),
+      },
+      cloudflare: {
+        endpointId: 'cloudflare',
+        tierLevel: 1,
+        lastLatency: 170,
+        lastStatus: 'ok',
+        lastErrorMessage: null,
+        samples: samples(170),
+      },
+    },
+  } satisfies MeasurementState);
+  uiStore.setSharedView(true);
+  uiStore.setSharedReportMode(true);
+  return endpoints;
+}
+
 describe('ReportView triage actions', () => {
   beforeEach(() => {
     cleanup();
@@ -215,6 +263,22 @@ describe('ReportView triage actions', () => {
     });
     expect((await findAllByText('Captured')).length).toBeGreaterThan(0);
     expect(await findAllByText(/1 of 3 endpoints was slow or failed/i)).toHaveLength(1);
+  });
+
+  it('opens focused local proof in the report instead of primary settings', async () => {
+    seedSharedNetworkReport();
+    const { getByLabelText, getByRole, findByRole } = render(ReportView);
+
+    await fireEvent.click(getByRole('button', { name: /deepen local proof/i }));
+
+    expect(get(uiStore).showSettings).toBe(false);
+    expect(get(uiStore).focusedEndpointId).toBe('api');
+    expect(await findByRole('region', { name: /focused local proof/i })).toBeTruthy();
+    expect((getByLabelText('Probe URL') as HTMLInputElement).value).toBe('https://api.example.com');
+
+    await fireEvent.click(getByRole('button', { name: /open full settings/i }));
+
+    expect(get(uiStore).showSettings).toBe(true);
   });
 
   it('scrolls to browser visibility from the triage card', async () => {


### PR DESCRIPTION
## Summary
- Adds a focused in-report local proof panel for the local-agent triage action.
- Reuses the companion controls with scoped IDs so the inline proof panel and full Settings panel can coexist.
- Keeps full Settings available as a secondary path instead of the primary local-proof action.

## Test Plan
- npm run typecheck
- npm run lint
- npm test -- tests/unit/components/report-view-actions.test.ts tests/unit/components/CompanionPanel.test.ts
- npm test
- npm run build
- Rendered smoke check at 1440px and 390px with focused local proof open; verified prefilled endpoint and no horizontal overflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a "Focused local proof" panel that displays in reports with customizable layout for desktop and mobile.
  * Added support for opening local proof workflows from report actions.

* **Enhancements**
  * CompanionPanel now supports configurable titles and IDs, enabling multiple panel instances without conflicts.

* **Tests**
  * Added test coverage for local proof panel functionality in reports.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xaedyn/chronoscope/pull/120)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->