### PR TITLE
Guide local agent pairing

### DIFF
--- a/docs/companion-local-agent.md
+++ b/docs/companion-local-agent.md
@@ -10,6 +10,8 @@ npm run companion
 
 The agent writes a one-time pairing token to `~/.chronoscope/agent-token.txt`. Paste that token into Chronoscope Settings under `Local Companion`.
 
+Chronoscope only connects to the agent on loopback, normally `http://127.0.0.1:47317`. Health checks are unsigned so the browser can confirm the agent is running. Probe and history requests are signed with the pairing token, timestamp, and nonce.
+
 ## Configuration
 
 ```bash
@@ -20,8 +22,16 @@ CHRONOSCOPE_ALLOWED_ORIGINS="https://chronoscope.dev,http://localhost:5173,http:
 npm run companion
 ```
 
-The HTTP server binds to `127.0.0.1` and rejects non-loopback browser configuration. Probe and history requests are signed with HMAC-SHA256 using timestamp and nonce headers; replayed or stale requests are rejected.
+The HTTP server binds to `127.0.0.1` and rejects non-loopback browser configuration. Replayed or stale signed requests are rejected.
 
 ## Privacy
 
 WiFi SSID and BSSID are shown only when `Private WiFi` is selected; otherwise they are redacted. Probe history is stored locally in SQLite at `~/.chronoscope/agent-history.sqlite` by default.
+
+## What Local Probes Can Prove
+
+- DNS shows what this computer resolved for the target host. It does not prove every resolver or network will resolve the same way.
+- TLS shows the certificate and handshake details visible from this computer. It does not prove the remote service is healthy for everyone.
+- Route/MTR shows the path tool output available on this device. It can show a local-path clue, but missing hops or blocked probes are common.
+- WiFi shows local signal and noise when available. Private SSID and BSSID values stay redacted unless explicitly enabled for the run.
+- History shows prior local-agent probes stored on this computer. It is local context, not public report evidence unless explicitly exported in a later flow.

--- a/docs/vision/10-star-product-roadmap.md
+++ b/docs/vision/10-star-product-roadmap.md
@@ -2,7 +2,7 @@
 
 **Status:** Living source of truth  
 **Created:** 2026-05-12  
-**Current production baseline:** `main` through PR #129, deployed to Cloudflare Pages
+**Current production baseline:** `main` through PR #130, deployed to Cloudflare Pages
 **Read this first in future sessions.**
 
 ---
@@ -84,6 +84,7 @@ Recent product spine:
 - PR #127: Claim registry foundation for evidence-gated diagnostic language.
 - PR #128: Claim registry wired into diagnostic narrative validation and copied report summaries.
 - PR #129: Trust-copy hardening for remote vantage, evidence trail, and history baseline surfaces.
+- PR #130: Plain-language metric copy for copied reports and outside-vantage explanations.
 
 ---
 
@@ -346,4 +347,4 @@ The assistant should then:
 - Created this roadmap after PR #116 shipped the compact evidence trail and executable report triage actions.
 - Decided the next phase should be **Guided Proof Flow**, not another visual redesign.
 - Decided the product's highest-order constraint remains trust: every diagnostic claim must be tied to measured evidence, known browser limits, or an explicit next validation step.
-- Shipped Phase 1 and Phase 2 through PR #126. Phase 3 began with PR #127's registry and PR #128's narrative/report wiring, then PR #129 extended trust-copy guardrails through evidence trail, remote vantage, and history baseline surfaces. The current Phase 3 focus is plain-language metric copy that keeps engineering terms available in data models without exposing them as unexplained user-facing shorthand.
+- Shipped Phase 1 and Phase 2 through PR #126. Phase 3 began with PR #127's registry and PR #128's narrative/report wiring, then PR #129 extended trust-copy guardrails through evidence trail, remote vantage, and history baseline surfaces. PR #130 completed the plain-language metric copy slice by keeping internal p50 data while exposing median language in copied report and outside-vantage text.

