### PR TITLE
Render report mode copy

### DIFF
--- a/src/lib/components/ReportView.svelte
+++ b/src/lib/components/ReportView.svelte
@@ -287,7 +287,7 @@
   style:--accent-pink={tokens.color.accent.pink}
 >
   <header class="report-hero">
-    <div class="report-kicker">Shared diagnostic report</div>
+    <div class="report-kicker">{report.modeKicker}</div>
     <div class="report-title-row">
       <h1>{report.diagnosis.primaryAnswer.text}</h1>
       <span
@@ -298,14 +298,14 @@
         title={report.diagnosis.confidenceReason}
       >{report.diagnosis.confidenceLabel}</span>
     </div>
-    <p class="report-lede">{report.diagnosis.supportingSummary}</p>
+    <p class="report-lede">{report.modeLede}</p>
 
     <div class="report-actions" aria-label="Report actions">
       <button type="button" class="action action-primary" onclick={handleInteractive}>
         Open Interactive Analysis
       </button>
       <button type="button" class="action" onclick={handleCopySummary}>
-        {copyError === 'summary' ? 'Copy Failed' : copiedSummary ? 'Summary Copied' : 'Copy Summary'}
+        {copyError === 'summary' ? 'Copy Failed' : copiedSummary ? 'Summary Copied' : report.copySummaryLabel}
       </button>
       <button type="button" class="action" onclick={handleCopyLink}>
         {copyError === 'link' ? 'Copy Failed' : copiedLink ? 'Link Copied' : 'Copy Report Link'}

--- a/tests/unit/components/report-view-actions.test.ts
+++ b/tests/unit/components/report-view-actions.test.ts
@@ -101,7 +101,7 @@ const sharedContext: SharedReportContext = {
   sourceVersion: 2,
 };
 
