### PR TITLE
Add diagnostic claim registry

### DIFF
--- a/docs/vision/10-star-product-roadmap.md
+++ b/docs/vision/10-star-product-roadmap.md
@@ -2,7 +2,7 @@
 
 **Status:** Living source of truth  
 **Created:** 2026-05-12  
-**Current production baseline:** `main` through PR #117, deployed to Cloudflare Pages
+**Current production baseline:** `main` through PR #126, deployed to Cloudflare Pages
 **Read this first in future sessions.**
 
 ---
@@ -79,6 +79,8 @@ Recent product spine:
 - PR #110-#114: Plain-language verdict and trust hierarchy polish.
 - PR #115: Guided triage actions.
 - PR #116: Executable triage evidence trail.
+- PR #119-#121: Guided proof flow with remote proof loop, focused local proof, and stale proof refresh.
+- PR #122-#126: Share/report excellence with support versus snapshot report modes, mode-specific rendering, and copy/visual guardrails.
 
 ---
 
@@ -341,3 +343,4 @@ The assistant should then:
 - Created this roadmap after PR #116 shipped the compact evidence trail and executable report triage actions.
 - Decided the next phase should be **Guided Proof Flow**, not another visual redesign.
 - Decided the product's highest-order constraint remains trust: every diagnostic claim must be tied to measured evidence, known browser limits, or an explicit next validation step.
+- Shipped Phase 1 and Phase 2 through PR #126. Phase 3 begins with a registry that makes evidence-gated claim language reusable across narrative, reports, evidence trail, remote vantage, and history surfaces.

--- a/src/lib/utils/claim-registry.ts
+++ b/src/lib/utils/claim-registry.ts
@@ -1,0 +1,105 @@
+import type {
+  DiagnosticClaim,
+  DiagnosticClaimKind,
+  DiagnosticConfidence,
+  DiagnosticEvidenceGate,
+} from './diagnostic-narrative';
+
+export type ClaimId =
+  | 'browser-measured-comparison'
+  | 'browser-visibility-limited'
+  | 'remote-vantage-measured'
+  | 'local-path-needs-proof'
+  | 'run-outside-check-next'
+  | 'run-local-agent-next';
+
+export interface ClaimEvidenceState {
+  readonly sampleReady: boolean;
+  readonly sampleActionable: boolean;
+  readonly sampleMature: boolean;
+  readonly allEnabledReady: boolean;
+  readonly totalTiming: boolean;
+  readonly phaseTiming: boolean;
+  readonly remoteVantage: boolean;
+  readonly baselineReady: boolean;
+  readonly localAgent: boolean;
+}
+
+interface ClaimTemplate {
+  readonly kind: DiagnosticClaimKind;
+  readonly strength: DiagnosticConfidence;
+  readonly requiredEvidence: readonly DiagnosticEvidenceGate[];
+  readonly text: (vars: Record<string, string>) => string;
+}
+
+const templates: Record<ClaimId, ClaimTemplate> = {
+  'browser-measured-comparison': {
+    kind: 'measured',
+    strength: 'medium',
+    requiredEvidence: ['sample-ready', 'all-enabled-ready', 'total-timing'],
+    text: (vars) => `Chronoscope measured ${vars.endpointLabel ?? 'this endpoint'} against the other enabled sites in this browser run.`,
+  },
+  'browser-visibility-limited': {
+    kind: 'limited',
+    strength: 'low',
+    requiredEvidence: ['total-timing'],
+    text: () => 'The browser can compare total load time, but some lower-level timing details are hidden.',
+  },
+  'remote-vantage-measured': {
+    kind: 'measured',
+    strength: 'medium',
+    requiredEvidence: ['remote-vantage'],
+    text: (vars) => `Cloudflare also measured ${vars.endpointLabel ?? 'this endpoint'} from outside this browser path.`,
+  },
+  'local-path-needs-proof': {
+    kind: 'inferred',
+    strength: 'low',
+    requiredEvidence: ['sample-actionable', 'remote-vantage'],
+    text: (vars) => `${vars.endpointLabel ?? 'This endpoint'} needs a local-agent or second-network check before naming the local path.`,
+  },
+  'run-outside-check-next': {
+    kind: 'next-validation',
+    strength: 'low',
+    requiredEvidence: [],
+    text: (vars) => `Run an outside check for ${vars.endpointLabel ?? 'this endpoint'} to compare your browser path with a Cloudflare edge.`,
+  },
+  'run-local-agent-next': {
+    kind: 'next-validation',
+    strength: 'low',
+    requiredEvidence: [],
+    text: (vars) => `Run the local agent for ${vars.endpointLabel ?? 'this endpoint'} to capture DNS, TLS, route, and WiFi evidence from this device.`,
+  },
+};
+
+const gateToState: Record<DiagnosticEvidenceGate, keyof ClaimEvidenceState> = {
+  'sample-ready': 'sampleReady',
+  'sample-actionable': 'sampleActionable',
+  'sample-mature': 'sampleMature',
+  'all-enabled-ready': 'allEnabledReady',
+  'total-timing': 'totalTiming',
+  'phase-timing': 'phaseTiming',
+  'remote-vantage': 'remoteVantage',
+  'baseline-ready': 'baselineReady',
+  'local-agent': 'localAgent',
+};
+
+export function canRenderClaim(id: ClaimId, evidence: ClaimEvidenceState): boolean {
+  return templates[id].requiredEvidence.every((gate) => evidence[gateToState[gate]]);
+}
+
+export function renderClaim(
+  id: ClaimId,
+  evidence: ClaimEvidenceState,
+  vars: Record<string, string> = {},
+): DiagnosticClaim | null {
+  const template = templates[id];
+  if (!canRenderClaim(id, evidence)) return null;
+  return {
+    id,
+    kind: template.kind,
+    strength: template.strength,
+    text: template.text(vars),
+    evidenceIds: template.requiredEvidence,
+    requiredEvidence: template.requiredEvidence,
+  };
+}