--- a/src/lib/components/CompanionPanel.svelte
+++ b/src/lib/components/CompanionPanel.svelte
@@ -113,6 +113,17 @@
     <span class="status-pill" data-status={state.status}>{statusLabel}</span>
   </div>
 
+  <p class="agent-note">
+    Local-only: Chronoscope talks to 127.0.0.1. Signed probes use the token at ~/.chronoscope/agent-token.txt.
+  </p>
+
+  <div class="health-row" aria-live="polite">
+    <span>Health check: {statusLabel}</span>
+    {#if state.version}
+      <span>Agent {state.version}</span>
+    {/if}
+  </div>
+
   <label class="field-line" for={urlId}>
     <span>Agent URL</span>
     <input
@@ -202,6 +213,10 @@
       </label>
     </div>
 
+    <p class="agent-note subtle">
+      Private WiFi is off by default; SSID and BSSID stay redacted unless enabled for this run.
+    </p>
+
     <button
       type="button"
       class="agent-btn primary full"
@@ -267,6 +282,35 @@
     padding: 2px 7px;
     border: 1px solid var(--glass-border);
     border-radius: 999px;
+    color: var(--t3);
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0;
+  }
+
+  .agent-note {
+    margin: 0;
+    color: var(--t2);
+    font-family: var(--sans);
+    font-size: 12px;
+    line-height: 1.45;
+    overflow-wrap: anywhere;
+  }
+
+  .agent-note.subtle {
+    color: var(--t3);
+    font-size: 11px;
+  }
+
+  .health-row {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--spacing-xs);
+    min-width: 0;
+    padding: var(--spacing-xs) var(--spacing-sm);
+    border: 1px solid var(--glass-border);
+    border-radius: var(--btn-radius);
+    background: rgba(0,0,0,.14);
     color: var(--t3);
     font-family: var(--mono);
     font-size: 10px;

--- a/tests/unit/components/CompanionPanel.test.ts
+++ b/tests/unit/components/CompanionPanel.test.ts
@@ -63,6 +63,16 @@ beforeEach(() => {
 });
 
 describe('CompanionPanel', () => {
+  it('guides first-time pairing without enabling private WiFi sharing by default', () => {
+    const store = createFakeCompanionStore();
+    const { getByLabelText, getByText } = render(CompanionPanel, { props: { agentStore: store } });
+
+    expect(getByText(/local-only/i)).toBeTruthy();
+    expect(getByText(/agent-token\.txt/i)).toBeTruthy();
+    expect(getByText(/Health check: Offline/i)).toBeTruthy();
+    expect((getByLabelText('Private WiFi') as HTMLInputElement).checked).toBe(false);
+  });
+
   it('checks local companion health with the configured loopback URL', async () => {
     const store = createFakeCompanionStore();
     const { getByLabelText, getByRole, findByText } = render(CompanionPanel, { props: { agentStore: store } });


### PR DESCRIPTION
## Summary
- add compact local-only pairing guidance, token path, and health-check state to the companion panel
- keep Private WiFi off by default with visible redaction guidance
- expand local companion docs with loopback, signed request, privacy, and probe evidence boundaries
- update the 10-star roadmap baseline through PR #130

## Test plan
- npm test -- tests/unit/components/CompanionPanel.test.ts
- npm run typecheck
- npm run lint
- npm run build
- npm test
- Playwright rendered check at http://127.0.0.1:5174/ for desktop and 390px mobile companion settings panel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced local agent documentation covering connectivity, request security (signed probes and unsigned health checks), and privacy configuration details.
  * Updated product roadmap with latest release progress.

* **New Features**
  * Added health status display with agent version information in the companion panel.
  * Added "Local-only" agent indicator and clarified WiFi privacy settings (disabled by default, with SSID/BSSID redacted unless explicitly enabled).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xaedyn/chronoscope/pull/131)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->