### PR TITLE
Add share popover report modes

### DIFF
--- a/src/lib/components/SharePopover.svelte
+++ b/src/lib/components/SharePopover.svelte
@@ -16,7 +16,7 @@
     MAX_SHARE_URL_CHARS,
   } from '$lib/share/share-payload-builder';
   import { tokens } from '$lib/tokens';
-  import type { SharePayload } from '$lib/types';
+  import type { ReportKind, SharePayload } from '$lib/types';
 
   const MAX_HOSTED_REPORT_CHARS = 100_000;
 
@@ -35,8 +35,8 @@
   );
 
   let configPayload = $derived(buildConfigPayload());
-  let builtHostedReport = $derived(hasResults ? buildResultsPayload(MAX_HOSTED_REPORT_CHARS) : null);
-  let builtResults = $derived(hasResults ? buildResultsPayload() : null);
+  let builtHostedReport = $derived(hasResults ? buildResultsPayload(MAX_HOSTED_REPORT_CHARS, 'support') : null);
+  let builtResults = $derived(hasResults ? buildResultsPayload(MAX_SHARE_URL_CHARS, 'snapshot') : null);
   let hostedReportPayload = $derived(builtHostedReport?.payload ?? null);
   let resultsPayload = $derived(builtResults?.payload ?? null);
   let hostedReportTruncated = $derived(builtHostedReport?.truncated ?? false);
@@ -46,14 +46,14 @@
     return buildConfigSharePayload(get(endpointStore), get(settingsStore));
   }
 
-  function buildResultsPayload(maxChars = MAX_SHARE_URL_CHARS) {
+  function buildResultsPayload(maxChars = MAX_SHARE_URL_CHARS, reportKind: ReportKind = 'support') {
     return buildResultsSharePayload(
       get(endpointStore),
       get(settingsStore),
       get(measurementStore),
       maxChars,
       Date.now(),
-      undefined,
+      { reportKind },
       get(remoteVantageStore).lastProbe,
     );
   }

--- a/tests/unit/components/share-popover.test.ts
+++ b/tests/unit/components/share-popover.test.ts
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import SharePopover from '../../../src/lib/components/SharePopover.svelte';
+import { parseShareURL } from '../../../src/lib/share/share-manager';
 import { endpointStore } from '../../../src/lib/stores/endpoints';
 import { measurementStore } from '../../../src/lib/stores/measurements';
 import { settingsStore } from '../../../src/lib/stores/settings';
@@ -98,6 +99,7 @@ describe('SharePopover hosted support reports', () => {
     });
     const payload = mocks.createHostedReport.mock.calls[0]?.[0];
     expect(payload?.mode).toBe('results');
+    expect(payload?.report?.reportKind).toBe('support');
     expect(payload?.results?.[0]?.samples).toHaveLength(4);
   });
 
@@ -124,6 +126,31 @@ describe('SharePopover hosted support reports', () => {
 
     expect(button.hasAttribute('disabled')).toBe(true);
     expect(get(uiStore).showShare).toBe(true);
+  });
+
+  it('copies snapshot links with snapshot report metadata', async () => {
+    seedResults();
+
+    const { getByRole } = render(SharePopover);
+    await fireEvent.click(getByRole('button', { name: /copy snapshot link/i }));
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expect.stringContaining('/#s='));
+    });
+    const copiedUrl = vi.mocked(navigator.clipboard.writeText).mock.calls.at(-1)?.[0] as string;
+    const payload = parseShareURL(copiedUrl);
+
+    expect(payload?.mode).toBe('results');
+    expect(payload?.report?.reportKind).toBe('snapshot');
+  });
+
+  it('disables snapshot links until a run has samples', () => {
+    endpointStore.setEndpoints([endpoint]);
+
+    const { getByRole } = render(SharePopover);
+    const button = getByRole('button', { name: /copy snapshot link/i });
+
+    expect(button.hasAttribute('disabled')).toBe(true);
   });
 
   it('orders share actions as support report, snapshot link, then configuration link', () => {


### PR DESCRIPTION
## Summary
- Makes SharePopover generate hosted support reports with `reportKind: 'support'` explicitly.
- Makes compact snapshot links generate `reportKind: 'snapshot'` so shared reports can render snapshot-specific copy later.
- Adds component coverage for support metadata, snapshot metadata, and disabled snapshot state before results exist.

## Test Plan
- `npm test -- tests/unit/components/share-popover.test.ts tests/unit/share-payload-builder.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:visual -- tests/visual/ac-verification.spec.ts`

## Rendered QA note
- In-app Browser runtime was attempted, but the expected Browser tab/session APIs were unavailable in this session (`nameSession` missing, `tabs` undefined). The project Playwright visual acceptance suite was used for rendered regression coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Share functionality now supports explicit report type configuration for both support and snapshot reports
  * Snapshot link generation updated with proper report type parameters in shared URLs

* **Tests**
  * Added comprehensive test coverage for snapshot link sharing, including URL payload validation
  * Added tests to verify snapshot link button behavior and state based on endpoint run samples

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xaedyn/chronoscope/pull/124)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->