--- a/tests/unit/utils/claim-registry.test.ts
+++ b/tests/unit/utils/claim-registry.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canRenderClaim,
+  renderClaim,
+  type ClaimEvidenceState,
+} from '../../../src/lib/utils/claim-registry';
+
+const measured: ClaimEvidenceState = {
+  sampleReady: true,
+  sampleActionable: true,
+  sampleMature: true,
+  allEnabledReady: true,
+  totalTiming: true,
+  phaseTiming: false,
+  remoteVantage: false,
+  baselineReady: false,
+  localAgent: false,
+};
+
+describe('claim-registry', () => {
+  it('allows measured browser comparison claims when samples are ready', () => {
+    const claim = renderClaim('browser-measured-comparison', measured, { endpointLabel: 'API' });
+
+    expect(canRenderClaim('browser-measured-comparison', measured)).toBe(true);
+    expect(claim).toMatchObject({
+      id: 'browser-measured-comparison',
+      kind: 'measured',
+      strength: 'medium',
+      requiredEvidence: ['sample-ready', 'all-enabled-ready', 'total-timing'],
+    });
+    expect(claim?.text).toContain('measured');
+    expect(claim?.text).toContain('API');
+  });
+
+  it('blocks local-path claims without outside proof or local proof', () => {
+    expect(canRenderClaim('local-path-needs-proof', measured)).toBe(false);
+    expect(renderClaim('local-path-needs-proof', measured, { endpointLabel: 'API' })).toBeNull();
+  });
+
+  it('renders next validation claims when evidence is missing', () => {
+    expect(renderClaim('run-outside-check-next', measured, { endpointLabel: 'API' })).toMatchObject({
+      id: 'run-outside-check-next',
+      kind: 'next-validation',
+      text: 'Run an outside check for API to compare your browser path with a Cloudflare edge.',
+      requiredEvidence: [],
+    });
+  });
+
+  it('keeps registry text away from unsupported cause and fix claims', () => {
+    const rendered = [
+      renderClaim('browser-measured-comparison', measured, { endpointLabel: 'API' }),
+      renderClaim('browser-visibility-limited', measured),
+      renderClaim('run-outside-check-next', measured, { endpointLabel: 'API' }),
+      renderClaim('run-local-agent-next', measured, { endpointLabel: 'API' }),
+    ].filter((claim) => claim !== null);
+
+    for (const claim of rendered) {
+      expect(claim.text).not.toMatch(/your ISP is|your router is|the server is the cause|this will fix|guaranteed/i);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a central diagnostic claim registry with evidence gates for measured, limited, inferred, and next-validation claims.
- Adds registry tests for evidence gating, next-validation fallback copy, and forbidden overclaim language.
- Updates the 10-star roadmap baseline through PR #126 and marks Phase 3 as current.

## Test Plan
- npm test -- tests/unit/utils/claim-registry.test.ts
- npm run typecheck
- npm run lint
- npm run build
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated product roadmap reflecting Phase 1–2 completion and Phase 3 initiation focused on evidence-gated claim infrastructure.

* **New Features**
  * Introduced claim registry system with evidence-gating capabilities, enabling dynamic rendering of claims based on satisfied evidence requirements.

* **Tests**
  * Added unit tests for claim registry functionality, including evidence validation and claim rendering scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xaedyn/chronoscope/pull/127)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->