### PR TITLE
Add evidence proof freshness state

### DIFF
--- a/src/lib/components/ReportView.svelte
+++ b/src/lib/components/ReportView.svelte
@@ -16,7 +16,12 @@
   import { buildDiagnosticReport, formatReportMetric } from '$lib/utils/diagnostic-report';
   import { buildEvidenceTrail } from '$lib/utils/evidence-trail';
   import { buildHistoryBaselineInsight } from '$lib/utils/history-baseline';
-  import { buildProofActionState, summarizeLocalProof, summarizeRemoteProof } from '$lib/utils/proof-flow';
+  import {
+    buildProofActionState,
+    isProofStale,
+    summarizeLocalProof,
+    summarizeRemoteProof,
+  } from '$lib/utils/proof-flow';
   import { tokens } from '$lib/tokens';
   import type { DiagnosticTriageAction } from '$lib/utils/diagnostic-narrative';
 
@@ -220,8 +225,12 @@
       status: remoteVantage.status,
       hasProof: Boolean(remoteVantage.lastProbe),
       hasError: Boolean(remoteVantage.error),
+      isStale: isProofStale({
+        reportCreatedAt: report.createdAt,
+        proofGeneratedAt: remoteVantage.lastProbe?.generatedAt ?? null,
+      }),
     });
-    if (remoteBusy || !remoteVantage.lastProbe) return state;
+    if (remoteBusy || !remoteVantage.lastProbe || state.label === 'Stale') return state;
     return { ...state, tone: summarizeRemoteProof(remoteVantage.lastProbe).tone };
   }
 
@@ -232,11 +241,16 @@
       hasProof: Boolean(companion.lastProbe),
       hasError: Boolean(companion.error),
       hasSecret: companion.hasSecret,
+      isStale: isProofStale({
+        reportCreatedAt: report.createdAt,
+        proofGeneratedAt: companion.lastProbe?.createdAt ?? null,
+      }),
     });
     if (companionBusy || !companion.lastProbe) {
       if (companion.status === 'connected') return { label: 'Ready', tone: 'neutral' };
       return state;
     }
+    if (state.label === 'Stale') return state;
     return { ...state, tone: summarizeLocalProof(companion.lastProbe).tone };
   }
 

--- a/src/lib/utils/evidence-trail.ts
+++ b/src/lib/utils/evidence-trail.ts
@@ -1,7 +1,7 @@
 import type { CompanionState } from '../stores/companion';
 import type { RemoteVantageState } from '../stores/remote-vantage';
 import type { DiagnosticReport } from './diagnostic-report';
-import { summarizeLocalProof, summarizeRemoteProof } from './proof-flow';
+import { proofFreshnessLabel, summarizeLocalProof, summarizeRemoteProof } from './proof-flow';
 
 export type EvidenceTrailTone = 'good' | 'watch' | 'bad' | 'neutral';
 
@@ -73,9 +73,21 @@ function confidenceStatus(confidence: DiagnosticReport['diagnosis']['confidence'
   return confidence.charAt(0).toUpperCase() + confidence.slice(1);
 }
 
-function remoteTrail(remoteVantage: EvidenceTrailInput['remoteVantage']): EvidenceTrailItem {
+function staleProofDetail(source: 'outside check' | 'local agent'): string {
+  return `This ${source} was captured before the report snapshot. Run it again to refresh the proof.`;
+}
+
+function remoteTrail(
+  remoteVantage: EvidenceTrailInput['remoteVantage'],
+  reportCreatedAt: number | null,
+): EvidenceTrailItem {
   if (remoteVantage.lastProbe) {
     const summary = summarizeRemoteProof(remoteVantage.lastProbe);
+    const freshness = proofFreshnessLabel({
+      reportCreatedAt,
+      proofGeneratedAt: remoteVantage.lastProbe.generatedAt,
+    });
+    const stale = freshness === 'Stale';
     const hasProblem = summary.tone === 'bad';
     const edge = edgeLabel(remoteVantage.lastProbe.edge);
     return {
@@ -84,9 +96,9 @@ function remoteTrail(remoteVantage: EvidenceTrailInput['remoteVantage']): Eviden
       fact: truncateFact(hasProblem
         ? summary.text.replace('from Cloudflare', `from ${edge}`)
         : summary.text),
-      status: summary.status,
-      tone: summary.tone,
-      detail: `Checked from ${edge}.`,
+      status: stale ? freshness : summary.status,
+      tone: stale ? 'watch' : summary.tone,
+      detail: stale ? staleProofDetail('outside check') : `Checked from ${edge}.`,
     };
   }
 
@@ -120,15 +132,24 @@ function remoteTrail(remoteVantage: EvidenceTrailInput['remoteVantage']): Eviden
   };
 }
 
-function companionTrail(companion: EvidenceTrailInput['companion']): EvidenceTrailItem {
+function companionTrail(
+  companion: EvidenceTrailInput['companion'],
+  reportCreatedAt: number | null,
+): EvidenceTrailItem {
   if (companion.lastProbe) {
     const summary = summarizeLocalProof(companion.lastProbe);
+    const freshness = proofFreshnessLabel({
+      reportCreatedAt,
+      proofGeneratedAt: companion.lastProbe.createdAt,
+    });
+    const stale = freshness === 'Stale';
     return {
       id: 'local-agent',
       source: 'Local agent',
       fact: truncateFact(summary.text),
-      status: summary.status,
-      tone: summary.tone,
+      status: stale ? freshness : summary.status,
+      tone: stale ? 'watch' : summary.tone,
+      detail: stale ? staleProofDetail('local agent') : undefined,
     };
   }
 
@@ -202,7 +223,7 @@ export function buildEvidenceTrail(input: EvidenceTrailInput): EvidenceTrailItem
       tone: visibilityTone(report.diagnosis.timingVisibility.level),
       detail: truncateFact(report.diagnosis.timingVisibility.detail),
     },
-    remoteTrail(input.remoteVantage),
-    companionTrail(input.companion),
+    remoteTrail(input.remoteVantage, report.createdAt),
+    companionTrail(input.companion, report.createdAt),
   ];
 }

