### PR TITLE
Harden trust copy surfaces

### DIFF
--- a/docs/vision/10-star-product-roadmap.md
+++ b/docs/vision/10-star-product-roadmap.md
@@ -2,7 +2,7 @@
 
 **Status:** Living source of truth  
 **Created:** 2026-05-12  
-**Current production baseline:** `main` through PR #127, deployed to Cloudflare Pages
+**Current production baseline:** `main` through PR #128, deployed to Cloudflare Pages
 **Read this first in future sessions.**
 
 ---
@@ -82,6 +82,7 @@ Recent product spine:
 - PR #119-#121: Guided proof flow with remote proof loop, focused local proof, and stale proof refresh.
 - PR #122-#126: Share/report excellence with support versus snapshot report modes, mode-specific rendering, and copy/visual guardrails.
 - PR #127: Claim registry foundation for evidence-gated diagnostic language.
+- PR #128: Claim registry wired into diagnostic narrative validation and copied report summaries.
 
 ---
 
@@ -344,4 +345,4 @@ The assistant should then:
 - Created this roadmap after PR #116 shipped the compact evidence trail and executable report triage actions.
 - Decided the next phase should be **Guided Proof Flow**, not another visual redesign.
 - Decided the product's highest-order constraint remains trust: every diagnostic claim must be tied to measured evidence, known browser limits, or an explicit next validation step.
-- Shipped Phase 1 and Phase 2 through PR #126. Phase 3 began with PR #127's registry, then continues by wiring registry-gated language through narrative, reports, evidence trail, remote vantage, and history surfaces.
+- Shipped Phase 1 and Phase 2 through PR #126. Phase 3 began with PR #127's registry and PR #128's narrative/report wiring, then continues by extending registry-gated language and copy safety through evidence trail, remote vantage, and history surfaces.

--- a/src/lib/remote-vantage/insight.ts
+++ b/src/lib/remote-vantage/insight.ts
@@ -78,7 +78,7 @@ export function buildRemoteVantageInsight(input: RemoteVantageInsightInput): Rem
       status: 'local-path',
       headline: `This outside check reached ${label} within threshold`,
       detail: `${edge} measured ${fmtMs(result.durationMs)} while your browser p50 measured ${fmtMs(browserP50 ?? 0)}.`,
-      action: 'Use the local companion agent or another network to add local-path evidence.',
+      action: 'Run the local agent or compare another network to test whether the slowdown follows this connection.',
       edgeLabel: edge,
       result,
     };
@@ -100,7 +100,7 @@ export function buildRemoteVantageInsight(input: RemoteVantageInsightInput): Rem
       status: 'remote-slow-only',
       headline: `${label} is slow from ${edge}, but not your browser`,
       detail: `Only the outside check was elevated in this snapshot${browserP50 !== null ? `; your browser p50 measured ${fmtMs(browserP50)}` : ''}.`,
-      action: 'Run the check again or compare another outside vantage before deciding what to inspect next.',
+      action: 'Run the outside check again, or compare another outside vantage, before choosing the next test.',
       edgeLabel: edge,
       result,
     };

--- a/src/lib/utils/evidence-trail.ts
+++ b/src/lib/utils/evidence-trail.ts
@@ -73,8 +73,8 @@ function confidenceStatus(confidence: DiagnosticReport['diagnosis']['confidence'
   return confidence.charAt(0).toUpperCase() + confidence.slice(1);
 }
 
-function staleProofDetail(source: 'outside check' | 'local agent'): string {
-  return `This ${source} was captured before the report snapshot. Run it again to refresh the proof.`;
+function staleEvidenceDetail(source: 'outside check' | 'local agent'): string {
+  return `This ${source} was captured before the report snapshot. Run it again to refresh the evidence.`;
 }
 
 function remoteTrail(
@@ -98,7 +98,7 @@ function remoteTrail(
         : summary.text),
       status: stale ? freshness : summary.status,
       tone: stale ? 'watch' : summary.tone,
-      detail: stale ? staleProofDetail('outside check') : `Checked from ${edge}.`,
+      detail: stale ? staleEvidenceDetail('outside check') : `Checked from ${edge}.`,
     };
   }
 
@@ -149,7 +149,7 @@ function companionTrail(
       fact: truncateFact(summary.text),
       status: stale ? freshness : summary.status,
       tone: stale ? 'watch' : summary.tone,
-      detail: stale ? staleProofDetail('local agent') : undefined,
+      detail: stale ? staleEvidenceDetail('local agent') : undefined,
     };
   }
 