-function seedIsolatedReport(): Endpoint[] {
+function seedIsolatedReport(reportKind: SharedReportContext['reportKind'] = 'support'): Endpoint[] {
   const endpoints = [
     endpoint('api', 'API'),
     endpoint('google', 'Google'),
@@ -146,7 +146,7 @@ function seedIsolatedReport(): Endpoint[] {
   } satisfies MeasurementState);
   uiStore.setSharedView(true);
   uiStore.setSharedReportMode(true);
-  uiStore.setSharedReportContext(sharedContext);
+  uiStore.setSharedReportContext({ ...sharedContext, reportKind });
   return endpoints;
 }
 
@@ -229,6 +229,24 @@ describe('ReportView triage actions', () => {
 
   afterEach(() => {
     cleanup();
+  });
+
+  it('renders support report mode copy from shared metadata', () => {
+    seedIsolatedReport('support');
+    const { getByRole, getByText, queryByText } = render(ReportView);
+
+    expect(getByText('Support report')).toBeTruthy();
+    expect(queryByText('Shared diagnostic report')).toBeNull();
+    expect(getByRole('button', { name: /copy support summary/i })).toBeTruthy();
+  });
+
+  it('renders snapshot report mode copy from shared metadata', () => {
+    seedIsolatedReport('snapshot');
+    const { getByRole, getByText, queryByText } = render(ReportView);
+
+    expect(getByText('Performance snapshot')).toBeTruthy();
+    expect(queryByText('Shared diagnostic report')).toBeNull();
+    expect(getByRole('button', { name: /copy snapshot summary/i })).toBeTruthy();
   });
 
   it('opens Investigate on the implicated endpoint from the triage card', async () => {

--- a/tests/unit/components/shared-run-own-reset.test.ts
+++ b/tests/unit/components/shared-run-own-reset.test.ts
@@ -81,7 +81,7 @@ describe('shared run-own reset', () => {
     });
     const { getByRole, queryByRole } = render(ReportView);
 
-    await fireEvent.click(getByRole('button', { name: /copy summary/i }));
+    await fireEvent.click(getByRole('button', { name: /copy support summary/i }));
 
     await waitFor(() => {
       expect(writeText).toHaveBeenCalledTimes(1);

--- a/tests/visual/ac-verification.spec.ts
+++ b/tests/visual/ac-verification.spec.ts
@@ -294,10 +294,11 @@ test.describe('Acceptance criteria verification', () => {
     await page.goto(sharedReportUrl());
     await page.waitForSelector('#chronoscope-root');
 
-    await expect(page.getByText('Shared diagnostic report').first()).toBeVisible();
+    await expect(page.getByText('Support report').first()).toBeVisible();
     await expect(page.getByRole('heading', { name: /api\.example\.com is slower than the others in this test/i })).toBeVisible();
-    await expect(page.getByText(/medium confidence|high confidence/i)).toBeVisible();
+    await expect(page.locator('.report-title-row .confidence')).toContainText(/medium confidence|high confidence/i);
     await expect(page.getByRole('button', { name: /Open Interactive Analysis/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Copy Support Summary/i })).toBeVisible();
     await expect(page.getByRole('table', { name: /Endpoint report table/i })).toContainText('inspect');
     await expect(page.getByRole('region', { name: /Evidence trail/i })).toContainText('Browser test');
     await expect(page.getByRole('region', { name: /Evidence trail/i })).toContainText('Outside check');


### PR DESCRIPTION
## Summary
- Renders support vs snapshot report kickers, ledes, and copy-summary button labels from the diagnostic report model.
- Adds component coverage for support and snapshot report rendering.
- Updates existing copy-failure and visual acceptance checks for the new support-summary label.

## Test Plan
- 
> chronoscope@0.1.0 test
> vitest run tests/unit/components/report-view-actions.test.ts tests/unit/utils/diagnostic-report.test.ts


 RUN  v4.1.3 /Users/shane/claude/chronoscope


 Test Files  2 passed (2)
      Tests  15 passed (15)
   Start at  19:15:32
   Duration  1.02s (transform 422ms, setup 25ms, import 506ms, tests 265ms, environment 489ms)
- 
> chronoscope@0.1.0 test
> vitest run tests/unit/components/shared-run-own-reset.test.ts tests/unit/components/report-view-actions.test.ts tests/unit/utils/diagnostic-report.test.ts


 RUN  v4.1.3 /Users/shane/claude/chronoscope


 Test Files  3 passed (3)
      Tests  19 passed (19)
   Start at  19:15:33
   Duration  1.03s (transform 792ms, setup 38ms, import 990ms, tests 375ms, environment 739ms)
- 
> chronoscope@0.1.0 typecheck
> tsc --noEmit && npm run typecheck:functions


> chronoscope@0.1.0 typecheck:functions
> tsc -p functions/tsconfig.json --noEmit
- 
> chronoscope@0.1.0 lint
> eslint src
- 
> chronoscope@0.1.0 build
> vite build

vite v8.0.7 building client environment for production...
[2Ktransforming...✓ 227 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                   0.88 kB │ gzip:  0.48 kB
dist/assets/worker-BbcVQD2l.js    2.70 kB
dist/assets/index-ND7W6Fjq.css  103.84 kB │ gzip: 15.42 kB
dist/assets/index-xrzXka1E.js   303.91 kB │ gzip: 93.04 kB

✓ built in 346ms
- 
> chronoscope@0.1.0 test
> vitest run


 RUN  v4.1.3 /Users/shane/claude/chronoscope


 Test Files  80 passed (80)
      Tests  1022 passed (1022)
   Start at  19:15:38
   Duration  4.87s (transform 9.11s, setup 1.32s, import 14.60s, tests 3.13s, environment 33.18s)
- 
> chronoscope@0.1.0 test:visual
> playwright test tests/visual/ac-verification.spec.ts


Running 72 tests using 7 workers

  ✓   2 [chromium] › tests/visual/ac-verification.spec.ts:214:3 › Acceptance criteria verification › cold Status renders dial, racing comparison, and event feed (453ms)
  ✓   3 [chromium] › tests/visual/ac-verification.spec.ts:170:3 › Acceptance criteria verification › default public endpoint visit starts measuring (472ms)
  ✓   5 [chromium] › tests/visual/ac-verification.spec.ts:224:3 › Acceptance criteria verification › Status first paint shows verdict before the dial on desktop (495ms)
  ✓   6 [chromium] › tests/visual/ac-verification.spec.ts:158:3 › Acceptance criteria verification › data appears in the current Status surfaces after samples arrive (487ms)
  ✓   1 [chromium] › tests/visual/ac-verification.spec.ts:190:3 › Acceptance criteria verification › keyboard shortcut Escape closes overlay (569ms)
  ✓   4 [chromium] › tests/visual/ac-verification.spec.ts:178:3 › Acceptance criteria verification › keyboard shortcut ? opens overlay (581ms)
  ✓   7 [chromium] › tests/visual/ac-verification.spec.ts:202:3 › Acceptance criteria verification › endpoint rail renders default endpoint controls on desktop (592ms)
  ✓   8 [chromium] › tests/visual/ac-verification.spec.ts:229:3 › Acceptance criteria verification › Status first paint shows verdict before the dial on mobile (356ms)
  ✓  14 [chromium] › tests/visual/ac-verification.spec.ts:343:5 › UX polish @ 1440px › secondary topbar buttons do not use the run button class (426ms)
  ✓  13 [chromium] › tests/visual/ac-verification.spec.ts:330:5 › UX polish @ 1440px › run button uses the current run button contract (436ms)
  ✓  11 [chromium] › tests/visual/ac-verification.spec.ts:276:3 › Acceptance criteria verification › diagnostic narrative exposes confidence and browser timing limits (571ms)
  ✓  12 [chromium] › tests/visual/ac-verification.spec.ts:292:3 › Acceptance criteria verification › shared result link opens as a diagnostic report (507ms)
  ✓  15 [chromium] › tests/visual/ac-verification.spec.ts:349:5 › UX polish @ 1440px › enabled view shortcuts match the shipped views (342ms)
  ✓  17 [chromium] › tests/visual/ac-verification.spec.ts:362:5 › UX polish @ 1440px › no horizontal overflow (305ms)
  ✓  16 [chromium] › tests/visual/ac-verification.spec.ts:356:5 › UX polish @ 1440px › run button has a background transition for hover feedback (315ms)
  ✓   9 [chromium] › tests/visual/ac-verification.spec.ts:235:5 › Acceptance criteria verification › Investigate tab auto-selects an endpoint detail with data on desktop (887ms)
  ✓  10 [chromium] › tests/visual/ac-verification.spec.ts:235:5 › Acceptance criteria verification › Investigate tab auto-selects an endpoint detail with data on mobile (894ms)
  ✓  19 [chromium] › tests/visual/ac-verification.spec.ts:343:5 › UX polish @ 768px › secondary topbar buttons do not use the run button class (343ms)
  ✓  18 [chromium] › tests/visual/ac-verification.spec.ts:330:5 › UX polish @ 768px › run button uses the current run button contract (369ms)
  ✓  20 [chromium] › tests/visual/ac-verification.spec.ts:349:5 › UX polish @ 768px › enabled view shortcuts match the shipped views (369ms)
  ✓  22 [chromium] › tests/visual/ac-verification.spec.ts:362:5 › UX polish @ 768px › no horizontal overflow (304ms)
  ✓  21 [chromium] › tests/visual/ac-verification.spec.ts:356:5 › UX polish @ 768px › run button has a background transition for hover feedback (316ms)
  ✓  23 [chromium] › tests/visual/ac-verification.spec.ts:330:5 › UX polish @ 480px › run button uses the current run button contract (364ms)
  ✓  24 [chromium] › tests/visual/ac-verification.spec.ts:343:5 › UX polish @ 480px › secondary topbar buttons do not use the run button class (370ms)
  ✓  25 [chromium] › tests/visual/ac-verification.spec.ts:349:5 › UX polish @ 480px › enabled view shortcuts match the shipped views (394ms)
  ✓  26 [chromium] › tests/visual/ac-verification.spec.ts:356:5 › UX polish @ 480px › run button has a background transition for hover feedback (406ms)
  ✓  27 [chromium] › tests/visual/ac-verification.spec.ts:362:5 › UX polish @ 480px › no horizontal overflow (323ms)
  ✓  29 [chromium] › tests/visual/ac-verification.spec.ts:343:5 › UX polish @ 375px › secondary topbar buttons do not use the run button class (306ms)
  ✓  28 [chromium] › tests/visual/ac-verification.spec.ts:330:5 › UX polish @ 375px › run button uses the current run button contract (345ms)
  ✓  30 [chromium] › tests/visual/ac-verification.spec.ts:349:5 › UX polish @ 375px › enabled view shortcuts match the shipped views (318ms)
  ✓  31 [chromium] › tests/visual/ac-verification.spec.ts:356:5 › UX polish @ 375px › run button has a background transition for hover feedback (325ms)
  ✓  32 [chromium] › tests/visual/ac-verification.spec.ts:362:5 › UX polish @ 375px › no horizontal overflow (295ms)
  ✓  33 [chromium] › tests/visual/ac-verification.spec.ts:376:3 › 375px specific checks › Start/Stop keeps its text label (282ms)
  ✓  34 [chromium] › tests/visual/ac-verification.spec.ts:383:3 › 375px specific checks › secondary topbar buttons keep accessible labels (288ms)
  ✓  35 [chromium] › tests/visual/ac-verification.spec.ts:398:3 › prefers-reduced-motion › Dial emits no SVG animate elements in reduced motion (305ms)
  ✓  36 [chromium] › tests/visual/ac-verification.spec.ts:403:3 › prefers-reduced-motion › run button transition-duration is 0s (291ms)
  ✓  38 [mobile-chrome] › tests/visual/ac-verification.spec.ts:170:3 › Acceptance criteria verification › default public endpoint visit starts measuring (315ms)
  ✓  37 [mobile-chrome] › tests/visual/ac-verification.spec.ts:158:3 › Acceptance criteria verification › data appears in the current Status surfaces after samples arrive (349ms)
  ✓  40 [mobile-chrome] › tests/visual/ac-verification.spec.ts:178:3 › Acceptance criteria verification › keyboard shortcut ? opens overlay (409ms)
  ✓  39 [mobile-chrome] › tests/visual/ac-verification.spec.ts:190:3 › Acceptance criteria verification › keyboard shortcut Escape closes overlay (416ms)
  ✓  41 [mobile-chrome] › tests/visual/ac-verification.spec.ts:202:3 › Acceptance criteria verification › endpoint rail renders default endpoint controls on desktop (412ms)
  ✓  44 [mobile-chrome] › tests/visual/ac-verification.spec.ts:229:3 › Acceptance criteria verification › Status first paint shows verdict before the dial on mobile (370ms)
  ✓  43 [mobile-chrome] › tests/visual/ac-verification.spec.ts:214:3 › Acceptance criteria verification › cold Status renders dial, racing comparison, and event feed (519ms)
  ✓  42 [mobile-chrome] › tests/visual/ac-verification.spec.ts:224:3 › Acceptance criteria verification › Status first paint shows verdict before the dial on desktop (557ms)
  ✓  47 [mobile-chrome] › tests/visual/ac-verification.spec.ts:276:3 › Acceptance criteria verification › diagnostic narrative exposes confidence and browser timing limits (536ms)
  ✓  48 [mobile-chrome] › tests/visual/ac-verification.spec.ts:292:3 › Acceptance criteria verification › shared result link opens as a diagnostic report (495ms)
  ✓  49 [mobile-chrome] › tests/visual/ac-verification.spec.ts:330:5 › UX polish @ 1440px › run button uses the current run button contract (367ms)
  ✓  50 [mobile-chrome] › tests/visual/ac-verification.spec.ts:343:5 › UX polish @ 1440px › secondary topbar buttons do not use the run button class (335ms)
  ✓  45 [mobile-chrome] › tests/visual/ac-verification.spec.ts:235:5 › Acceptance criteria verification › Investigate tab auto-selects an endpoint detail with data on desktop (936ms)
  ✓  51 [mobile-chrome] › tests/visual/ac-verification.spec.ts:349:5 › UX polish @ 1440px › enabled view shortcuts match the shipped views (373ms)
  ✓  53 [mobile-chrome] › tests/visual/ac-verification.spec.ts:362:5 › UX polish @ 1440px › no horizontal overflow (306ms)
  ✓  46 [mobile-chrome] › tests/visual/ac-verification.spec.ts:235:5 › Acceptance criteria verification › Investigate tab auto-selects an endpoint detail with data on mobile (865ms)
  ✓  52 [mobile-chrome] › tests/visual/ac-verification.spec.ts:356:5 › UX polish @ 1440px › run button has a background transition for hover feedback (319ms)
  ✓  54 [mobile-chrome] › tests/visual/ac-verification.spec.ts:330:5 › UX polish @ 768px › run button uses the current run button contract (359ms)
  ✓  55 [mobile-chrome] › tests/visual/ac-verification.spec.ts:343:5 › UX polish @ 768px › secondary topbar buttons do not use the run button class (342ms)
  ✓  56 [mobile-chrome] › tests/visual/ac-verification.spec.ts:349:5 › UX polish @ 768px › enabled view shortcuts match the shipped views (341ms)
  ✓  57 [mobile-chrome] › tests/visual/ac-verification.spec.ts:356:5 › UX polish @ 768px › run button has a background transition for hover feedback (345ms)
  ✓  58 [mobile-chrome] › tests/visual/ac-verification.spec.ts:362:5 › UX polish @ 768px › no horizontal overflow (329ms)
  ✓  59 [mobile-chrome] › tests/visual/ac-verification.spec.ts:330:5 › UX polish @ 480px › run button uses the current run button contract (338ms)
  ✓  60 [mobile-chrome] › tests/visual/ac-verification.spec.ts:343:5 › UX polish @ 480px › secondary topbar buttons do not use the run button class (367ms)
  ✓  61 [mobile-chrome] › tests/visual/ac-verification.spec.ts:349:5 › UX polish @ 480px › enabled view shortcuts match the shipped views (335ms)
  ✓  62 [mobile-chrome] › tests/visual/ac-verification.spec.ts:356:5 › UX polish @ 480px › run button has a background transition for hover feedback (305ms)
  ✓  63 [mobile-chrome] › tests/visual/ac-verification.spec.ts:362:5 › UX polish @ 480px › no horizontal overflow (318ms)
  ✓  64 [mobile-chrome] › tests/visual/ac-verification.spec.ts:330:5 › UX polish @ 375px › run button uses the current run button contract (327ms)
  ✓  65 [mobile-chrome] › tests/visual/ac-verification.spec.ts:343:5 › UX polish @ 375px › secondary topbar buttons do not use the run button class (318ms)
  ✓  66 [mobile-chrome] › tests/visual/ac-verification.spec.ts:349:5 › UX polish @ 375px › enabled view shortcuts match the shipped views (321ms)
  ✓  67 [mobile-chrome] › tests/visual/ac-verification.spec.ts:356:5 › UX polish @ 375px › run button has a background transition for hover feedback (321ms)
  ✓  68 [mobile-chrome] › tests/visual/ac-verification.spec.ts:362:5 › UX polish @ 375px › no horizontal overflow (308ms)
  ✓  69 [mobile-chrome] › tests/visual/ac-verification.spec.ts:376:3 › 375px specific checks › Start/Stop keeps its text label (287ms)
  ✓  70 [mobile-chrome] › tests/visual/ac-verification.spec.ts:383:3 › 375px specific checks › secondary topbar buttons keep accessible labels (306ms)
  ✓  71 [mobile-chrome] › tests/visual/ac-verification.spec.ts:398:3 › prefers-reduced-motion › Dial emits no SVG animate elements in reduced motion (316ms)
  ✓  72 [mobile-chrome] › tests/visual/ac-verification.spec.ts:403:3 › prefers-reduced-motion › run button transition-duration is 0s (309ms)

  72 passed (6.1s)