### PR TITLE
Wire claim registry into diagnostic narrative

### DIFF
--- a/docs/vision/10-star-product-roadmap.md
+++ b/docs/vision/10-star-product-roadmap.md
@@ -2,7 +2,7 @@
 
 **Status:** Living source of truth  
 **Created:** 2026-05-12  
-**Current production baseline:** `main` through PR #126, deployed to Cloudflare Pages
+**Current production baseline:** `main` through PR #127, deployed to Cloudflare Pages
 **Read this first in future sessions.**
 
 ---
@@ -81,6 +81,7 @@ Recent product spine:
 - PR #116: Executable triage evidence trail.
 - PR #119-#121: Guided proof flow with remote proof loop, focused local proof, and stale proof refresh.
 - PR #122-#126: Share/report excellence with support versus snapshot report modes, mode-specific rendering, and copy/visual guardrails.
+- PR #127: Claim registry foundation for evidence-gated diagnostic language.
 
 ---
 
@@ -343,4 +344,4 @@ The assistant should then:
 - Created this roadmap after PR #116 shipped the compact evidence trail and executable report triage actions.
 - Decided the next phase should be **Guided Proof Flow**, not another visual redesign.
 - Decided the product's highest-order constraint remains trust: every diagnostic claim must be tied to measured evidence, known browser limits, or an explicit next validation step.
-- Shipped Phase 1 and Phase 2 through PR #126. Phase 3 begins with a registry that makes evidence-gated claim language reusable across narrative, reports, evidence trail, remote vantage, and history surfaces.
+- Shipped Phase 1 and Phase 2 through PR #126. Phase 3 began with PR #127's registry, then continues by wiring registry-gated language through narrative, reports, evidence trail, remote vantage, and history surfaces.

--- a/src/lib/utils/diagnostic-narrative.ts
+++ b/src/lib/utils/diagnostic-narrative.ts
@@ -3,6 +3,7 @@
 // confidence, supporting evidence, browser visibility limits, and next steps.
 
 import type { MeasurementSample, Settings } from '../types';
+import { renderClaim, type ClaimEvidenceState, type ClaimId } from './claim-registry';
 import { computeCausalVerdict, PHASE_LABELS, type Verdict, type VerdictRow } from './verdict';
 
 export type DiagnosticKind =
@@ -528,6 +529,74 @@ function endpointLabelFor(verdict: Verdict, rows: readonly VerdictRow[]): string
   return rows.find((row) => row.ep.id === verdict.worstEpId)?.ep.label ?? 'the slow site';
 }
 