@@ -177,7 +177,7 @@ function companionTrail(
     return {
       id: 'local-agent',
       source: 'Local agent',
-      fact: 'Local agent proof is not captured.',
+      fact: 'Local agent evidence is not captured.',
       status: companion.hasSecret ? 'Needs check' : 'Needs setup',
       tone: 'watch',
       detail: truncateFact(companion.error),

--- a/src/lib/utils/history-baseline.ts
+++ b/src/lib/utils/history-baseline.ts
@@ -135,7 +135,7 @@ function classifyComparison(input: {
       status: 'severe',
       p50Ratio,
       p95Ratio,
-      summary: `Current p50 is ${fmtRatio(p50Ratio)} baseline (${fmtMs(current.p50)} vs ${fmtMs(baselineP50)}).`,
+      summary: `Current median is ${fmtRatio(p50Ratio)} baseline (${fmtMs(current.p50)} vs ${fmtMs(baselineP50)}).`,
     };
   }
 
@@ -144,7 +144,7 @@ function classifyComparison(input: {
       status: 'elevated',
       p50Ratio,
       p95Ratio,
-      summary: `Current p50 is ${fmtRatio(p50Ratio)} baseline (${fmtMs(current.p50)} vs ${fmtMs(baselineP50)}).`,
+      summary: `Current median is ${fmtRatio(p50Ratio)} baseline (${fmtMs(current.p50)} vs ${fmtMs(baselineP50)}).`,
     };
   }
 
@@ -152,7 +152,7 @@ function classifyComparison(input: {
     status: 'normal',
     p50Ratio,
     p95Ratio,
-    summary: `Current p50 is close to baseline (${fmtMs(current.p50)} vs ${fmtMs(baselineP50)}).`,
+    summary: `Current median is close to baseline (${fmtMs(current.p50)} vs ${fmtMs(baselineP50)}).`,
   };
 }
 
@@ -260,7 +260,7 @@ export function buildHistoryBaselineInsight(input: BuildHistoryBaselineInsightIn
     return {
       status: 'severe',
       headline: `${worst.label} is far above its local baseline.`,
-      detail: `${worst.label} is ${multiple} above its usual latency across ${worst.priorSessionCount} prior local runs. ${worst.summary}`,
+      detail: `${worst.label} is ${multiple} above its prior local baseline across ${worst.priorSessionCount} prior local runs. ${worst.summary}`,
       privacyNote: PRIVACY_NOTE,
       comparisons,
     };
@@ -271,7 +271,7 @@ export function buildHistoryBaselineInsight(input: BuildHistoryBaselineInsightIn
     return {
       status: 'elevated',
       headline: `${worst.label} is above its local baseline.`,
-      detail: `${worst.label} is ${multiple} above its usual latency across ${worst.priorSessionCount} prior local runs. ${worst.summary}`,
+      detail: `${worst.label} is ${multiple} above its prior local baseline across ${worst.priorSessionCount} prior local runs. ${worst.summary}`,
       privacyNote: PRIVACY_NOTE,
       comparisons,
     };

--- a/tests/unit/remote-vantage/insight.test.ts
+++ b/tests/unit/remote-vantage/insight.test.ts
@@ -71,7 +71,9 @@ describe('buildRemoteVantageInsight', () => {
     expect(insight.status).toBe('local-path');
     expect(insight.headline).toContain('outside check reached API within threshold');
     expect(insight.detail).toContain('browser p50 measured');
+    expect(insight.action).toBe('Run the local agent or compare another network to test whether the slowdown follows this connection.');
     expect(insight.detail).not.toMatch(/ISP|VPN|WiFi|local network/i);
+    expect(insightCopy(insight)).not.toMatch(/local-path evidence|cause|likely/i);
   });
 
   it('calls out shared outside trouble when both local and remote vantage are slow', () => {
@@ -97,6 +99,7 @@ describe('buildRemoteVantageInsight', () => {
 
     expect(insight.status).toBe('remote-slow-only');
     expect(insight.detail).toContain('Only the outside check was elevated');
+    expect(insight.action).toBe('Run the outside check again, or compare another outside vantage, before choosing the next test.');
     expect(insight.action).not.toMatch(/blaming|likely/i);
   });
 

--- a/tests/unit/user-facing-copy-safety.test.ts
+++ b/tests/unit/user-facing-copy-safety.test.ts
@@ -25,6 +25,9 @@ const forbiddenClaims: readonly RegExp[] = [
   /your ISP is/i,
   /your router is/i,
   /the server is the cause/i,
+  /local-path evidence/i,
+  /usual latency/i,
+  /before deciding what to inspect/i,
 ];
 
 const reportModeTerms: readonly string[] = [

--- a/tests/unit/utils/evidence-trail.test.ts
+++ b/tests/unit/utils/evidence-trail.test.ts
@@ -183,6 +183,7 @@ describe('buildEvidenceTrail', () => {
       expect(item.status.length).toBeLessThanOrEqual(18);
       expect(item.fact.length).toBeLessThanOrEqual(96);
       expect(item.fact).not.toMatch(/likely|probably|wild goose chase|router|ISP/i);
+      expect(`${item.fact} ${item.detail ?? ''}`).not.toMatch(/\bproof\b/i);
     }
   });
 
@@ -269,6 +270,7 @@ describe('buildEvidenceTrail', () => {
     expect(trail.find((item) => item.id === 'outside-check')).toMatchObject({
       status: 'Stale',
       tone: 'watch',
+      detail: 'This outside check was captured before the report snapshot. Run it again to refresh the evidence.',
     });
   });
 
@@ -293,6 +295,7 @@ describe('buildEvidenceTrail', () => {
     expect(trail.find((item) => item.id === 'local-agent')).toMatchObject({
       status: 'Stale',
       tone: 'watch',
+      detail: 'This local agent was captured before the report snapshot. Run it again to refresh the evidence.',
     });
   });
 });

--- a/tests/unit/utils/history-baseline.test.ts
+++ b/tests/unit/utils/history-baseline.test.ts
@@ -115,6 +115,9 @@ describe('history baseline insight', () => {
     expect(insight.status).toBe('severe');
     expect(insight.headline).toContain('API');
     expect(insight.detail).toContain('3.1x');
+    expect(insight.detail).toContain('prior local baseline');
+    expect(insight.detail).not.toMatch(/usual latency|cause|likely/i);
+    expect(insight.comparisons[0]?.summary).toContain('Current median');
     expect(insight.comparisons[0]?.status).toBe('severe');
   });
 


### PR DESCRIPTION
## Summary
- Tightens remote-vantage, evidence-trail, and history-baseline copy to avoid overclaiming and reduce jargon.
- Expands user-facing copy safety tests for local-path, usual-latency, and inspect-decision phrasing.
- Updates the 10-star roadmap baseline through PR #128.

## Test Plan
- npm test -- tests/unit/user-facing-copy-safety.test.ts tests/unit/remote-vantage/insight.test.ts tests/unit/utils/history-baseline.test.ts tests/unit/utils/evidence-trail.test.ts
- npm run typecheck
- npm run lint
- npm run build
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated production roadmap tracking through latest release.

* **Improvements**
  * Refined diagnostic action messages to provide clearer guidance for remote vantage scenarios.
  * Updated baseline comparison language for improved clarity (e.g., "Current median" phrasing).
  * Standardized evidence terminology consistently across diagnostic reports.

* **Tests**
  * Expanded copy safety validation to ensure diagnostic messaging quality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xaedyn/chronoscope/pull/129)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->