### PR TITLE
Type local companion probe results

### DIFF
--- a/companion/local-agent.cjs
+++ b/companion/local-agent.cjs
@@ -141,11 +141,37 @@ function timeoutPromise(ms, label) {
   });
 }
 
-async function timed(label, fn) {
+async function timed(label, fn, timeoutMs = 7000) {
   const startedAt = Date.now();
   try {
-    const value = await Promise.race([fn(), timeoutPromise(7000, label)]);
+    const value = await Promise.race([fn(), timeoutPromise(timeoutMs, label)]);
     return { ok: true, durationMs: Date.now() - startedAt, value };
+  } catch (error) {
+    return {
+      ok: false,
+      durationMs: Date.now() - startedAt,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+async function timedSection(label, fn, timeoutMs = 7000) {
+  const startedAt = Date.now();
+  try {
+    const result = await Promise.race([fn(), timeoutPromise(timeoutMs, label)]);
+    const durationMs = Date.now() - startedAt;
+    if (result && typeof result === 'object' && result.ok === false) {
+      const { ok, error, unavailable, reason, ...value } = result;
+      return {
+        ok,
+        durationMs,
+        ...(Object.keys(value).length > 0 ? { value } : {}),
+        ...(error ? { error } : {}),
+        ...(unavailable ? { unavailable } : {}),
+        ...(reason ? { reason } : {}),
+      };
+    }
+    return { ok: true, durationMs, value: result };
   } catch (error) {
     return {
       ok: false,
@@ -249,22 +275,43 @@ function parseRouteOutput(output) {
     .map((line) => ({ raw: line.replace(/\s+/g, ' ') }));
 }
 
-async function routeTrace(hostname) {
-  if (commandExists('mtr')) {
-    const result = await runCommand('mtr', ['--report', '--report-cycles', '3', '--no-dns', hostname], 15000);
-    if (result.code === 0) {
-      return { ok: true, tool: 'mtr', hops: parseRouteOutput(result.stdout), stderr: result.stderr };
+function routeCommandTimeout(input) {
+  const now = input.now ?? Date.now();
+  const remaining = input.budgetMs - (now - input.startedAt);
+  if (remaining <= 0) return 0;
+  return Math.min(input.capMs, Math.max(100, remaining));
+}
+
+function routeTrace(hostname) {
+  const routeBudgetMs = 16000;
+  const startedAt = Date.now();
+  const remainingFor = (capMs) => routeCommandTimeout({ startedAt, budgetMs: routeBudgetMs, capMs });
+
+  return timedSection('Route trace', async () => {
+    if (commandExists('mtr')) {
+      const timeoutMs = remainingFor(15000);
+      if (timeoutMs <= 0) return { ok: false, unavailable: true, reason: 'Route trace timed out before mtr could run.' };
+      const result = await runCommand('mtr', ['--report', '--report-cycles', '3', '--no-dns', hostname], timeoutMs);
+      if (result.code === 0) {
+        return { tool: 'mtr', hops: parseRouteOutput(result.stdout), stderr: result.stderr };
+      }
     }
-  }
-  if (process.platform === 'win32') {
-    const result = await runCommand('tracert', ['-d', '-h', '16', hostname]);
-    return { ok: result.code === 0, tool: 'tracert', hops: parseRouteOutput(result.stdout), stderr: result.stderr };
-  }
-  if (!commandExists('traceroute')) {
-    return { ok: false, tool: 'traceroute', unavailable: true, reason: 'traceroute command not found' };
-  }
-  const result = await runCommand('traceroute', ['-n', '-m', '16', hostname]);
-  return { ok: result.code === 0, tool: 'traceroute', hops: parseRouteOutput(result.stdout), stderr: result.stderr };
+    if (process.platform === 'win32') {
+      const timeoutMs = remainingFor(10000);
+      if (timeoutMs <= 0) return { ok: false, tool: 'tracert', unavailable: true, reason: 'Route trace timed out before tracert could run.' };
+      const result = await runCommand('tracert', ['-d', '-h', '16', hostname], timeoutMs);
+      if (result.code === 0) return { tool: 'tracert', hops: parseRouteOutput(result.stdout), stderr: result.stderr };
+      return { ok: false, tool: 'tracert', hops: parseRouteOutput(result.stdout), stderr: result.stderr };
+    }
+    if (!commandExists('traceroute')) {
+      return { ok: false, tool: 'traceroute', unavailable: true, reason: 'traceroute command not found' };
+    }
+    const timeoutMs = remainingFor(10000);
+    if (timeoutMs <= 0) return { ok: false, tool: 'traceroute', unavailable: true, reason: 'Route trace timed out before traceroute could run.' };
+    const result = await runCommand('traceroute', ['-n', '-m', '16', hostname], timeoutMs);
+    if (result.code === 0) return { tool: 'traceroute', hops: parseRouteOutput(result.stdout), stderr: result.stderr };
+    return { ok: false, tool: 'traceroute', hops: parseRouteOutput(result.stdout), stderr: result.stderr };
+  }, routeBudgetMs);
 }
 
 function redactWifiInfo(input, includePrivate = false) {
@@ -290,17 +337,19 @@ function parseAirportInfo(output) {
   };
 }
 
-async function wifiSignal(includePrivate) {
-  if (process.platform !== 'darwin') {
-    return { ok: false, unavailable: true, reason: 'WiFi signal is currently implemented for macOS only.' };
-  }
-  const airport = '/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport';
-  if (!fs.existsSync(airport)) {
-    return { ok: false, unavailable: true, reason: 'macOS airport utility not found.' };
-  }
-  const result = await runCommand(airport, ['-I'], 4000);
-  if (result.code !== 0) return { ok: false, stderr: result.stderr };
-  return { ok: true, ...redactWifiInfo(parseAirportInfo(result.stdout), includePrivate) };
+function wifiSignal(includePrivate) {
+  return timedSection('WiFi signal', async () => {
+    if (process.platform !== 'darwin') {
+      return { ok: false, unavailable: true, reason: 'WiFi signal is currently implemented for macOS only.' };
+    }
+    const airport = '/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport';
+    if (!fs.existsSync(airport)) {
+      return { ok: false, unavailable: true, reason: 'macOS airport utility not found.' };
+    }
+    const result = await runCommand(airport, ['-I'], 4000);
+    if (result.code !== 0) return { ok: false, error: result.stderr };
+    return redactWifiInfo(parseAirportInfo(result.stdout), includePrivate);
+  }, 5000);
 }
 
 function createHistoryStore(databasePath) {
@@ -510,6 +559,8 @@ module.exports = {
   signAgentRequest,
   verifySignedRequest,
   redactWifiInfo,
+  routeCommandTimeout,
   createHistoryStore,
   createServer,
+  runProbe,
 };

--- a/docs/companion-local-agent.md
+++ b/docs/companion-local-agent.md
@@ -28,6 +28,10 @@ The HTTP server binds to `127.0.0.1` and rejects non-loopback browser configurat
 
 WiFi SSID and BSSID are shown only when `Private WiFi` is selected; otherwise they are redacted. Probe history is stored locally in SQLite at `~/.chronoscope/agent-history.sqlite` by default.
 
+## Probe Response Shape
+
+Probe responses group evidence by section: `dns`, `tls`, `route`, and `wifi`. Each section uses the same timed envelope: `ok`, `durationMs`, optional `value`, optional `error`, and optional `unavailable`/`reason`. This lets the app explain which local proof was captured, which proof was unavailable, and how long each local check took without guessing from a generic blob.
+
 ## What Local Probes Can Prove
 
 - DNS shows what this computer resolved for the target host. It does not prove every resolver or network will resolve the same way.

--- a/docs/vision/10-star-product-roadmap.md
+++ b/docs/vision/10-star-product-roadmap.md
@@ -2,7 +2,7 @@
 
 **Status:** Living source of truth  
 **Created:** 2026-05-12  
-**Current production baseline:** `main` through PR #130, deployed to Cloudflare Pages
+**Current production baseline:** `main` through PR #131, deployed to Cloudflare Pages
 **Read this first in future sessions.**
 
 ---
@@ -85,6 +85,7 @@ Recent product spine:
 - PR #128: Claim registry wired into diagnostic narrative validation and copied report summaries.
 - PR #129: Trust-copy hardening for remote vantage, evidence trail, and history baseline surfaces.
 - PR #130: Plain-language metric copy for copied reports and outside-vantage explanations.
+- PR #131: Guided local-agent pairing with local-only safety, token-path guidance, health state, and WiFi redaction defaults.
 
 ---
 
@@ -347,4 +348,4 @@ The assistant should then:
 - Created this roadmap after PR #116 shipped the compact evidence trail and executable report triage actions.
 - Decided the next phase should be **Guided Proof Flow**, not another visual redesign.
 - Decided the product's highest-order constraint remains trust: every diagnostic claim must be tied to measured evidence, known browser limits, or an explicit next validation step.
-- Shipped Phase 1 and Phase 2 through PR #126. Phase 3 began with PR #127's registry and PR #128's narrative/report wiring, then PR #129 extended trust-copy guardrails through evidence trail, remote vantage, and history baseline surfaces. PR #130 completed the plain-language metric copy slice by keeping internal p50 data while exposing median language in copied report and outside-vantage text.
+- Shipped Phase 1 and Phase 2 through PR #126. Phase 3 began with PR #127's registry and PR #128's narrative/report wiring, then PR #129 extended trust-copy guardrails through evidence trail, remote vantage, and history baseline surfaces. PR #130 completed the plain-language metric copy slice by keeping internal p50 data while exposing median language in copied report and outside-vantage text. PR #131 opened Phase 4 with guided local-agent pairing, token-path guidance, health state, and default WiFi privacy.

--- a/src/lib/companion/protocol.ts
+++ b/src/lib/companion/protocol.ts
@@ -27,13 +27,53 @@ export interface CompanionProbeRequest {
   readonly includePrivateWifi?: boolean;
 }
 
+export interface CompanionTimedResult<T> {
+  readonly ok: boolean;
+  readonly durationMs: number;
+  readonly value?: T;
+  readonly error?: string;
+  readonly unavailable?: boolean;
+  readonly reason?: string;
+}
+
+export interface CompanionProbeResults {
+  readonly dns?: CompanionTimedResult<{
+    readonly lookup: readonly { readonly address: string; readonly family: number }[];
+    readonly a: readonly string[];
+    readonly aaaa: readonly string[];
+    readonly cname: readonly string[];
+  }>;
+  readonly tls?: CompanionTimedResult<{
+    readonly authorized: boolean;
+    readonly authorizationError: string | null;
+    readonly protocol: string | null;
+    readonly cipher: string | null;
+    readonly validFrom: string | null;
+    readonly validTo: string | null;
+    readonly subject: string | null;
+    readonly issuer: string | null;
+    readonly fingerprint256: string | null;
+  }>;
+  readonly route?: CompanionTimedResult<{
+    readonly tool: string;
+    readonly hops: readonly { readonly raw: string }[];
+    readonly stderr?: string;
+  }>;
+  readonly wifi?: CompanionTimedResult<{
+    readonly ssid?: string;
+    readonly bssid?: string;
+    readonly rssi: number | null;
+    readonly noise: number | null;
+  }>;
+}
+
 export interface CompanionProbeResponse {
   readonly ok: boolean;
   readonly id: string;
   readonly targetHost: string;
   readonly createdAt: number;
   readonly summary: string;
-  readonly results: Record<string, unknown>;
+  readonly results: CompanionProbeResults;
 }
 
 export interface CompanionHistoryEntry {

--- a/tests/unit/companion/local-agent.test.ts
+++ b/tests/unit/companion/local-agent.test.ts
@@ -56,6 +56,35 @@ const agent = requireAgent(path.resolve('companion/local-agent.cjs')) as {
     secret: string;
     history: AgentHistoryStore;
   };
+  routeCommandTimeout(input: {
+    startedAt: number;
+    budgetMs: number;
+    capMs: number;
+    now?: number;
+  }): number;
+  runProbe(payload: {
+    targetUrl: string;
+    probes?: readonly string[];
+    includePrivateWifi?: boolean;
+  }): Promise<{
+    ok: boolean;
+    targetHost: string;
+    results: {
+      wifi?: {
+        ok: boolean;
+        durationMs: number;
+        value?: {
+          ssid?: string;
+          bssid?: string;
+          rssi: number | null;
+          noise: number | null;
+        };
+        unavailable?: boolean;
+        reason?: string;
+        error?: string;
+      };
+    };
+  }>;
 };
 
 describe('local companion agent helpers', () => {
@@ -165,6 +194,47 @@ describe('local companion agent helpers', () => {
       }),
     ]);
     history.close();
+  });
+
+  it('keeps route command timeouts inside the route probe budget', () => {
+    expect(agent.routeCommandTimeout({
+      startedAt: 1000,
+      budgetMs: 16000,
+      capMs: 15000,
+      now: 1000,
+    })).toBe(15000);
+    expect(agent.routeCommandTimeout({
+      startedAt: 1000,
+      budgetMs: 16000,
+      capMs: 10000,
+      now: 16050,
+    })).toBe(950);
+    expect(agent.routeCommandTimeout({
+      startedAt: 1000,
+      budgetMs: 16000,
+      capMs: 10000,
+      now: 17001,
+    })).toBe(0);
+  });
+
+  it('returns local probe sections as timed result envelopes', async () => {
+    const probe = await agent.runProbe({
+      targetUrl: 'https://example.com',
+      probes: ['wifi'],
+      includePrivateWifi: false,
+    });
+
+    expect(probe).toMatchObject({
+      ok: true,
+      targetHost: 'example.com',
+      results: {
+        wifi: {
+          ok: expect.any(Boolean),
+          durationMs: expect.any(Number),
+        },
+      },
+    });
+    expect(probe.results.wifi?.value?.ssid).not.toBe('Home Network');
   });
 
   it('allows health checks unsigned but requires signatures for local history', async () => {

--- a/tests/unit/companion/protocol.test.ts
+++ b/tests/unit/companion/protocol.test.ts
@@ -3,6 +3,7 @@ import {
   buildCompanionHeaders,
   canonicalCompanionRequest,
   normalizeCompanionBaseUrl,
+  type CompanionProbeResults,
 } from '../../../src/lib/companion/protocol';
 
 describe('companion protocol', () => {
@@ -46,5 +47,56 @@ describe('companion protocol', () => {
       'X-Chronoscope-Nonce': 'nonce-1',
       'X-Chronoscope-Signature': 'pairing-secret:39',
     });
+  });
+
+  it('allows typed companion probe sections', () => {
+    const results: CompanionProbeResults = {
+      dns: {
+        ok: true,
+        durationMs: 12,
+        value: {
+          lookup: [{ address: '203.0.113.1', family: 4 }],
+          a: ['203.0.113.1'],
+          aaaa: [],
+          cname: [],
+        },
+      },
+      tls: {
+        ok: true,
+        durationMs: 28,
+        value: {
+          authorized: true,
+          authorizationError: null,
+          protocol: 'TLSv1.3',
+          cipher: 'TLS_AES_128_GCM_SHA256',
+          validFrom: 'Jan 1',
+          validTo: 'Dec 31',
+          subject: 'example.com',
+          issuer: 'Example CA',
+          fingerprint256: 'AA:BB',
+        },
+      },
+      route: {
+        ok: false,
+        durationMs: 10000,
+        error: 'traceroute command not found',
+        unavailable: true,
+        reason: 'traceroute command not found',
+      },
+      wifi: {
+        ok: true,
+        durationMs: 4,
+        value: {
+          ssid: 'redacted',
+          bssid: 'redacted',
+          rssi: -48,
+          noise: -91,
+        },
+      },
+    };
+
+    expect(results.dns?.ok).toBe(true);
+    expect(results.route?.durationMs).toBe(10000);
+    expect(results.wifi?.value?.ssid).toBe('redacted');
   });
 });


### PR DESCRIPTION
## Summary
- add typed companion probe result sections for DNS, TLS, route, and WiFi
- normalize route and WiFi output into timed result envelopes with duration, value/error, and unavailable reasons
- export runProbe for local-agent contract tests and document the response shape
- update the 10-star roadmap baseline through PR #131

## Test plan
- npm test -- tests/unit/companion/protocol.test.ts tests/unit/companion/local-agent.test.ts
- npm run typecheck
- npm run lint
- npm run build
- npm test
- signed local companion HTTP smoke for /v1/probe with WiFi section redaction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Probe responses now include execution timing (`durationMs`) and structured result envelopes for DNS, TLS, route, and WiFi checks
  * Added privacy control: private WiFi SSIDs are filtered based on user settings

* **Documentation**
  * Documented probe response shape and timing envelope structure
  * Updated product roadmap with latest phase 4 progress

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xaedyn/chronoscope/pull/132)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->