### PR TITLE
Add report mode copy model

### DIFF
--- a/src/lib/utils/diagnostic-report.ts
+++ b/src/lib/utils/diagnostic-report.ts
@@ -7,11 +7,13 @@ import type {
   EndpointStatistics,
   MeasurementSample,
   MeasurementState,
+  ReportKind,
   Settings,
   SharedReportContext,
   StatisticsState,
 } from '../types';
 import { buildDiagnosticNarrative, type DiagnosticNarrative } from './diagnostic-narrative';
+import { reportModeCopy } from './report-mode';
 import type { VerdictRow } from './verdict';
 
 export interface ReportEndpointRow {
@@ -34,6 +36,10 @@ export interface ReportEndpointRow {
 }
 
 export interface DiagnosticReport {
+  readonly reportKind: ReportKind;
+  readonly modeKicker: string;
+  readonly modeLede: string;
+  readonly copySummaryLabel: string;
   readonly diagnosis: DiagnosticNarrative;
   readonly endpointRows: readonly ReportEndpointRow[];
   readonly threshold: number;
@@ -162,9 +168,12 @@ function buildCopySummary(report: Omit<DiagnosticReport, 'copySummary'>): string
   const visibility = report.diagnosis.timingVisibility;
   const limitation = report.diagnosis.limitations[0];
   const firstTriageAction = report.diagnosis.triageActions[0];
+  const reportLabel = report.reportKind === 'snapshot'
+    ? 'Chronoscope performance snapshot'
+    : 'Chronoscope support report';
 
   return [
-    `Chronoscope diagnostic report: ${report.diagnosis.primaryAnswer.text} (${report.diagnosis.confidenceLabel}).`,
+    `${reportLabel}: ${report.diagnosis.primaryAnswer.text} (${report.diagnosis.confidenceLabel}).`,
     `Trust: ${report.diagnosis.supportingSummary}`,
     slowLine,
     `Evidence: ${report.keptSampleCount} samples kept across ${report.endpointRows.length} endpoints; threshold ${fmtMs(report.threshold)}; browser visibility: ${visibility.headline}.`,
@@ -178,6 +187,7 @@ export function buildDiagnosticReport(input: DiagnosticReportInput): DiagnosticR
   const threshold = input.context?.healthThreshold ?? input.settings.healthThreshold;
   const thresholdSource = input.context?.healthThreshold != null ? 'shared' : 'local-default';
   const corsMode = input.context?.corsMode ?? input.settings.corsMode;
+  const reportKind = input.context?.reportKind ?? 'support';
   const corsModeSource = input.context?.corsMode != null
     ? (input.context.sourceVersion === 2 ? 'shared' : 'payload-settings')
     : 'local-default';
@@ -203,7 +213,21 @@ export function buildDiagnosticReport(input: DiagnosticReportInput): DiagnosticR
   });
 
   const fallbackSampleCount = sumSamples(samplesByEndpoint);
+  const totalSampleCount = input.context?.totalSampleCount ?? fallbackSampleCount;
+  const keptSampleCount = input.context?.keptSampleCount ?? fallbackSampleCount;
+  const modeCopy = reportModeCopy({
+    reportKind,
+    primaryAnswer: diagnosis.primaryAnswer.text,
+    confidenceLabel: diagnosis.confidenceLabel,
+    sampleCount: keptSampleCount,
+    endpointCount: input.endpoints.length,
+    timingHeadline: diagnosis.timingVisibility.headline,
+  });
   const reportWithoutSummary: Omit<DiagnosticReport, 'copySummary'> = {
+    reportKind,
+    modeKicker: modeCopy.kicker,
+    modeLede: modeCopy.lede,
+    copySummaryLabel: modeCopy.primaryActionLabel,
     diagnosis,
     endpointRows: buildEndpointRows({
       endpoints: input.endpoints,
@@ -217,8 +241,8 @@ export function buildDiagnosticReport(input: DiagnosticReportInput): DiagnosticR
     corsMode,
     corsModeSource,
     roundCount: input.context?.roundCount ?? input.measurements.roundCounter,
-    totalSampleCount: input.context?.totalSampleCount ?? fallbackSampleCount,
-    keptSampleCount: input.context?.keptSampleCount ?? fallbackSampleCount,
+    totalSampleCount,
+    keptSampleCount,
     truncated: input.context?.truncated ?? false,
     createdAt: input.context?.createdAt ?? null,
     createdLabel: defaultCreatedLabel(input.context?.createdAt ?? null),

--- a/src/lib/utils/report-mode.ts
+++ b/src/lib/utils/report-mode.ts
@@ -15,8 +15,12 @@ export interface ReportModeCopy {
   readonly primaryActionLabel: string;
 }
 
+function countLabel(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? '' : 's'}`;
+}
+
 export function reportModeCopy(input: ReportModeCopyInput): ReportModeCopy {
-  const evidence = `${input.sampleCount} samples across ${input.endpointCount} endpoints`;
+  const evidence = `${countLabel(input.sampleCount, 'sample')} across ${countLabel(input.endpointCount, 'endpoint')}`;
   if (input.reportKind === 'snapshot') {
     return {
       kicker: 'Performance snapshot',

--- a/src/lib/utils/report-mode.ts
+++ b/src/lib/utils/report-mode.ts
@@ -1,0 +1,33 @@
+import type { ReportKind } from '../types';
+
+export interface ReportModeCopyInput {
+  readonly reportKind: ReportKind;
+  readonly primaryAnswer: string;
+  readonly confidenceLabel: string;
+  readonly sampleCount: number;
+  readonly endpointCount: number;
+  readonly timingHeadline: string;
+}
+
+export interface ReportModeCopy {
+  readonly kicker: string;
+  readonly lede: string;
+  readonly primaryActionLabel: string;
+}
+
+export function reportModeCopy(input: ReportModeCopyInput): ReportModeCopy {
+  const evidence = `${input.sampleCount} samples across ${input.endpointCount} endpoints`;
+  if (input.reportKind === 'snapshot') {
+    return {
+      kicker: 'Performance snapshot',
+      lede: `${input.primaryAnswer} Evidence: ${evidence}. ${input.timingHeadline}.`,
+      primaryActionLabel: 'Copy Snapshot Summary',
+    };
+  }
+
+  return {
+    kicker: 'Support report',
+    lede: `${input.primaryAnswer} ${input.confidenceLabel}. Evidence includes ${evidence}. ${input.timingHeadline}.`,
+    primaryActionLabel: 'Copy Support Summary',
+  };
+}

--- a/tests/unit/utils/diagnostic-report.test.ts
+++ b/tests/unit/utils/diagnostic-report.test.ts
@@ -133,10 +133,15 @@ describe('buildDiagnosticReport', () => {
     expect(report.threshold).toBe(120);
     expect(report.thresholdSource).toBe('shared');
     expect(report.corsMode).toBe('no-cors');
+    expect(report.reportKind).toBe('support');
+    expect(report.modeKicker).toBe('Support report');
+    expect(report.modeLede).toContain(report.diagnosis.primaryAnswer.text);
+    expect(report.copySummaryLabel).toBe('Copy Support Summary');
     expect(report.diagnosis.kind).toBe('isolated-endpoint');
     expect(report.endpointRows.find((row) => row.endpointId === 'api')?.implicated).toBe(true);
     expect(report.endpointRows.find((row) => row.endpointId === 'api')?.statusLabel).toBe('inspect');
     expect(report.copySummary).toContain('API');
+    expect(report.copySummary).toContain('Chronoscope support report:');
     expect(report.copySummary).toContain('threshold 120 ms');
     expect(report.copySummary).not.toMatch(/likely (affected|source|site|network|your network)/i);
     expect(report.copySummary).not.toContain(report.diagnosis.verdict.headline);
@@ -164,6 +169,36 @@ describe('buildDiagnosticReport', () => {
     expect(report.threshold).toBe(90);
     expect(report.thresholdSource).toBe('local-default');
     expect(report.corsModeSource).toBe('payload-settings');
+  });
+
+  it('uses snapshot copy when the shared report context requests it', () => {
+    const endpoints = [
+      endpoint('api', 'API'),
+      endpoint('google', 'Google'),
+      endpoint('cloudflare', 'Cloudflare'),
+    ];
+    const report = buildDiagnosticReport({
+      endpoints,
+      stats: {
+        api: stats({ endpointId: 'api', p50: 42, p95: 55 }),
+        google: stats({ endpointId: 'google', p50: 45, p95: 60 }),
+        cloudflare: stats({ endpointId: 'cloudflare', p50: 38, p95: 52 }),
+      },
+      measurements: measurementState({
+        api: Array.from({ length: 30 }, (_, i) => ok(i + 1, 42)),
+        google: Array.from({ length: 30 }, (_, i) => ok(i + 1, 45)),
+        cloudflare: Array.from({ length: 30 }, (_, i) => ok(i + 1, 38)),
+      }),
+      settings: DEFAULT_SETTINGS,
+      context: { ...context, reportKind: 'snapshot' },
+    });
+
+    expect(report.reportKind).toBe('snapshot');
+    expect(report.modeKicker).toBe('Performance snapshot');
+    expect(report.copySummaryLabel).toBe('Copy Snapshot Summary');
+    expect(report.modeLede).toContain(report.diagnosis.primaryAnswer.text);
+    expect(report.copySummary).toContain('Chronoscope performance snapshot:');
+    expect(report.copySummary).not.toMatch(/guaranteed|perfect|will fix|your ISP is/i);
   });
 
   it('marks truncated reports and carries sample counts through the model', () => {

--- a/tests/unit/utils/report-mode.test.ts
+++ b/tests/unit/utils/report-mode.test.ts
@@ -2,6 +2,19 @@ import { describe, expect, it } from 'vitest';
 import { reportModeCopy } from '../../../src/lib/utils/report-mode';
 
 describe('reportModeCopy', () => {
+  it('uses singular nouns when counts are 1', () => {
+    const copy = reportModeCopy({
+      reportKind: 'support',
+      primaryAnswer: 'Single endpoint check.',
+      confidenceLabel: 'High confidence',
+      sampleCount: 1,
+      endpointCount: 1,
+      timingHeadline: 'Detailed timing visible',
+    });
+
+    expect(copy.lede).toContain('1 sample across 1 endpoint');
+  });
+
   it('keeps support mode focused on facts, caveats, and next validation', () => {
     const copy = reportModeCopy({
       reportKind: 'support',

--- a/tests/unit/utils/report-mode.test.ts
+++ b/tests/unit/utils/report-mode.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { reportModeCopy } from '../../../src/lib/utils/report-mode';
+
+describe('reportModeCopy', () => {
+  it('keeps support mode focused on facts, caveats, and next validation', () => {
+    const copy = reportModeCopy({
+      reportKind: 'support',
+      primaryAnswer: 'One site is slower than the others.',
+      confidenceLabel: 'Medium confidence',
+      sampleCount: 105,
+      endpointCount: 3,
+      timingHeadline: 'Some timing details are hidden by the browser',
+    });
+
+    expect(copy).toMatchObject({
+      kicker: 'Support report',
+      primaryActionLabel: 'Copy Support Summary',
+    });
+    expect(copy.lede).toContain('One site is slower than the others.');
+    expect(copy.lede).toContain('Medium confidence.');
+    expect(copy.lede).toContain('105 samples across 3 endpoints');
+    expect(copy.lede).toContain('Some timing details are hidden by the browser.');
+    expect(copy.lede).not.toMatch(/will fix|the problem is your|your ISP is/i);
+  });
+
+  it('keeps snapshot mode brag-friendly without dropping evidence', () => {
+    const copy = reportModeCopy({
+      reportKind: 'snapshot',
+      primaryAnswer: 'All measured sites look healthy.',
+      confidenceLabel: 'High confidence',
+      sampleCount: 180,
+      endpointCount: 4,
+      timingHeadline: 'Detailed timing visible',
+    });
+
+    expect(copy).toMatchObject({
+      kicker: 'Performance snapshot',
+      primaryActionLabel: 'Copy Snapshot Summary',
+    });
+    expect(copy.lede).toContain('All measured sites look healthy.');
+    expect(copy.lede).toContain('180 samples across 4 endpoints');
+    expect(copy.lede).toContain('Detailed timing visible.');
+    expect(copy.lede).not.toMatch(/guaranteed|perfect|fastest|beats/i);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a pure `reportModeCopy` helper for support reports versus performance snapshots.
- Threads `reportKind`, mode kicker, mode lede, and copy-summary label through `buildDiagnosticReport`.
- Makes copied summaries mode-aware while keeping the evidence, caveats, and no-overclaim protections intact.

## Test Plan
- `npm test -- tests/unit/utils/report-mode.test.ts tests/unit/utils/diagnostic-report.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diagnostic reports now include a selectable report kind (Performance snapshot vs Support report) with mode-specific kicker, lede, and summary label; summaries reflect sample/endpoint counts and adjusted headline wording.
* **Tests**
  * Added unit tests covering mode-specific copy, count phrasing, and summary content for both snapshot and support modes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xaedyn/chronoscope/pull/123)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->