### PR TITLE
Polish plain-language metric copy

### DIFF
--- a/docs/vision/10-star-product-roadmap.md
+++ b/docs/vision/10-star-product-roadmap.md
@@ -2,7 +2,7 @@
 
 **Status:** Living source of truth  
 **Created:** 2026-05-12  
-**Current production baseline:** `main` through PR #128, deployed to Cloudflare Pages
+**Current production baseline:** `main` through PR #129, deployed to Cloudflare Pages
 **Read this first in future sessions.**
 
 ---
@@ -83,6 +83,7 @@ Recent product spine:
 - PR #122-#126: Share/report excellence with support versus snapshot report modes, mode-specific rendering, and copy/visual guardrails.
 - PR #127: Claim registry foundation for evidence-gated diagnostic language.
 - PR #128: Claim registry wired into diagnostic narrative validation and copied report summaries.
+- PR #129: Trust-copy hardening for remote vantage, evidence trail, and history baseline surfaces.
 
 ---
 
@@ -345,4 +346,4 @@ The assistant should then:
 - Created this roadmap after PR #116 shipped the compact evidence trail and executable report triage actions.
 - Decided the next phase should be **Guided Proof Flow**, not another visual redesign.
 - Decided the product's highest-order constraint remains trust: every diagnostic claim must be tied to measured evidence, known browser limits, or an explicit next validation step.
-- Shipped Phase 1 and Phase 2 through PR #126. Phase 3 began with PR #127's registry and PR #128's narrative/report wiring, then continues by extending registry-gated language and copy safety through evidence trail, remote vantage, and history surfaces.
+- Shipped Phase 1 and Phase 2 through PR #126. Phase 3 began with PR #127's registry and PR #128's narrative/report wiring, then PR #129 extended trust-copy guardrails through evidence trail, remote vantage, and history baseline surfaces. The current Phase 3 focus is plain-language metric copy that keeps engineering terms available in data models without exposing them as unexplained user-facing shorthand.

--- a/src/lib/remote-vantage/insight.ts
+++ b/src/lib/remote-vantage/insight.ts
@@ -56,8 +56,8 @@ export function buildRemoteVantageInsight(input: RemoteVantageInsightInput): Rem
     };
   }
 