--- a/src/lib/utils/proof-flow.ts
+++ b/src/lib/utils/proof-flow.ts
@@ -100,9 +100,13 @@ export function buildProofActionState(input: {
   readonly hasProof: boolean;
   readonly hasError: boolean;
   readonly hasSecret?: boolean;
+  readonly isStale?: boolean;
 }): ProofActionState {
   if (input.status === 'checking' || input.status === 'probing') {
     return { label: 'Running', tone: 'watch', disabled: true };
+  }
+  if (input.hasProof && input.isStale) {
+    return { label: 'Stale', tone: 'watch', disabled: false };
   }
   if (input.hasProof) return { label: 'Captured', tone: 'good', disabled: false };
   if (input.hasError) {

--- a/tests/unit/components/report-view-actions.test.ts
+++ b/tests/unit/components/report-view-actions.test.ts
@@ -6,7 +6,13 @@ import { endpointStore } from '../../../src/lib/stores/endpoints';
 import { measurementStore } from '../../../src/lib/stores/measurements';
 import { resetStatisticsCache } from '../../../src/lib/stores/statistics';
 import { uiStore } from '../../../src/lib/stores/ui';
-import type { Endpoint, MeasurementSample, MeasurementState } from '../../../src/lib/types';
+import type {
+  Endpoint,
+  MeasurementSample,
+  MeasurementState,
+  SharePayload,
+  SharedReportContext,
+} from '../../../src/lib/types';
 import type { RemoteVantageState } from '../../../src/lib/stores/remote-vantage';
 
 const mocks = vi.hoisted(() => {
@@ -25,7 +31,7 @@ const mocks = vi.hoisted(() => {
     historyUnsubscribe: vi.fn(),
     remoteUnsubscribe,
     runProbe: vi.fn(),
-    createHostedReport: vi.fn<() => Promise<null>>().mockResolvedValue(null),
+    createHostedReport: vi.fn<(payload: SharePayload) => Promise<string | null>>().mockResolvedValue(null),
     get remoteState(): RemoteVantageState {
       return remoteState;
     },
@@ -83,6 +89,17 @@ function samples(latency: number): MeasurementSample[] {
   }));
 }
 
+const sharedContext: SharedReportContext = {
+  createdAt: 1778352000000,
+  healthThreshold: 120,
+  corsMode: 'no-cors',
+  roundCount: 35,
+  totalSampleCount: 105,
+  keptSampleCount: 105,
+  truncated: false,
+  sourceVersion: 2,
+};
+
 function seedIsolatedReport(): Endpoint[] {
   const endpoints = [
     endpoint('api', 'API'),
@@ -128,6 +145,7 @@ function seedIsolatedReport(): Endpoint[] {
   } satisfies MeasurementState);
   uiStore.setSharedView(true);
   uiStore.setSharedReportMode(true);
+  uiStore.setSharedReportContext(sharedContext);
   return endpoints;
 }
 
@@ -176,6 +194,7 @@ function seedSharedNetworkReport(): Endpoint[] {
   } satisfies MeasurementState);
   uiStore.setSharedView(true);
   uiStore.setSharedReportMode(true);
+  uiStore.setSharedReportContext(sharedContext);
   return endpoints;
 }
 
@@ -199,6 +218,11 @@ describe('ReportView triage actions', () => {
     Object.defineProperty(Element.prototype, 'scrollIntoView', {
       configurable: true,
       value: vi.fn(),
+    });
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(),
+      },
     });
   });
 
@@ -263,6 +287,78 @@ describe('ReportView triage actions', () => {
     });
     expect((await findAllByText('Captured')).length).toBeGreaterThan(0);
     expect(await findAllByText(/1 of 3 endpoints was slow or failed/i)).toHaveLength(1);