+function claimEvidenceStateFor(
+  readiness: ReturnType<typeof sampleReadiness>,
+  timingVisibility: TimingVisibility,
+): ClaimEvidenceState {
+  return {
+    sampleReady: readiness.minSamples >= MIN_READY_SAMPLES,
+    sampleActionable: readiness.allEnabledActionable,
+    sampleMature: readiness.allEnabledMature,
+    allEnabledReady: readiness.allEnabledReady,
+    totalTiming: timingVisibility.level !== 'none',
+    phaseTiming: timingVisibility.level === 'phase' || timingVisibility.level === 'mixed',
+    remoteVantage: false,
+    baselineReady: false,
+    localAgent: false,
+  };
+}
+
+function appendRegistryClaim(
+  claims: DiagnosticClaim[],
+  id: ClaimId,
+  evidence: ClaimEvidenceState,
+  vars: Record<string, string> = {},
+): void {
+  const claim = renderClaim(id, evidence, vars);
+  if (claim) claims.push(claim);
+}
+
+function registryClaimsFor(input: {
+  readonly kind: DiagnosticKind;
+  readonly verdict: Verdict;
+  readonly rows: readonly VerdictRow[];
+  readonly timingVisibility: TimingVisibility;
+  readonly readiness: ReturnType<typeof sampleReadiness>;
+}): readonly DiagnosticClaim[] {
+  const { kind, verdict, rows, timingVisibility, readiness } = input;
+  const evidence = claimEvidenceStateFor(readiness, timingVisibility);
+  const endpointLabel = endpointLabelFor(verdict, rows);
+  const claims: DiagnosticClaim[] = [];
+
+  if (kind === 'isolated-endpoint' && readiness.allEnabledActionable) {
+    appendRegistryClaim(claims, 'browser-measured-comparison', evidence, { endpointLabel });
+  }
+
+  if (timingVisibility.level === 'total-only' || timingVisibility.level === 'mixed') {
+    appendRegistryClaim(claims, 'browser-visibility-limited', evidence);
+  }
+
+  if (verdict.worstEpId !== undefined && readiness.allEnabledActionable) {
+    appendRegistryClaim(claims, 'run-outside-check-next', evidence, { endpointLabel });
+  }
+
+  if (
+    readiness.allEnabledActionable &&
+    (kind === 'shared-network' || kind === 'multiple-slow' || kind === 'packet-loss' || kind === 'jitter')
+  ) {
+    appendRegistryClaim(claims, 'run-local-agent-next', evidence, { endpointLabel: 'this result' });
+  }
+
+  return claims;
+}
+
+function registryClaimById(
+  claims: readonly DiagnosticClaim[],
+  id: ClaimId,
+): DiagnosticClaim | null {
+  return claims.find((claim) => claim.id === id) ?? null;
+}
+
 function triageActionsFor(input: {
   readonly kind: DiagnosticKind;
   readonly verdict: Verdict;
@@ -776,10 +845,21 @@ function primaryValidationFor(input: {
   readonly timingVisibility: TimingVisibility;
   readonly verdict: Verdict;
   readonly claim: DiagnosticClaim;
+  readonly registryClaims: readonly DiagnosticClaim[];
   readonly snapshotEligibility: SnapshotEligibility;
   readonly readiness: ReturnType<typeof sampleReadiness>;
 }): PrimaryValidationAction {
-  const { kind, rows, monitoredEndpointCount, timingVisibility, verdict, claim, snapshotEligibility, readiness } = input;
+  const {
+    kind,
+    rows,
+    monitoredEndpointCount,
+    timingVisibility,
+    verdict,
+    claim,
+    registryClaims,
+    snapshotEligibility,
+    readiness,
+  } = input;
   const minSamples = readiness.minSamples;
 
   // Priority 1: sample readiness outranks every other action so the UI does not
@@ -815,7 +895,7 @@ function primaryValidationFor(input: {
       id: 'explain-browser-visibility',
       label: 'Review browser visibility',
       reason: 'Chronoscope can compare total load time, but not every DNS, TCP, TLS, or server timing detail is visible.',
-      claim,
+      claim: registryClaimById(registryClaims, 'browser-visibility-limited') ?? claim,
       ...(verdict.worstEpId ? { endpointId: verdict.worstEpId } : {}),
     };
   }
@@ -827,7 +907,7 @@ function primaryValidationFor(input: {
       id: 'run-remote-check',
       label: 'Run remote check',
       reason: 'Compare this test from outside your network before assigning cause.',
-      claim,
+      claim: registryClaimById(registryClaims, 'run-outside-check-next') ?? claim,
       endpointId: verdict.worstEpId,
     };
   }
@@ -839,7 +919,7 @@ function primaryValidationFor(input: {
       id: 'compare-network',
       label: 'Compare another network',
       reason: 'This browser test shows the symptom; another network or the local agent can narrow where it appears.',
-      claim,
+      claim: registryClaimById(registryClaims, 'run-local-agent-next') ?? claim,
     };
   }
 
@@ -933,6 +1013,13 @@ export function buildDiagnosticNarrative(input: DiagnosticInput): DiagnosticNarr
     verdict,
     timingVisibility,
   });
+  const registryClaims = registryClaimsFor({
+    kind,
+    verdict,
+    rows: input.rows,
+    timingVisibility,
+    readiness,
+  });
   const evidence = evidenceFor({
     rows: input.rows,
     monitoredEndpointCount: input.monitoredEndpointCount,
@@ -955,6 +1042,7 @@ export function buildDiagnosticNarrative(input: DiagnosticInput): DiagnosticNarr
     timingVisibility,
     verdict,
     claim: primaryAnswer,
+    registryClaims,
     snapshotEligibility,
     readiness,
   });
@@ -974,7 +1062,7 @@ export function buildDiagnosticNarrative(input: DiagnosticInput): DiagnosticNarr
     confidenceLabel: `${confidence} confidence`,
     confidenceReason: confidenceReasonText,
     primaryAnswer,
-    claims: [primaryAnswer],
+    claims: [primaryAnswer, ...registryClaims],
     primaryValidation,
     safeSummary: safeSummaryFor(primaryAnswer, confidenceReasonText),
     supportingSummary: supportingSummaryFor({

--- a/src/lib/utils/diagnostic-report.ts
+++ b/src/lib/utils/diagnostic-report.ts
@@ -168,6 +168,9 @@ function buildCopySummary(report: Omit<DiagnosticReport, 'copySummary'>): string
   const visibility = report.diagnosis.timingVisibility;
   const limitation = report.diagnosis.limitations[0];
   const firstTriageAction = report.diagnosis.triageActions[0];
+  const validationLine = report.diagnosis.primaryValidation.claim.id !== report.diagnosis.primaryAnswer.id
+    ? `Next validation: ${report.diagnosis.primaryValidation.claim.text}`
+    : firstTriageAction ? `First next test: ${firstTriageAction.action}` : '';
   const reportLabel = report.reportKind === 'snapshot'
     ? 'Chronoscope performance snapshot'
     : 'Chronoscope support report';
@@ -178,7 +181,7 @@ function buildCopySummary(report: Omit<DiagnosticReport, 'copySummary'>): string
     slowLine,
     `Evidence: ${report.keptSampleCount} samples kept across ${report.endpointRows.length} endpoints; threshold ${fmtMs(report.threshold)}; browser visibility: ${visibility.headline}.`,
     limitation ? `Caveat: ${limitation.detail}` : '',
-    firstTriageAction ? `First next test: ${firstTriageAction.action}` : '',
+    validationLine,
     firstTriageAction ? `Watch for: ${firstTriageAction.watchFor}` : '',
   ].filter(Boolean).join('\n');
 }

--- a/tests/unit/utils/diagnostic-narrative.test.ts
+++ b/tests/unit/utils/diagnostic-narrative.test.ts
@@ -170,6 +170,20 @@ describe('buildDiagnosticNarrative', () => {
     expect(narrative.primaryAnswer.text).toBe('API is slower than the others in this test.');
     expect(narrative.primaryAnswer.kind).toBe('inferred');
     expect(narrative.primaryValidation.id).toBe('explain-browser-visibility');
+    expect(narrative.primaryValidation.claim).toMatchObject({
+      id: 'browser-visibility-limited',
+      kind: 'limited',
+      requiredEvidence: ['total-timing'],
+    });
+    expect(narrative.claims.map((claim) => claim.id)).toEqual([
+      'isolated-endpoint',
+      'browser-measured-comparison',
+      'browser-visibility-limited',
+      'run-outside-check-next',
+    ]);
+    expect(narrative.claims.find((claim) => claim.id === 'browser-measured-comparison')?.text).toBe(
+      'Chronoscope measured API against the other enabled sites in this browser run.',
+    );
     expect(narrative.evidence.some((item) => item.label === 'Site to inspect' && item.value === 'API')).toBe(true);
     expect(narrative.safeSummary).not.toMatch(/likely (source|site|network|your network)/i);
     expect(narrative.supportingSummary).toBe('Evidence: 18+ successful checks across 3 sites; total timing only.');
@@ -186,6 +200,42 @@ describe('buildDiagnosticNarrative', () => {
       requiredEvidence: ['all-enabled-ready', 'sample-actionable', 'total-timing'],
     });
     expect(narrative.triageActions[2].watchFor).toContain('outside check');
+  });
+
+  it('uses a registry next-validation claim when phase timing supports remote validation', () => {
+    const rows = [
+      row('api', { p50: 240, sampleCount: 18 }, 'API'),
+      row('google', { p50: 45, sampleCount: 18 }, 'Google'),
+      row('cloudflare', { p50: 35, sampleCount: 18 }, 'Cloudflare'),
+    ];
+    const narrative = buildDiagnosticNarrative({
+      rows,
+      threshold: 120,
+      corsMode: 'cors',
+      samplesByEndpoint: {
+        api: samples(18, 240, true),
+        google: samples(18, 45, true),
+        cloudflare: samples(18, 35, true),
+      },
+      monitoredEndpointCount: 3,
+    });
+
+    expect(narrative.primaryValidation.id).toBe('run-remote-check');
+    expect(narrative.primaryValidation.claim).toMatchObject({
+      id: 'run-outside-check-next',
+      kind: 'next-validation',
+      strength: 'low',
+      requiredEvidence: [],
+    });
+    expect(narrative.primaryValidation.claim.text).toBe(
+      'Run an outside check for API to compare your browser path with a Cloudflare edge.',
+    );
+    expect(narrative.claims.map((claim) => claim.id)).toEqual([
+      'isolated-endpoint',
+      'browser-measured-comparison',
+      'run-outside-check-next',
+    ]);
+    expect(narrative.claims.map((claim) => claim.text).join(' ')).not.toMatch(/likely|will fix|the problem is/i);
   });
 
   it('adds CORS and Timing-Allow-Origin guidance when timing is total-only', () => {

--- a/tests/unit/utils/diagnostic-report.test.ts
+++ b/tests/unit/utils/diagnostic-report.test.ts
@@ -147,7 +147,7 @@ describe('buildDiagnosticReport', () => {
     expect(report.copySummary).not.toContain(report.diagnosis.verdict.headline);
     expect(report.copySummary).toContain(report.diagnosis.primaryAnswer.text);
     expect(report.copySummary).toContain('Trust: Evidence: 30+ successful checks across 3 sites; total timing only.');
-    expect(report.copySummary).toContain('First next test: Review what the browser can and cannot see.');
+    expect(report.copySummary).toContain(`Next validation: ${report.diagnosis.primaryValidation.claim.text}`);
     expect(report.copySummary).toContain('Watch for: If detailed timing appears');
     expect(report.copySummary.match(new RegExp(report.diagnosis.primaryAnswer.text, 'g'))).toHaveLength(1);
     expect(report.copySummary).not.toMatch(/This browser test: .*This browser test:/s);


### PR DESCRIPTION
## Summary
- Wires the claim registry into diagnostic narrative output for measured browser comparison, browser-visibility limitation, and next-validation claims.
- Makes primary validation and copied report summaries reuse registry-gated validation copy instead of ad hoc action text.
- Updates the 10-star roadmap baseline through PR #127.

## Test Plan
- npm test -- tests/unit/utils/diagnostic-narrative.test.ts tests/unit/utils/diagnostic-report.test.ts
- npm test -- tests/unit/utils/claim-registry.test.ts tests/unit/user-facing-copy-safety.test.ts tests/unit/components/CausalVerdictStrip.test.ts tests/unit/utils/evidence-trail.test.ts
- npm run typecheck
- npm run lint
- npm run build
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated product roadmap to reflect the latest release and claim registry foundation.

* **New Features**
  * Enhanced diagnostic claims with more granular, context-specific validation information.
  * Improved validation reporting with dynamic next-step recommendations based on diagnostic context.

* **Tests**
  * Expanded test coverage for diagnostic claim generation and validation message formatting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xaedyn/chronoscope/pull/128)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->