-  const browserP50 = input.stats?.ready ? input.stats.p50 : null;
-  const browserSlow = browserP50 !== null && browserP50 > input.threshold;
+  const browserMedian = input.stats?.ready ? input.stats.p50 : null;
+  const browserSlow = browserMedian !== null && browserMedian > input.threshold;
   const remoteSlow = result.verdict === 'slow' || result.durationMs > input.threshold;
 
   if (!result.ok || result.verdict === 'unreachable' || result.verdict === 'http-error') {
@@ -77,7 +77,7 @@ export function buildRemoteVantageInsight(input: RemoteVantageInsightInput): Rem
     return {
       status: 'local-path',
       headline: `This outside check reached ${label} within threshold`,
-      detail: `${edge} measured ${fmtMs(result.durationMs)} while your browser p50 measured ${fmtMs(browserP50 ?? 0)}.`,
+      detail: `${edge} measured ${fmtMs(result.durationMs)} while your browser median measured ${fmtMs(browserMedian ?? 0)}.`,
       action: 'Run the local agent or compare another network to test whether the slowdown follows this connection.',
       edgeLabel: edge,
       result,
@@ -88,7 +88,7 @@ export function buildRemoteVantageInsight(input: RemoteVantageInsightInput): Rem
     return {
       status: 'remote-confirms',
       headline: `${label} was also slow from Cloudflare`,
-      detail: `${edge} took ${fmtMs(result.durationMs)} and your browser p50 is ${fmtMs(browserP50 ?? 0)}; both vantage points observed elevated latency.`,
+      detail: `${edge} took ${fmtMs(result.durationMs)} and your browser median is ${fmtMs(browserMedian ?? 0)}; both checks measured this endpoint above the threshold.`,
       action: 'Share the report with the service owner; it now contains outside-vantage evidence.',
       edgeLabel: edge,
       result,
@@ -99,7 +99,7 @@ export function buildRemoteVantageInsight(input: RemoteVantageInsightInput): Rem
     return {
       status: 'remote-slow-only',
       headline: `${label} is slow from ${edge}, but not your browser`,
-      detail: `Only the outside check was elevated in this snapshot${browserP50 !== null ? `; your browser p50 measured ${fmtMs(browserP50)}` : ''}.`,
+      detail: `Only the outside check was above the threshold in this snapshot${browserMedian !== null ? `; your browser median measured ${fmtMs(browserMedian)}` : ''}.`,
       action: 'Run the outside check again, or compare another outside vantage, before choosing the next test.',
       edgeLabel: edge,
       result,

--- a/src/lib/utils/diagnostic-report.ts
+++ b/src/lib/utils/diagnostic-report.ts
@@ -163,7 +163,7 @@ function buildEndpointRows(input: {
 function buildCopySummary(report: Omit<DiagnosticReport, 'copySummary'>): string {
   const slowRows = report.endpointRows.filter((row) => row.status === 'slow' || row.implicated);
   const slowLine = slowRows.length > 0
-    ? `Endpoints to inspect: ${slowRows.map((row) => `${row.label} (${fmtMs(row.p50)} p50)`).join(', ')}.`
+    ? `Endpoints to inspect: ${slowRows.map((row) => `${row.label} (${fmtMs(row.p50)} median)`).join(', ')}.`
     : 'No endpoint is currently above the report threshold.';
   const visibility = report.diagnosis.timingVisibility;
   const limitation = report.diagnosis.limitations[0];

--- a/tests/unit/remote-vantage/insight.test.ts
+++ b/tests/unit/remote-vantage/insight.test.ts
@@ -70,7 +70,7 @@ describe('buildRemoteVantageInsight', () => {
 
     expect(insight.status).toBe('local-path');
     expect(insight.headline).toContain('outside check reached API within threshold');
-    expect(insight.detail).toContain('browser p50 measured');
+    expect(insight.detail).toContain('browser median measured');
     expect(insight.action).toBe('Run the local agent or compare another network to test whether the slowdown follows this connection.');
     expect(insight.detail).not.toMatch(/ISP|VPN|WiFi|local network/i);
     expect(insightCopy(insight)).not.toMatch(/local-path evidence|cause|likely/i);
@@ -86,6 +86,7 @@ describe('buildRemoteVantageInsight', () => {
 
     expect(insight.status).toBe('remote-confirms');
     expect(insight.headline).toContain('was also slow from Cloudflare');
+    expect(insight.detail).toContain('both checks measured this endpoint above the threshold');
     expect(insight.detail).not.toMatch(/implicated|likely/i);
   });
 
@@ -98,7 +99,7 @@ describe('buildRemoteVantageInsight', () => {
     });
 
     expect(insight.status).toBe('remote-slow-only');
-    expect(insight.detail).toContain('Only the outside check was elevated');
+    expect(insight.detail).toContain('Only the outside check was above the threshold');
     expect(insight.action).toBe('Run the outside check again, or compare another outside vantage, before choosing the next test.');
     expect(insight.action).not.toMatch(/blaming|likely/i);
   });
@@ -164,6 +165,7 @@ describe('buildRemoteVantageInsight', () => {
 
     for (const insight of states) {
       expect(insightCopy(insight)).not.toMatch(/origin|cause|likely|healthy|local network|ISP|VPN/i);
+      expect(insightCopy(insight)).not.toMatch(/\bp50\b|elevated latency/i);
       expect(insightCopy(insight)).not.toMatch(/reaches .* normally/i);
       expect(insightCopy(insight)).not.toMatch(/outside edge path/i);
     }

--- a/tests/unit/user-facing-copy-safety.test.ts
+++ b/tests/unit/user-facing-copy-safety.test.ts
@@ -28,6 +28,9 @@ const forbiddenClaims: readonly RegExp[] = [
   /local-path evidence/i,
   /usual latency/i,
   /before deciding what to inspect/i,
+  /browser p50/i,
+  / p50\)/i,
+  /elevated latency/i,
 ];
 
 const reportModeTerms: readonly string[] = [

--- a/tests/unit/utils/diagnostic-report.test.ts
+++ b/tests/unit/utils/diagnostic-report.test.ts
@@ -141,8 +141,10 @@ describe('buildDiagnosticReport', () => {
     expect(report.endpointRows.find((row) => row.endpointId === 'api')?.implicated).toBe(true);
     expect(report.endpointRows.find((row) => row.endpointId === 'api')?.statusLabel).toBe('inspect');
     expect(report.copySummary).toContain('API');
+    expect(report.copySummary).toContain('API (240 ms median)');
     expect(report.copySummary).toContain('Chronoscope support report:');
     expect(report.copySummary).toContain('threshold 120 ms');
+    expect(report.copySummary).not.toMatch(/\bp50\b/i);
     expect(report.copySummary).not.toMatch(/likely (affected|source|site|network|your network)/i);
     expect(report.copySummary).not.toContain(report.diagnosis.verdict.headline);
     expect(report.copySummary).toContain(report.diagnosis.primaryAnswer.text);


### PR DESCRIPTION
## Summary
- replace user-facing p50 shorthand with median language in copied report summaries and remote-vantage explanations
- tighten outside-vantage slow wording around measured threshold evidence
- expand copy safety tests and update the 10-star roadmap baseline through PR #129

## Test plan
- npm test -- tests/unit/utils/diagnostic-report.test.ts tests/unit/remote-vantage/insight.test.ts tests/unit/user-facing-copy-safety.test.ts
- npm run typecheck
- npm run lint
- npm run build
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product roadmap with latest deployment status and Phase 3 focus details.
  * Refined diagnostic message and report wording to use "median" terminology.

* **Tests**
  * Updated test expectations to match revised message copy and strengthened user-facing copy safety guardrails.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xaedyn/chronoscope/pull/130)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->