### PR TITLE
Add report kind share metadata

### DIFF
--- a/src/lib/share/hash-router.ts
+++ b/src/lib/share/hash-router.ts
@@ -107,6 +107,7 @@ function buildSharedReportContext(payload: SharePayload): SharedReportContext | 
   const keptSampleCount = countResultSamples(payload.results);
   if (payload.v === 2 && payload.report) {
     return {
+      reportKind: payload.report.reportKind ?? 'support',
       createdAt: payload.report.createdAt,
       healthThreshold: payload.report.healthThreshold,
       corsMode: payload.report.corsMode,
@@ -119,6 +120,7 @@ function buildSharedReportContext(payload: SharePayload): SharedReportContext | 
   }
 
   return {
+    reportKind: 'support',
     createdAt: null,
     healthThreshold: null,
     corsMode: payload.settings.corsMode,

--- a/src/lib/share/share-payload-builder.ts
+++ b/src/lib/share/share-payload-builder.ts
@@ -102,6 +102,7 @@ export function buildResultsSharePayload(
   );
 
   const metadata: ShareReportMetadata = {
+    reportKind: reportMetadata.reportKind ?? 'support',
     createdAt: reportMetadata.createdAt ?? now,
     healthThreshold: reportMetadata.healthThreshold ?? settings.healthThreshold,
     corsMode: reportMetadata.corsMode ?? settings.corsMode,

--- a/src/lib/share/share-validator.ts
+++ b/src/lib/share/share-validator.ts
@@ -59,8 +59,10 @@ function validateReport(report: unknown, obj: Record<string, unknown>): boolean 
   if (obj['mode'] !== 'results' || obj['v'] !== 2) return false;
   if (!isRecord(report)) return false;
   if (!hasOnlyKeys(report, ALLOWED_REPORT_KEYS)) return false;
+  if (report['reportKind'] === undefined) {
+    report['reportKind'] = 'support';
+  }
   if (
-    report['reportKind'] !== undefined &&
     report['reportKind'] !== 'support' &&
     report['reportKind'] !== 'snapshot'
   ) return false;

--- a/src/lib/share/share-validator.ts
+++ b/src/lib/share/share-validator.ts
@@ -4,6 +4,7 @@ import { isSafeSharedUrl } from '../utils/url-safety';
 
 const ALLOWED_TOP_LEVEL = new Set(['v', 'mode', 'endpoints', 'settings', 'results', 'report', 'remoteVantage']);
 const ALLOWED_REPORT_KEYS = new Set([
+  'reportKind',
   'createdAt',
   'healthThreshold',
   'corsMode',
@@ -58,6 +59,11 @@ function validateReport(report: unknown, obj: Record<string, unknown>): boolean 
   if (obj['mode'] !== 'results' || obj['v'] !== 2) return false;
   if (!isRecord(report)) return false;
   if (!hasOnlyKeys(report, ALLOWED_REPORT_KEYS)) return false;
+  if (
+    report['reportKind'] !== undefined &&
+    report['reportKind'] !== 'support' &&
+    report['reportKind'] !== 'snapshot'
+  ) return false;
   if (!isNonNegativeFiniteNumber(report['createdAt'])) return false;
   if (!isNonNegativeFiniteNumber(report['healthThreshold']) || (report['healthThreshold'] as number) > 15000) return false;
   if (report['corsMode'] !== 'no-cors' && report['corsMode'] !== 'cors') return false;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -285,7 +285,10 @@ export interface UIState {
 }
 
 // ── Share payload ──────────────────────────────────────────────────────────
+export type ReportKind = 'support' | 'snapshot';
+
 export interface ShareReportMetadata {
+  readonly reportKind: ReportKind;
   readonly createdAt: number;
   readonly healthThreshold: number;
   readonly corsMode: 'no-cors' | 'cors';
@@ -296,6 +299,7 @@ export interface ShareReportMetadata {
 }
 
 export interface SharedReportContext {
+  readonly reportKind: ReportKind;
   readonly createdAt: number | null;
   readonly healthThreshold: number | null;
   readonly corsMode: 'no-cors' | 'cors' | null;

--- a/tests/unit/components/report-view-actions.test.ts
+++ b/tests/unit/components/report-view-actions.test.ts
@@ -90,6 +90,7 @@ function samples(latency: number): MeasurementSample[] {
 }
 
 const sharedContext: SharedReportContext = {
+  reportKind: 'support',
   createdAt: 1778352000000,
   healthThreshold: 120,
   corsMode: 'no-cors',

--- a/tests/unit/remote-vantage/functions.test.ts
+++ b/tests/unit/remote-vantage/functions.test.ts
@@ -35,6 +35,7 @@ const sharePayload: SharePayload = {
     corsMode: 'no-cors',
   },
   report: {
+    reportKind: 'support',
     createdAt: 1778352000000,
     healthThreshold: 120,
     corsMode: 'no-cors',

--- a/tests/unit/share-manager.test.ts
+++ b/tests/unit/share-manager.test.ts
@@ -88,6 +88,7 @@ describe('share-manager', () => {
       ...resultsPayload,
       v: 2,
       report: {
+        reportKind: 'support',
         createdAt: 1778352000000,
         healthThreshold: 120,
         corsMode: 'no-cors',

--- a/tests/unit/share-manager.test.ts
+++ b/tests/unit/share-manager.test.ts
@@ -101,8 +101,28 @@ describe('share-manager', () => {
 
     const decoded = decodeSharePayload(encodeSharePayload(payload));
     expect(decoded?.v).toBe(2);
+    expect(decoded?.report?.reportKind).toBe('support');
     expect(decoded?.report?.healthThreshold).toBe(120);
     expect(decoded?.report?.keptSampleCount).toBe(100);
+  });
+
+  it('normalizes legacy v2 report metadata without reportKind', () => {
+    const legacyPayload = {
+      ...resultsPayload,
+      v: 2,
+      report: {
+        createdAt: 1778352000000,
+        healthThreshold: 120,
+        corsMode: 'no-cors' as const,
+        roundCount: 50,
+        totalSampleCount: 100,
+        keptSampleCount: 100,
+        truncated: false,
+      },
+    };
+
+    const decoded = decodeSharePayload(encodeSharePayload(legacyPayload as never));
+    expect(decoded?.report?.reportKind).toBe('support');
   });
 
   it('config-only payload is small', () => {

--- a/tests/unit/share-payload-builder.test.ts
+++ b/tests/unit/share-payload-builder.test.ts
@@ -89,6 +89,20 @@ describe('share-payload-builder', () => {
     expect(built.truncated).toBe(false);
   });
 
+  it('stores the requested report kind in v2 result metadata', () => {
+    const ep = endpoint('api');
+    const built = buildResultsSharePayload(
+      [ep],
+      DEFAULT_SETTINGS,
+      measurementState(ep.id, Array.from({ length: 12 }, (_, i) => ok(i + 1))),
+      8000,
+      1778352000000,
+      { reportKind: 'snapshot' },
+    );
+
+    expect(built.payload.report?.reportKind).toBe('snapshot');
+  });
+
   it('preserves report metadata overrides when re-copying a report link', () => {
     const ep = endpoint('api');
     const built = buildResultsSharePayload(

--- a/tests/unit/share/hash-router.test.ts
+++ b/tests/unit/share/hash-router.test.ts
@@ -90,6 +90,7 @@ function reportPayload(): SharePayload {
     ...resultsPayload(),
     v: 2,
     report: {
+      reportKind: 'support',
       createdAt: 1778352000000,
       healthThreshold: 140,
       corsMode: 'cors',
@@ -443,6 +444,7 @@ describe('hash-router: results-mode application', () => {
     const ui = get(uiStore);
     expect(ui.sharedReportContext?.healthThreshold).toBe(140);
     expect(ui.sharedReportContext?.corsMode).toBe('cors');
+    expect(ui.sharedReportContext?.reportKind).toBe('support');
     expect(ui.sharedReportContext?.sourceVersion).toBe(2);
 
     const s = get(settingsStore);
@@ -450,10 +452,24 @@ describe('hash-router: results-mode application', () => {
     expect(s.corsMode).toBe(DEFAULT_SETTINGS.corsMode);
   });
 
+  it('stores explicit v2 snapshot report mode in shared report context', () => {
+    const payload = reportPayload();
+    applySharePayload({
+      ...payload,
+      report: {
+        ...payload.report,
+        reportKind: 'snapshot',
+      },
+    });
+
+    expect(get(uiStore).sharedReportContext?.reportKind).toBe('snapshot');
+  });
+
   it('infers legacy v1 report context from results without threshold metadata', () => {
     applySharePayload(resultsPayload());
     const context = get(uiStore).sharedReportContext;
     expect(context?.sourceVersion).toBe(1);
+    expect(context?.reportKind).toBe('support');
     expect(context?.healthThreshold).toBeNull();
     expect(context?.corsMode).toBe(MALICIOUS_CADENCE.corsMode);
     expect(context?.keptSampleCount).toBe(20);

--- a/tests/unit/share/hosted-report-router.test.ts
+++ b/tests/unit/share/hosted-report-router.test.ts
@@ -22,6 +22,7 @@ function hostedPayload(): SharePayload {
       corsMode: 'no-cors',
     },
     report: {
+      reportKind: 'support',
       createdAt: 1778352000000,
       healthThreshold: 120,
       corsMode: 'no-cors',

--- a/tests/unit/share/share-payload-rejects-unknown-keys.test.ts
+++ b/tests/unit/share/share-payload-rejects-unknown-keys.test.ts
@@ -148,6 +148,7 @@ describe('validateSharePayload: top-level unknown key rejection', () => {
       endpoints: [{ url: 'https://example.com', enabled: true }],
       settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'no-cors' },
       report: {
+        reportKind: 'support',
         createdAt: 1778352000000,
         healthThreshold: 120,
         corsMode: 'no-cors',
@@ -176,6 +177,50 @@ describe('validateSharePayload: top-level unknown key rejection', () => {
     };
     const encoded = encodeSharePayload(payload);
     expect(decodeSharePayload(encoded)).not.toBeNull();
+  });
+
+  it('accepts a bounded reportKind in v2 report metadata', () => {
+    const payload: SharePayload = {
+      v: 2,
+      mode: 'results',
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'no-cors' },
+      report: {
+        createdAt: 1778352000000,
+        healthThreshold: 120,
+        corsMode: 'no-cors',
+        roundCount: 1,
+        totalSampleCount: 1,
+        keptSampleCount: 1,
+        truncated: false,
+        reportKind: 'support',
+      },
+      results: [{ samples: [{ round: 0, latency: 42, status: 'ok' }] }],
+    };
+
+    expect(decodeSharePayload(encodeSharePayload(payload))).not.toBeNull();
+  });
+
+  it('rejects unknown reportKind values', () => {
+    const payload = {
+      v: 2,
+      mode: 'results',
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'no-cors' as const },
+      report: {
+        createdAt: 1778352000000,
+        healthThreshold: 120,
+        corsMode: 'no-cors' as const,
+        roundCount: 1,
+        totalSampleCount: 1,
+        keptSampleCount: 1,
+        truncated: false,
+        reportKind: 'marketing',
+      },
+      results: [{ samples: [{ round: 0, latency: 42, status: 'ok' as const }] }],
+    };
+
+    expect(decodeSharePayload(encodeSharePayload(payload as never))).toBeNull();
   });
 
   it('rejects unknown remoteVantage nested keys', () => {

--- a/tests/unit/utils/diagnostic-report.test.ts
+++ b/tests/unit/utils/diagnostic-report.test.ts
@@ -96,6 +96,7 @@ function measurementState(samplesByEndpoint: Record<string, readonly Measurement
 }
 
 const context: SharedReportContext = {
+  reportKind: 'support',
   createdAt: 1778352000000,
   healthThreshold: 120,
   corsMode: 'no-cors',

--- a/tests/unit/utils/evidence-trail.test.ts
+++ b/tests/unit/utils/evidence-trail.test.ts
@@ -96,6 +96,7 @@ function measurementState(samplesByEndpoint: Record<string, readonly Measurement
 }
 
 const context: SharedReportContext = {
+  reportKind: 'support',
   createdAt: 1778352000000,
   healthThreshold: 120,
   corsMode: 'no-cors',

--- a/tests/visual/ac-verification.spec.ts
+++ b/tests/visual/ac-verification.spec.ts
@@ -139,6 +139,7 @@ function sharedReportUrl(): string {
       corsMode: 'no-cors',
     },
     report: {
+      reportKind: 'support',
       createdAt: 1778352000000,
       healthThreshold: 120,
       corsMode: 'no-cors',


### PR DESCRIPTION
## Summary
- Adds a bounded `reportKind` contract (`support` or `snapshot`) to v2 report metadata and shared report context.
- Defaults generated and legacy shared reports to `support` so existing links remain deterministic.
- Extends builder, validator, hash-router, unit fixtures, and the acceptance fixture to preserve the new mode safely.

## Test Plan
- `npm test -- tests/unit/share-payload-builder.test.ts tests/unit/share/share-payload-rejects-unknown-keys.test.ts tests/unit/share/hash-router.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run test:visual -- tests/visual/ac-verification.spec.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reports can be typed as "support" or "snapshot"
  * Report kind is included and preserved across shared payloads

* **Bug Fixes**
  * Missing report kind now defaults to "support" for legacy and incoming shares
  * Unknown report kinds are rejected during validation

* **Tests**
  * Unit and visual tests updated to cover reportKind behavior and validation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xaedyn/chronoscope/pull/122)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->