+  });
+
+  it('includes newly captured outside proof in copied report payloads', async () => {
+    const endpoints = seedIsolatedReport();
+    mocks.runProbe.mockImplementation(() => {
+      mocks.setRemoteState({
+        status: 'connected',
+        lastProbe: {
+          ok: true,
+          generatedAt: 1778352005000,
+          edge: { colo: 'IAD', city: 'Ashburn', country: 'US' },
+          results: endpoints.map((ep) => ({
+            endpointId: ep.id,
+            label: ep.label,
+            url: ep.url,
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            durationMs: ep.id === 'api' ? 310 : 45,
+            checkedAt: 1778352005000,
+            verdict: ep.id === 'api' ? 'slow' : 'reachable',
+            headers: {},
+          })),
+        },
+      });
+      return Promise.resolve(mocks.remoteState.lastProbe);
+    });
+    const { getByRole } = render(ReportView);
+
+    await fireEvent.click(getByRole('button', { name: /run outside check/i }));
+    await waitFor(() => {
+      expect(mocks.runProbe).toHaveBeenCalledWith(endpoints);
+    });
+    await fireEvent.click(getByRole('button', { name: /copy report link/i }));
+
+    await waitFor(() => {
+      expect(mocks.createHostedReport).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.createHostedReport.mock.calls[0]?.[0].remoteVantage).toEqual(expect.objectContaining({
+      generatedAt: 1778352005000,
+      edge: { colo: 'IAD', city: 'Ashburn', country: 'US' },
+      results: expect.arrayContaining([
+        expect.objectContaining({ endpointId: 'api', verdict: 'slow' }),
+      ]),
+    }));
+  });
+
+  it('marks an older outside proof action as stale against the current report', () => {
+    seedIsolatedReport();
+    mocks.setRemoteState({
+      status: 'connected',
+      lastProbe: {
+        ok: true,
+        generatedAt: 1,
+        edge: { colo: 'IAD', city: 'Ashburn', country: 'US' },
+        results: [{
+          endpointId: 'api',
+          label: 'API',
+          url: 'https://api.example.com',
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          durationMs: 45,
+          checkedAt: 1,
+          verdict: 'reachable',
+          headers: {},
+        }],
+      },
+    });
+    const { getAllByText } = render(ReportView);
+
+    expect(getAllByText('Stale').length).toBeGreaterThanOrEqual(2);
   });
 
   it('opens focused local proof in the report instead of primary settings', async () => {

--- a/tests/unit/utils/evidence-trail.test.ts
+++ b/tests/unit/utils/evidence-trail.test.ts
@@ -248,4 +248,50 @@ describe('buildEvidenceTrail', () => {
       fact: 'api.example.test: DNS, TLS, route, and WiFi completed',
     });
   });
+
+  it('marks outside proof as stale when the report is newer than the outside check', () => {
+    const trail = buildEvidenceTrail({
+      report: isolatedReport(),
+      remoteVantage: {
+        ...emptyRemote,
+        status: 'connected',
+        lastProbe: {
+          ok: true,
+          generatedAt: context.createdAt - 1000,
+          edge: { colo: 'IAD' },
+          results: [],
+        },
+      },
+      companion: emptyCompanion,
+    });
+
+    expect(trail.find((item) => item.id === 'outside-check')).toMatchObject({
+      status: 'Stale',
+      tone: 'watch',
+    });
+  });
+
+  it('marks local proof as stale when the report is newer than the local probe', () => {
+    const trail = buildEvidenceTrail({
+      report: isolatedReport(),
+      remoteVantage: emptyRemote,
+      companion: {
+        ...emptyCompanion,
+        status: 'connected',
+        lastProbe: {
+          ok: true,
+          id: 'probe-1',
+          targetHost: 'api.example.test',
+          createdAt: context.createdAt - 1000,
+          summary: 'DNS and route completed',
+          results: {},
+        },
+      },
+    });
+
+    expect(trail.find((item) => item.id === 'local-agent')).toMatchObject({
+      status: 'Stale',
+      tone: 'watch',
+    });
+  });
 });

--- a/tests/unit/utils/proof-flow.test.ts
+++ b/tests/unit/utils/proof-flow.test.ts
@@ -103,4 +103,18 @@ describe('proof-flow', () => {
       tone: 'watch',
     });
   });
+
+  it('marks captured proof actions as stale when the proof predates the report', () => {
+    expect(buildProofActionState({
+      kind: 'remote',
+      status: 'connected',
+      hasProof: true,
+      hasError: false,
+      isStale: true,
+    })).toMatchObject({
+      label: 'Stale',
+      disabled: false,
+      tone: 'watch',
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Mark remote and local proof as stale when the captured proof predates the report snapshot.
- Surface stale proof in report triage badges while preserving captured/fresh proof tones.
- Add regression coverage that copied report payloads include newly captured outside proof.

## Test Plan
- npm run typecheck
- npm run lint
- npm test
- npm run build
- npm run test:visual -- tests/visual/ac-verification.spec.ts
- Rendered Playwright smoke at 1440x900 and 390x844 for stale/captured proof states, console health, and horizontal overflow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Proof staleness detection: remote checks and local proofs older than the report are marked "Stale", shown with a "watch" tone, and are treated as captured-before-report (skipping freshness-derived tones).
* **Tests**
  * Added unit tests and component tests verifying "Stale" labels, tones, and related report behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xaedyn/chronoscope/pull/121)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->