### PR TITLE
Add privacy-safe local proof sharing

### DIFF
--- a/docs/companion-local-agent.md
+++ b/docs/companion-local-agent.md
@@ -32,6 +32,18 @@ WiFi SSID and BSSID are shown only when `Private WiFi` is selected; otherwise th
 
 Probe responses group evidence by section: `dns`, `tls`, `route`, and `wifi`. Each section uses the same timed envelope: `ok`, `durationMs`, optional `value`, optional `error`, and optional `unavailable`/`reason`. This lets the app explain which local proof was captured, which proof was unavailable, and how long each local check took without guessing from a generic blob.
 
+## Public Report Privacy
+
+Local-agent evidence stays local by default. Support reports and snapshot links do not include companion probe output unless the sender explicitly enables **Include redacted local proof**.
+
+When included, Chronoscope exports a sanitized local-proof summary only:
+
+- DNS, TLS, route, and WiFi section status, duration, and plain-language detail.
+- WiFi signal and noise values when available.
+- WiFi SSID and BSSID as `redacted` unless private WiFi was explicitly allowed for that sanitized export path.
+- Route/MTR hop counts only; raw hop lines, private gateway addresses, and local hostnames stay out of public reports.
+- No SQLite history entries are included in public reports by default.
+
 ## What Local Probes Can Prove
 
 - DNS shows what this computer resolved for the target host. It does not prove every resolver or network will resolve the same way.

--- a/docs/vision/10-star-product-roadmap.md
+++ b/docs/vision/10-star-product-roadmap.md
@@ -2,7 +2,7 @@
 
 **Status:** Living source of truth  
 **Created:** 2026-05-12  
-**Current production baseline:** `main` through PR #131, deployed to Cloudflare Pages
+**Current production baseline:** `main` through PR #132, deployed to Cloudflare Pages
 **Read this first in future sessions.**
 
 ---
@@ -86,6 +86,7 @@ Recent product spine:
 - PR #129: Trust-copy hardening for remote vantage, evidence trail, and history baseline surfaces.
 - PR #130: Plain-language metric copy for copied reports and outside-vantage explanations.
 - PR #131: Guided local-agent pairing with local-only safety, token-path guidance, health state, and WiFi redaction defaults.
+- PR #132: Typed local companion probe results with section envelopes and bounded route subprocess timeouts.
 
 ---
 
@@ -348,4 +349,4 @@ The assistant should then:
 - Created this roadmap after PR #116 shipped the compact evidence trail and executable report triage actions.
 - Decided the next phase should be **Guided Proof Flow**, not another visual redesign.
 - Decided the product's highest-order constraint remains trust: every diagnostic claim must be tied to measured evidence, known browser limits, or an explicit next validation step.
-- Shipped Phase 1 and Phase 2 through PR #126. Phase 3 began with PR #127's registry and PR #128's narrative/report wiring, then PR #129 extended trust-copy guardrails through evidence trail, remote vantage, and history baseline surfaces. PR #130 completed the plain-language metric copy slice by keeping internal p50 data while exposing median language in copied report and outside-vantage text. PR #131 opened Phase 4 with guided local-agent pairing, token-path guidance, health state, and default WiFi privacy.
+- Shipped Phase 1 and Phase 2 through PR #126. Phase 3 began with PR #127's registry and PR #128's narrative/report wiring, then PR #129 extended trust-copy guardrails through evidence trail, remote vantage, and history baseline surfaces. PR #130 completed the plain-language metric copy slice by keeping internal p50 data while exposing median language in copied report and outside-vantage text. PR #131 opened Phase 4 with guided local-agent pairing, token-path guidance, health state, and default WiFi privacy. PR #132 added typed local companion probe result sections and bounded route command timeouts.

--- a/src/lib/companion/sanitize.ts
+++ b/src/lib/companion/sanitize.ts
@@ -1,0 +1,172 @@
+// src/lib/companion/sanitize.ts
+// Converts local companion probe output into report-safe, bounded evidence.
+
+import type { CompanionProbeName, CompanionProbeResponse, CompanionTimedResult } from './protocol';
+import type {
+  ShareLocalCompanionProbeName,
+  ShareLocalCompanionSection,
+  ShareLocalCompanionSectionStatus,
+  ShareLocalCompanionSnapshot,
+  ShareLocalCompanionWifi,
+} from '../types';
+
+const PROBE_ORDER: readonly CompanionProbeName[] = ['dns', 'tls', 'route', 'wifi'];
+const MAX_SUMMARY_LENGTH = 160;
+const MAX_DETAIL_LENGTH = 180;
+
+function truncate(text: string, maxLength: number): string {
+  const cleaned = text.replace(/[\r\n\t]+/g, ' ').replace(/\s+/g, ' ').trim();
+  if (cleaned.length <= maxLength) return cleaned;
+  return `${cleaned.slice(0, maxLength - 1).trimEnd()}...`;
+}
+
+function statusFor(section: CompanionTimedResult<unknown>): ShareLocalCompanionSectionStatus {
+  if (section.ok) return 'captured';
+  return section.unavailable ? 'unavailable' : 'failed';
+}
+
+function durationMs(section: CompanionTimedResult<unknown>): number {
+  return Number.isFinite(section.durationMs) && section.durationMs >= 0
+    ? Math.round(section.durationMs)
+    : 0;
+}
+
+function probeLabel(name: CompanionProbeName): string {
+  switch (name) {
+    case 'dns':
+      return 'DNS';
+    case 'tls':
+      return 'TLS';
+    case 'route':
+      return 'route';
+    case 'wifi':
+      return 'WiFi';
+  }
+}
+
+function joinList(parts: readonly string[]): string {
+  if (parts.length === 0) return 'Local agent ran.';
+  if (parts.length === 1) return `${parts[0]} completed.`;
+  return `${parts.slice(0, -1).join(', ')}, and ${parts[parts.length - 1]} completed.`;
+}
+
+function dnsDetail(section: NonNullable<CompanionProbeResponse['results']['dns']>): string {
+  if (!section.ok || !section.value) return detailForUnavailableOrFailed('DNS lookup', section);
+  const addressCount = section.value.lookup.length;
+  const cnameCount = section.value.cname.length;
+  return `DNS lookup captured ${addressCount} ${addressCount === 1 ? 'address' : 'addresses'}${cnameCount > 0 ? ` and ${cnameCount} CNAME ${cnameCount === 1 ? 'record' : 'records'}` : ''}.`;
+}
+
+function tlsDetail(section: NonNullable<CompanionProbeResponse['results']['tls']>): string {
+  if (!section.ok || !section.value) return detailForUnavailableOrFailed('TLS check', section);
+  if (section.value.authorized) return 'TLS certificate was accepted by the local system trust store.';
+  return section.value.authorizationError
+    ? `TLS certificate was not accepted: ${truncate(section.value.authorizationError, 72)}.`
+    : 'TLS certificate was not accepted by the local system trust store.';
+}
+
+function routeDetail(section: NonNullable<CompanionProbeResponse['results']['route']>): string {
+  if (!section.ok || !section.value) return detailForUnavailableOrFailed('Route check', section);
+  const tool = section.value.tool || 'route check';
+  const hopCount = section.value.hops.length;
+  return `${tool} captured ${hopCount} ${hopCount === 1 ? 'hop' : 'hops'}; raw hop details stay local.`;
+}
+
+function wifiDetail(
+  section: NonNullable<CompanionProbeResponse['results']['wifi']>,
+  includePrivateWifi: boolean,
+): string {
+  if (!section.ok || !section.value) return detailForUnavailableOrFailed('WiFi signal check', section);
+  return includePrivateWifi
+    ? 'WiFi signal captured; private network names were explicitly included.'
+    : 'WiFi signal captured; private network names are redacted.';
+}
+
+function detailForUnavailableOrFailed(label: string, section: CompanionTimedResult<unknown>): string {
+  const reason = section.reason ?? section.error;
+  if (section.unavailable) {
+    return reason ? `${label} unavailable: ${truncate(reason, 88)}.` : `${label} unavailable on this device.`;
+  }
+  return reason ? `${label} failed: ${truncate(reason, 96)}.` : `${label} did not complete.`;
+}
+
+function detailFor(
+  name: CompanionProbeName,
+  section: CompanionProbeResponse['results'][CompanionProbeName],
+  includePrivateWifi: boolean,
+): string {
+  if (!section) return '';
+  switch (name) {
+    case 'dns':
+      return dnsDetail(section as NonNullable<CompanionProbeResponse['results']['dns']>);
+    case 'tls':
+      return tlsDetail(section as NonNullable<CompanionProbeResponse['results']['tls']>);
+    case 'route':
+      return routeDetail(section as NonNullable<CompanionProbeResponse['results']['route']>);
+    case 'wifi':
+      return wifiDetail(
+        section as NonNullable<CompanionProbeResponse['results']['wifi']>,
+        includePrivateWifi,
+      );
+  }
+}
+
+function sectionFor(
+  name: CompanionProbeName,
+  section: CompanionProbeResponse['results'][CompanionProbeName],
+  includePrivateWifi: boolean,
+): ShareLocalCompanionSection | null {
+  if (!section) return null;
+  return {
+    name: name as ShareLocalCompanionProbeName,
+    status: statusFor(section),
+    ok: section.ok,
+    durationMs: durationMs(section),
+    detail: truncate(detailFor(name, section, includePrivateWifi), MAX_DETAIL_LENGTH),
+  };
+}
+
+function wifiForReport(
+  probe: CompanionProbeResponse,
+  includePrivateWifi: boolean,
+): ShareLocalCompanionWifi | undefined {
+  const wifi = probe.results.wifi;
+  if (!wifi?.value) return undefined;
+  const ssid = wifi.value.ssid;
+  const bssid = wifi.value.bssid;
+  return {
+    rssi: wifi.value.rssi,
+    noise: wifi.value.noise,
+    ...(ssid ? { ssid: includePrivateWifi ? truncate(ssid, 64) : 'redacted' } : {}),
+    ...(bssid ? { bssid: includePrivateWifi ? truncate(bssid, 64) : 'redacted' } : {}),
+  };
+}
+
+function summaryFor(sections: readonly ShareLocalCompanionSection[]): string {
+  const captured = sections
+    .filter((section) => section.status === 'captured')
+    .map((section) => probeLabel(section.name));
+  if (captured.length > 0) return joinList(captured);
+
+  const unavailable = sections.filter((section) => section.status === 'unavailable').length;
+  if (unavailable === sections.length) return 'Local companion probes were unavailable on this device.';
+  return 'Local companion probes did not complete.';
+}
+
+export function sanitizeCompanionProbeForReport(
+  probe: CompanionProbeResponse,
+  options: { readonly includePrivateWifi: boolean },
+): ShareLocalCompanionSnapshot {
+  const sections = PROBE_ORDER
+    .map((name) => sectionFor(name, probe.results[name], options.includePrivateWifi))
+    .filter((section): section is ShareLocalCompanionSection => section !== null);
+  const wifi = wifiForReport(probe, options.includePrivateWifi);
+
+  return {
+    generatedAt: probe.createdAt,
+    targetHost: truncate(probe.targetHost, 253),
+    summary: truncate(summaryFor(sections), MAX_SUMMARY_LENGTH),
+    sections,
+    ...(wifi ? { wifi } : {}),
+  };
+}

--- a/src/lib/components/ReportView.svelte
+++ b/src/lib/components/ReportView.svelte
@@ -11,6 +11,7 @@
   import { companionStore } from '$lib/stores/companion';
   import { remoteVantageStore } from '$lib/stores/remote-vantage';
   import LocalProofPanel from './LocalProofPanel.svelte';
+  import { sanitizeCompanionProbeForReport } from '$lib/companion/sanitize';
   import { buildShareURL } from '$lib/share/share-manager';
   import { buildResultsSharePayload, MAX_SHARE_URL_CHARS } from '$lib/share/share-payload-builder';
   import { buildDiagnosticReport, formatReportMetric } from '$lib/utils/diagnostic-report';
@@ -33,6 +34,7 @@
   const settings = $derived($settingsStore);
   const stats = $derived($statisticsStore);
   const context = $derived($uiStore.sharedReportContext);
+  const sharedLocalCompanion = $derived($uiStore.sharedLocalCompanion);
 
   const report = $derived(buildDiagnosticReport({
     endpoints,
@@ -59,6 +61,7 @@
     report,
     remoteVantage,
     companion,
+    sharedLocalCompanion,
   }));
   const remoteBusy = $derived(remoteVantage.status === 'checking' || remoteVantage.status === 'probing');
   const companionBusy = $derived(companion.status === 'checking' || companion.status === 'probing');
@@ -67,7 +70,9 @@
   let copiedLink = $state(false);
   let copyError = $state<'summary' | 'link' | null>(null);
   let localProofOpen = $state(false);
+  let includeLocalProofInReport = $state(false);
   let browserVisibilityPanel = $state<HTMLElement | null>(null);
+  const localProofExportAvailable = $derived(Boolean(companion.lastProbe));
 
   interface TriageOutcome {
     readonly label: string;
@@ -118,6 +123,10 @@
       totalSampleCount: report.totalSampleCount,
       truncated: report.truncated,
     };
+    const liveCompanion = get(companionStore);
+    const localCompanion = includeLocalProofInReport && liveCompanion.lastProbe
+      ? sanitizeCompanionProbeForReport(liveCompanion.lastProbe, { includePrivateWifi: false })
+      : null;
     const builtForHostedReport = buildResultsSharePayload(
       get(endpointStore),
       settingsForReport,
@@ -126,6 +135,7 @@
       Date.now(),
       metadata,
       get(remoteVantageStore).lastProbe,
+      localCompanion,
     );
     const hostedUrl = await remoteVantageStore.createHostedReport(builtForHostedReport.payload);
     const fallbackPayload = hostedUrl === null
@@ -137,6 +147,7 @@
           Date.now(),
           metadata,
           get(remoteVantageStore).lastProbe,
+          localCompanion,
         ).payload
       : null;
     copyText(hostedUrl ?? buildShareURL(fallbackPayload ?? builtForHostedReport.payload), () => {
@@ -314,6 +325,16 @@
         Run Your Own Test
       </button>
     </div>
+
+    {#if localProofExportAvailable}
+      <label class="local-proof-export">
+        <input type="checkbox" bind:checked={includeLocalProofInReport} />
+        <span>
+          <strong>Include redacted local proof</strong>
+          <small>Shares local-agent status only. WiFi names and raw route details stay out.</small>
+        </span>
+      </label>
+    {/if}
   </header>
 
   <section class="report-strip" aria-label="Report metadata">
@@ -604,6 +625,40 @@
     color: var(--accent-cyan);
     border-color: rgba(103,232,249,.35);
     background: rgba(103,232,249,.08);
+  }
+
+  .local-proof-export {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: start;
+    gap: 10px;
+    max-width: 620px;
+    padding: 10px 12px;
+    border: 1px solid rgba(134,239,172,.22);
+    border-radius: 8px;
+    background: rgba(134,239,172,.055);
+    color: var(--t2);
+    font-size: var(--ts-sm);
+  }
+  .local-proof-export input {
+    margin-top: 2px;
+    accent-color: var(--accent-green);
+  }
+  .local-proof-export span {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .local-proof-export strong {
+    color: var(--t1);
+    font-size: var(--ts-sm);
+    font-weight: 600;
+  }
+  .local-proof-export small {
+    color: var(--t3);
+    font-size: var(--ts-xs);
+    line-height: 1.45;
   }
 
   .report-strip {

--- a/src/lib/components/SharePopover.svelte
+++ b/src/lib/components/SharePopover.svelte
@@ -8,7 +8,9 @@
   import { endpointStore } from '$lib/stores/endpoints';
   import { settingsStore } from '$lib/stores/settings';
   import { measurementStore } from '$lib/stores/measurements';
+  import { companionStore } from '$lib/stores/companion';
   import { remoteVantageStore } from '$lib/stores/remote-vantage';
+  import { sanitizeCompanionProbeForReport } from '$lib/companion/sanitize';
   import { buildShareURL } from '$lib/share/share-manager';
   import {
     buildConfigSharePayload,
@@ -28,6 +30,7 @@
   let reportNotice = $state<string | null>(null);
   let fallbackUrl: string | null = $state(null);
   let fallbackInputEl: HTMLInputElement | undefined = $state();
+  let includeLocalProofInReport = $state(false);
 
   let hasResults = $derived(
     Object.keys($measurementStore.endpoints).length > 0 &&
@@ -41,12 +44,18 @@
   let resultsPayload = $derived(builtResults?.payload ?? null);
   let hostedReportTruncated = $derived(builtHostedReport?.truncated ?? false);
   let resultsTruncated = $derived(builtResults?.truncated ?? false);
+  let localProofAvailable = $derived(Boolean($companionStore.lastProbe));
 
   function buildConfigPayload(): SharePayload {
     return buildConfigSharePayload(get(endpointStore), get(settingsStore));
   }
 
   function buildResultsPayload(maxChars = MAX_SHARE_URL_CHARS, reportKind: ReportKind = 'support') {
+    const companion = get(companionStore);
+    const localCompanion = reportKind === 'support' && includeLocalProofInReport && companion.lastProbe
+      ? sanitizeCompanionProbeForReport(companion.lastProbe, { includePrivateWifi: false })
+      : null;
+
     return buildResultsSharePayload(
       get(endpointStore),
       get(settingsStore),
@@ -55,6 +64,7 @@
       Date.now(),
       { reportKind },
       get(remoteVantageStore).lastProbe,
+      localCompanion,
     );
   }
 
@@ -223,6 +233,16 @@
       <div class="warning" role="note">
         Compact URL results are trimmed to fit browser URL limits. Newest rounds are kept.
       </div>
+    {/if}
+
+    {#if localProofAvailable}
+      <label class="privacy-option">
+        <input type="checkbox" bind:checked={includeLocalProofInReport} />
+        <span>
+          <strong>Include redacted local proof</strong>
+          <small>Shares local-agent status only. WiFi names and raw route details stay out.</small>
+        </span>
+      </label>
     {/if}
 
     <!-- Buttons -->
@@ -415,7 +435,8 @@
 
   /* ── Notices ───────────────────────────────────────────────────────────── */
   .notice,
-  .warning {
+  .warning,
+  .privacy-option {
     padding: var(--spacing-xs) var(--spacing-sm);
     border-radius: var(--btn-radius);
     font-family: var(--sans);
@@ -434,6 +455,36 @@
     background: rgba(255,140,0,.08);
     border: 1px solid rgba(255,140,0,.25);
     color: var(--t2);
+  }
+
+  .privacy-option {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: start;
+    gap: var(--spacing-sm);
+    background: rgba(134,239,172,.055);
+    border: 1px solid rgba(134,239,172,.2);
+    color: var(--t2);
+  }
+  .privacy-option input {
+    margin-top: 2px;
+    accent-color: var(--accent-green);
+  }
+  .privacy-option span {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .privacy-option strong {
+    color: var(--t1);
+    font-size: 12px;
+    font-weight: 600;
+  }
+  .privacy-option small {
+    color: var(--t3);
+    font-size: 11px;
+    line-height: 1.35;
   }
 
   /* ── Actions ───────────────────────────────────────────────────────────── */

--- a/src/lib/share/hash-router.ts
+++ b/src/lib/share/hash-router.ts
@@ -175,6 +175,7 @@ export function applySharePayload(payload: SharePayload): string[] {
     });
     uiStore.setSharedReportMode(false);
     uiStore.setSharedReportContext(null);
+    uiStore.setSharedLocalCompanion(null);
     return [];
   }
 
@@ -249,6 +250,7 @@ export function applySharePayload(payload: SharePayload): string[] {
     measurementStore.loadSnapshot(snapshot);
 
     uiStore.setSharedReportContext(buildSharedReportContext(payload));
+    uiStore.setSharedLocalCompanion(payload.localCompanion ?? null);
     uiStore.setSharedView(true);
     uiStore.setSharedReportMode(true);
     remoteVantageStore.setProbe(payload.remoteVantage ? { ...payload.remoteVantage, ok: true } : null);
@@ -256,6 +258,7 @@ export function applySharePayload(payload: SharePayload): string[] {
     uiStore.setSharedView(false);
     uiStore.setSharedReportMode(false);
     uiStore.setSharedReportContext(null);
+    uiStore.setSharedLocalCompanion(null);
     remoteVantageStore.setProbe(null);
   }
 

--- a/src/lib/share/share-payload-builder.ts
+++ b/src/lib/share/share-payload-builder.ts
@@ -7,6 +7,7 @@ import type {
   MeasurementState,
   Settings,
   SharePayload,
+  ShareLocalCompanionSnapshot,
   ShareRemoteVantageSnapshot,
   ShareReportMetadata,
 } from '../types';
@@ -85,6 +86,33 @@ function serializeRemoteVantage(
   };
 }
 
+function serializeLocalCompanion(
+  localCompanion: ShareLocalCompanionSnapshot | null | undefined,
+): ShareLocalCompanionSnapshot | undefined {
+  if (!localCompanion) return undefined;
+  if (localCompanion.sections.length === 0) return undefined;
+  return {
+    generatedAt: localCompanion.generatedAt,
+    targetHost: localCompanion.targetHost,
+    summary: localCompanion.summary,
+    sections: localCompanion.sections.slice(0, 4).map((section) => ({
+      name: section.name,
+      status: section.status,
+      ok: section.ok,
+      durationMs: section.durationMs,
+      detail: section.detail,
+    })),
+    ...(localCompanion.wifi ? {
+      wifi: {
+        rssi: localCompanion.wifi.rssi,
+        noise: localCompanion.wifi.noise,
+        ...(localCompanion.wifi.ssid ? { ssid: localCompanion.wifi.ssid } : {}),
+        ...(localCompanion.wifi.bssid ? { bssid: localCompanion.wifi.bssid } : {}),
+      },
+    } : {}),
+  };
+}
+
 export function buildResultsSharePayload(
   endpoints: readonly Endpoint[],
   settings: Settings,
@@ -93,6 +121,7 @@ export function buildResultsSharePayload(
   now = Date.now(),
   reportMetadata: Partial<ShareReportMetadata> = {},
   remoteVantage: ShareRemoteVantageSnapshot | null = null,
+  localCompanion: ShareLocalCompanionSnapshot | null = null,
 ): BuiltResultsSharePayload {
   const results = buildResults(endpoints, measurements);
   const keptSampleCount = countSamples(results);
@@ -112,6 +141,7 @@ export function buildResultsSharePayload(
     truncated: reportMetadata.truncated ?? false,
   };
   const serializedRemoteVantage = serializeRemoteVantage(remoteVantage);
+  const serializedLocalCompanion = serializeLocalCompanion(localCompanion);
 
   const basePayload: SharePayload = {
     v: 2,
@@ -120,6 +150,7 @@ export function buildResultsSharePayload(
     settings: toSharedSettings(settings),
     report: metadata,
     ...(serializedRemoteVantage ? { remoteVantage: serializedRemoteVantage } : {}),
+    ...(serializedLocalCompanion ? { localCompanion: serializedLocalCompanion } : {}),
     results,
   };
 

--- a/src/lib/share/share-validator.ts
+++ b/src/lib/share/share-validator.ts
@@ -2,7 +2,7 @@ import { MAX_CAP } from '../limits';
 import type { SharePayload } from '../types';
 import { isSafeSharedUrl } from '../utils/url-safety';
 
-const ALLOWED_TOP_LEVEL = new Set(['v', 'mode', 'endpoints', 'settings', 'results', 'report', 'remoteVantage']);
+const ALLOWED_TOP_LEVEL = new Set(['v', 'mode', 'endpoints', 'settings', 'results', 'report', 'remoteVantage', 'localCompanion']);
 const ALLOWED_REPORT_KEYS = new Set([
   'reportKind',
   'createdAt',
@@ -29,6 +29,9 @@ const ALLOWED_REMOTE_RESULT_KEYS = new Set([
   'error',
 ]);
 const ALLOWED_REMOTE_HEADERS = new Set(['content-type', 'server', 'cache-control', 'cf-cache-status']);
+const ALLOWED_LOCAL_KEYS = new Set(['generatedAt', 'targetHost', 'summary', 'sections', 'wifi']);
+const ALLOWED_LOCAL_SECTION_KEYS = new Set(['name', 'status', 'ok', 'durationMs', 'detail']);
+const ALLOWED_LOCAL_WIFI_KEYS = new Set(['rssi', 'noise', 'ssid', 'bssid']);
 const ALLOWED_RESULT_KEYS = new Set(['samples']);
 const MAX_DELAY_MS = 60_000;
 
@@ -129,6 +132,67 @@ function validateRemoteVantage(remote: unknown, obj: Record<string, unknown>): b
   return true;
 }
 
+function allowedEndpointHosts(obj: Record<string, unknown>): Set<string> {
+  const hosts = new Set<string>();
+  const endpoints = obj['endpoints'];
+  if (!Array.isArray(endpoints)) return hosts;
+  for (const endpoint of endpoints) {
+    if (!isRecord(endpoint) || typeof endpoint['url'] !== 'string') continue;
+    try {
+      hosts.add(new URL(endpoint['url']).hostname);
+    } catch {
+      // endpoint validation reports the structural failure elsewhere.
+    }
+  }
+  return hosts;
+}
+
+function validateNullableSignal(value: unknown): boolean {
+  if (value === null) return true;
+  return isFiniteNumber(value) && (value as number) >= -150 && (value as number) <= 50;
+}
+
+function validateLocalWifi(wifi: unknown): boolean {
+  if (!isRecord(wifi)) return false;
+  if (!hasOnlyKeys(wifi, ALLOWED_LOCAL_WIFI_KEYS)) return false;
+  if (!validateNullableSignal(wifi['rssi'])) return false;
+  if (!validateNullableSignal(wifi['noise'])) return false;
+  if (wifi['ssid'] !== undefined && !isStringWithin(wifi['ssid'], 64)) return false;
+  return wifi['bssid'] === undefined || isStringWithin(wifi['bssid'], 64);
+}
+
+function validateLocalCompanion(local: unknown, obj: Record<string, unknown>): boolean {
+  if (obj['mode'] !== 'results' || obj['v'] !== 2) return false;
+  if (!isRecord(local)) return false;
+  if (!hasOnlyKeys(local, ALLOWED_LOCAL_KEYS)) return false;
+  if (!isNonNegativeFiniteNumber(local['generatedAt'])) return false;
+  if (!isStringWithin(local['targetHost'], 253, 1)) return false;
+  if (!allowedEndpointHosts(obj).has(local['targetHost'] as string)) return false;
+  if (!isStringWithin(local['summary'], 160, 1)) return false;
+  if (!Array.isArray(local['sections']) || local['sections'].length === 0 || local['sections'].length > 4) return false;
+
+  for (const section of local['sections']) {
+    if (!isRecord(section)) return false;
+    if (!hasOnlyKeys(section, ALLOWED_LOCAL_SECTION_KEYS)) return false;
+    if (
+      section['name'] !== 'dns' &&
+      section['name'] !== 'tls' &&
+      section['name'] !== 'route' &&
+      section['name'] !== 'wifi'
+    ) return false;
+    if (
+      section['status'] !== 'captured' &&
+      section['status'] !== 'failed' &&
+      section['status'] !== 'unavailable'
+    ) return false;
+    if (typeof section['ok'] !== 'boolean') return false;
+    if (!isNonNegativeFiniteNumber(section['durationMs']) || (section['durationMs'] as number) > 60_000) return false;
+    if (!isStringWithin(section['detail'], 180, 1)) return false;
+  }
+
+  return local['wifi'] === undefined || validateLocalWifi(local['wifi']);
+}
+
 export function validateSharePayload(data: unknown): SharePayload | null {
   if (!isRecord(data)) return null;
   const obj = data;
@@ -162,6 +226,7 @@ export function validateSharePayload(data: unknown): SharePayload | null {
 
   if (obj['report'] !== undefined && !validateReport(obj['report'], obj)) return null;
   if (obj['remoteVantage'] !== undefined && !validateRemoteVantage(obj['remoteVantage'], obj)) return null;
+  if (obj['localCompanion'] !== undefined && !validateLocalCompanion(obj['localCompanion'], obj)) return null;
 
   for (const key of Object.keys(obj)) {
     if (!ALLOWED_TOP_LEVEL.has(key)) return null;

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -3,7 +3,14 @@
 // and panel visibility. No side effects; all state is local to this module.
 
 import { writable } from 'svelte/store';
-import type { LiveTimeRange, PendingShare, SharedReportContext, TerminalEventType, UIState } from '../types';
+import type {
+  LiveTimeRange,
+  PendingShare,
+  ShareLocalCompanionSnapshot,
+  SharedReportContext,
+  TerminalEventType,
+  UIState,
+} from '../types';
 
 function normalizeActiveView(view: UIState['activeView']): UIState['activeView'] {
   return view === 'strata' || view === 'terminal' ? 'overview' : view;
@@ -23,6 +30,7 @@ const initialState = (): UIState => ({
   isSharedView: false,
   sharedReportMode: false,
   sharedReportContext: null,
+  sharedLocalCompanion: null,
   pendingShare: null,
   showEndpoints: false,
   focusedEndpointId: null,
@@ -71,6 +79,7 @@ function createUiStore() {
         isSharedView: false,
         sharedReportMode: false,
         sharedReportContext: null,
+        sharedLocalCompanion: null,
       }));
     },
     setSharedReportMode(enabled: boolean): void {
@@ -78,6 +87,9 @@ function createUiStore() {
     },
     setSharedReportContext(context: SharedReportContext | null): void {
       update((s) => ({ ...s, sharedReportContext: context }));
+    },
+    setSharedLocalCompanion(localCompanion: ShareLocalCompanionSnapshot | null): void {
+      update((s) => ({ ...s, sharedLocalCompanion: localCompanion }));
     },
     setPendingShare(pending: PendingShare): void {
       update((s) => ({ ...s, pendingShare: pending }));

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -258,6 +258,7 @@ export interface UIState {
   isSharedView: boolean;
   sharedReportMode: boolean;
   sharedReportContext: SharedReportContext | null;
+  sharedLocalCompanion: ShareLocalCompanionSnapshot | null;
   pendingShare: PendingShare | null;
   showEndpoints: boolean;
 
@@ -340,6 +341,32 @@ export interface ShareRemoteVantageSnapshot {
   readonly results: readonly ShareRemoteVantageResult[];
 }
 
+export type ShareLocalCompanionProbeName = 'dns' | 'tls' | 'route' | 'wifi';
+export type ShareLocalCompanionSectionStatus = 'captured' | 'failed' | 'unavailable';
+
+export interface ShareLocalCompanionSection {
+  readonly name: ShareLocalCompanionProbeName;
+  readonly status: ShareLocalCompanionSectionStatus;
+  readonly ok: boolean;
+  readonly durationMs: number;
+  readonly detail: string;
+}
+
+export interface ShareLocalCompanionWifi {
+  readonly rssi: number | null;
+  readonly noise: number | null;
+  readonly ssid?: string;
+  readonly bssid?: string;
+}
+
+export interface ShareLocalCompanionSnapshot {
+  readonly generatedAt: number;
+  readonly targetHost: string;
+  readonly summary: string;
+  readonly sections: readonly ShareLocalCompanionSection[];
+  readonly wifi?: ShareLocalCompanionWifi;
+}
+
 export interface SharePayload {
   readonly v: 1 | 2;
   readonly mode: 'config' | 'results';
@@ -354,6 +381,7 @@ export interface SharePayload {
   };
   readonly report?: ShareReportMetadata;
   readonly remoteVantage?: ShareRemoteVantageSnapshot;
+  readonly localCompanion?: ShareLocalCompanionSnapshot;
   readonly results?: readonly {
     readonly samples: readonly {
       readonly round: number;

--- a/src/lib/utils/evidence-trail.ts
+++ b/src/lib/utils/evidence-trail.ts
@@ -1,7 +1,13 @@
 import type { CompanionState } from '../stores/companion';
 import type { RemoteVantageState } from '../stores/remote-vantage';
+import type { ShareLocalCompanionSnapshot } from '../types';
 import type { DiagnosticReport } from './diagnostic-report';
-import { proofFreshnessLabel, summarizeLocalProof, summarizeRemoteProof } from './proof-flow';
+import {
+  proofFreshnessLabel,
+  summarizeLocalProof,
+  summarizeRemoteProof,
+  summarizeSharedLocalProof,
+} from './proof-flow';
 
 export type EvidenceTrailTone = 'good' | 'watch' | 'bad' | 'neutral';
 
@@ -23,6 +29,7 @@ interface EvidenceTrailInput {
   readonly report: DiagnosticReport;
   readonly remoteVantage: Pick<RemoteVantageState, 'status' | 'lastProbe' | 'error'>;
   readonly companion: Pick<CompanionState, 'status' | 'lastProbe' | 'error' | 'hasSecret'>;
+  readonly sharedLocalCompanion?: ShareLocalCompanionSnapshot | null;
 }
 
 const MAX_FACT_LENGTH = 96;
@@ -135,7 +142,25 @@ function remoteTrail(
 function companionTrail(
   companion: EvidenceTrailInput['companion'],
   reportCreatedAt: number | null,
+  sharedLocalCompanion: ShareLocalCompanionSnapshot | null,
 ): EvidenceTrailItem {
+  if (!companion.lastProbe && sharedLocalCompanion) {
+    const summary = summarizeSharedLocalProof(sharedLocalCompanion);
+    const freshness = proofFreshnessLabel({
+      reportCreatedAt,
+      proofGeneratedAt: sharedLocalCompanion.generatedAt,
+    });
+    const stale = freshness === 'Stale';
+    return {
+      id: 'local-agent',
+      source: 'Local agent',
+      fact: truncateFact(summary.text),
+      status: stale ? freshness : summary.status,
+      tone: stale ? 'watch' : summary.tone,
+      detail: stale ? staleEvidenceDetail('local agent') : summary.detail,
+    };
+  }
+
   if (companion.lastProbe) {
     const summary = summarizeLocalProof(companion.lastProbe);
     const freshness = proofFreshnessLabel({
@@ -224,6 +249,6 @@ export function buildEvidenceTrail(input: EvidenceTrailInput): EvidenceTrailItem
       detail: truncateFact(report.diagnosis.timingVisibility.detail),
     },
     remoteTrail(input.remoteVantage, report.createdAt),
-    companionTrail(input.companion, report.createdAt),
+    companionTrail(input.companion, report.createdAt, input.sharedLocalCompanion ?? null),
   ];
 }

--- a/src/lib/utils/proof-flow.ts
+++ b/src/lib/utils/proof-flow.ts
@@ -2,6 +2,7 @@ import type { CompanionProbeResponse } from '../companion/protocol';
 import type { RemoteVantageProbeResponse } from '../remote-vantage/types';
 import type { CompanionStatus } from '../stores/companion';
 import type { RemoteVantageStatus } from '../stores/remote-vantage';
+import type { ShareLocalCompanionSnapshot } from '../types';
 import type { EvidenceTrailTone } from './evidence-trail';
 
 export type ProofKind = 'remote' | 'local';
@@ -91,6 +92,24 @@ export function summarizeLocalProof(probe: CompanionProbeResponse | null): Proof
     status: 'Captured',
     text: `${probe.targetHost}: ${probe.summary}`,
     tone: probe.ok ? 'good' : 'watch',
+  };
+}
+
+export function summarizeSharedLocalProof(probe: ShareLocalCompanionSnapshot | null): ProofSummary {
+  if (!probe) {
+    return {
+      status: 'Not run',
+      text: 'No local agent probe captured.',
+      tone: 'neutral',
+    };
+  }
+
+  const hasProblem = probe.sections.some((section) => section.status !== 'captured');
+  return {
+    status: 'Captured',
+    text: `${probe.targetHost}: ${probe.summary}`,
+    tone: hasProblem ? 'watch' : 'good',
+    detail: 'Shared report includes sanitized local-agent evidence only.',
   };
 }
 

--- a/tests/unit/companion/sanitize.test.ts
+++ b/tests/unit/companion/sanitize.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeCompanionProbeForReport } from '../../../src/lib/companion/sanitize';
+import type { CompanionProbeResponse } from '../../../src/lib/companion/protocol';
+
+const probe: CompanionProbeResponse = {
+  ok: true,
+  id: 'probe-1',
+  targetHost: 'api.example.com',
+  createdAt: 1778352000000,
+  summary: 'DNS, TLS, route, and WiFi completed.',
+  results: {
+    dns: {
+      ok: true,
+      durationMs: 12,
+      value: {
+        lookup: [{ address: '203.0.113.10', family: 4 }],
+        a: ['203.0.113.10'],
+        aaaa: [],
+        cname: [],
+      },
+    },
+    tls: {
+      ok: true,
+      durationMs: 32,
+      value: {
+        authorized: true,
+        authorizationError: null,
+        protocol: 'TLSv1.3',
+        cipher: 'TLS_AES_128_GCM_SHA256',
+        validFrom: 'Jan 1 00:00:00 2026 GMT',
+        validTo: 'Dec 31 23:59:59 2026 GMT',
+        subject: 'api.example.com',
+        issuer: 'Example CA',
+        fingerprint256: 'AA:BB:CC',
+      },
+    },
+    route: {
+      ok: true,
+      durationMs: 55,
+      value: {
+        tool: 'traceroute',
+        hops: [
+          { raw: '1  home-router.local (192.168.1.1)  1.2 ms' },
+          { raw: '2  isp.example.net (198.51.100.1)  9.8 ms' },
+        ],
+      },
+    },
+    wifi: {
+      ok: true,
+      durationMs: 5,
+      value: {
+        ssid: 'HomeNetwork',
+        bssid: 'aa:bb:cc:dd:ee:ff',
+        rssi: -51,
+        noise: -90,
+      },
+    },
+  },
+};
+
+describe('sanitizeCompanionProbeForReport', () => {
+  it('redacts private WiFi identifiers by default while keeping signal evidence', () => {
+    const sanitized = sanitizeCompanionProbeForReport(probe, { includePrivateWifi: false });
+
+    expect(sanitized.wifi).toMatchObject({
+      rssi: -51,
+      noise: -90,
+      ssid: 'redacted',
+      bssid: 'redacted',
+    });
+    expect(JSON.stringify(sanitized)).not.toContain('HomeNetwork');
+    expect(JSON.stringify(sanitized)).not.toContain('aa:bb:cc:dd:ee:ff');
+  });
+
+  it('keeps private WiFi identifiers only when explicitly allowed', () => {
+    const sanitized = sanitizeCompanionProbeForReport(probe, { includePrivateWifi: true });
+
+    expect(sanitized.wifi).toMatchObject({
+      ssid: 'HomeNetwork',
+      bssid: 'aa:bb:cc:dd:ee:ff',
+    });
+  });
+
+  it('summarizes route evidence without exporting raw hop lines or private LAN addresses', () => {
+    const sanitized = sanitizeCompanionProbeForReport(probe, { includePrivateWifi: false });
+
+    expect(sanitized.sections.find((section) => section.name === 'route')).toMatchObject({
+      name: 'route',
+      status: 'captured',
+      detail: 'traceroute captured 2 hops; raw hop details stay local.',
+    });
+    expect(JSON.stringify(sanitized)).not.toContain('home-router.local');
+    expect(JSON.stringify(sanitized)).not.toContain('192.168.1.1');
+  });
+});

--- a/tests/unit/components/report-view-actions.test.ts
+++ b/tests/unit/components/report-view-actions.test.ts
@@ -13,10 +13,12 @@ import type {
   SharePayload,
   SharedReportContext,
 } from '../../../src/lib/types';
+import type { CompanionState } from '../../../src/lib/stores/companion';
 import type { RemoteVantageState } from '../../../src/lib/stores/remote-vantage';
 
 const mocks = vi.hoisted(() => {
   const remoteSubscribers = new Set<(state: RemoteVantageState) => void>();
+  const companionSubscribers = new Set<(state: CompanionState) => void>();
   let remoteState = {
     status: 'idle',
     health: null,
@@ -25,12 +27,25 @@ const mocks = vi.hoisted(() => {
     hostedReportFallback: null,
     error: null,
   } as RemoteVantageState;
+  let companionState = {
+    baseUrl: 'http://127.0.0.1:47317',
+    hasSecret: false,
+    status: 'idle',
+    version: null,
+    capabilities: null,
+    lastProbe: null,
+    history: [],
+    error: null,
+  } as CompanionState;
   const remoteUnsubscribe = vi.fn();
+  const companionUnsubscribe = vi.fn();
 
   return {
     historyUnsubscribe: vi.fn(),
     remoteUnsubscribe,
+    companionUnsubscribe,
     runProbe: vi.fn(),
+    runCompanionProbe: vi.fn(),
     createHostedReport: vi.fn<(payload: SharePayload) => Promise<string | null>>().mockResolvedValue(null),
     get remoteState(): RemoteVantageState {
       return remoteState;
@@ -42,12 +57,37 @@ const mocks = vi.hoisted(() => {
       remoteState = { ...remoteState, ...update };
       for (const subscriber of remoteSubscribers) subscriber(remoteState);
     },
+    setCompanionState(update: Partial<CompanionState>): void {
+      companionState = { ...companionState, ...update };
+      for (const subscriber of companionSubscribers) subscriber(companionState);
+    },
+    resetCompanionState(): void {
+      companionState = {
+        baseUrl: 'http://127.0.0.1:47317',
+        hasSecret: false,
+        status: 'idle',
+        version: null,
+        capabilities: null,
+        lastProbe: null,
+        history: [],
+        error: null,
+      } as CompanionState;
+      for (const subscriber of companionSubscribers) subscriber(companionState);
+    },
     subscribeRemote(run: (state: RemoteVantageState) => void): () => void {
       remoteSubscribers.add(run);
       run(remoteState);
       return () => {
         remoteSubscribers.delete(run);
         remoteUnsubscribe();
+      };
+    },
+    subscribeCompanion(run: (state: CompanionState) => void): () => void {
+      companionSubscribers.add(run);
+      run(companionState);
+      return () => {
+        companionSubscribers.delete(run);
+        companionUnsubscribe();
       };
     },
   };
@@ -67,6 +107,17 @@ vi.mock('$lib/stores/remote-vantage', () => ({
     subscribe: mocks.subscribeRemote,
     runProbe: mocks.runProbe,
     createHostedReport: mocks.createHostedReport,
+  },
+}));
+
+vi.mock('$lib/stores/companion', () => ({
+  companionStore: {
+    subscribe: mocks.subscribeCompanion,
+    configure: vi.fn(),
+    checkHealth: vi.fn().mockResolvedValue(false),
+    runProbe: mocks.runCompanionProbe,
+    loadHistory: vi.fn().mockResolvedValue([]),
+    clearSecret: vi.fn(),
   },
 }));
 
@@ -216,6 +267,7 @@ describe('ReportView triage actions', () => {
       hostedReportFallback: null,
       error: null,
     });
+    mocks.resetCompanionState();
     Object.defineProperty(Element.prototype, 'scrollIntoView', {
       configurable: true,
       value: vi.fn(),
@@ -351,6 +403,53 @@ describe('ReportView triage actions', () => {
         expect.objectContaining({ endpointId: 'api', verdict: 'slow' }),
       ]),
     }));
+  });
+
+  it('keeps local proof out of copied report links until the sender opts in', async () => {
+    seedIsolatedReport();
+    mocks.setCompanionState({
+      status: 'connected',
+      lastProbe: {
+        ok: true,
+        id: 'probe-1',
+        targetHost: 'api.example.com',
+        createdAt: 1778352005000,
+        summary: 'WiFi completed.',
+        results: {
+          wifi: {
+            ok: true,
+            durationMs: 5,
+            value: {
+              ssid: 'HomeNetwork',
+              bssid: 'aa:bb:cc:dd:ee:ff',
+              rssi: -51,
+              noise: -90,
+            },
+          },
+        },
+      },
+    });
+    const { getByLabelText, getByRole } = render(ReportView);
+
+    await fireEvent.click(getByRole('button', { name: /copy report link/i }));
+    await waitFor(() => {
+      expect(mocks.createHostedReport).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.createHostedReport.mock.calls[0]?.[0].localCompanion).toBeUndefined();
+
+    mocks.createHostedReport.mockClear();
+    await fireEvent.click(getByLabelText(/include redacted local proof/i));
+    await fireEvent.click(getByRole('button', { name: /copy report link|link copied/i }));
+
+    await waitFor(() => {
+      expect(mocks.createHostedReport).toHaveBeenCalledTimes(1);
+    });
+    const payload = mocks.createHostedReport.mock.calls[0]?.[0];
+    expect(payload?.localCompanion).toMatchObject({
+      targetHost: 'api.example.com',
+      wifi: { ssid: 'redacted', bssid: 'redacted' },
+    });
+    expect(JSON.stringify(payload)).not.toContain('HomeNetwork');
   });
 
   it('marks an older outside proof action as stale against the current report', () => {

--- a/tests/unit/components/share-popover.test.ts
+++ b/tests/unit/components/share-popover.test.ts
@@ -7,12 +7,54 @@ import { endpointStore } from '../../../src/lib/stores/endpoints';
 import { measurementStore } from '../../../src/lib/stores/measurements';
 import { settingsStore } from '../../../src/lib/stores/settings';
 import { uiStore } from '../../../src/lib/stores/ui';
+import type { CompanionState } from '../../../src/lib/stores/companion';
 import type { Endpoint, MeasurementSample, MeasurementState, SharePayload } from '../../../src/lib/types';
 
-const mocks = vi.hoisted(() => ({
-  remoteUnsubscribe: vi.fn(),
-  createHostedReport: vi.fn<(payload: SharePayload) => Promise<string | null>>(),
-}));
+const mocks = vi.hoisted(() => {
+  const companionSubscribers = new Set<(state: CompanionState) => void>();
+  const companionUnsubscribe = vi.fn();
+  let companionState = {
+    baseUrl: 'http://127.0.0.1:47317',
+    hasSecret: false,
+    status: 'idle',
+    version: null,
+    capabilities: null,
+    lastProbe: null,
+    history: [],
+    error: null,
+  } as CompanionState;
+
+  return {
+    remoteUnsubscribe: vi.fn(),
+    companionUnsubscribe,
+    createHostedReport: vi.fn<(payload: SharePayload) => Promise<string | null>>(),
+    setCompanionState(update: Partial<CompanionState>): void {
+      companionState = { ...companionState, ...update };
+      for (const subscriber of companionSubscribers) subscriber(companionState);
+    },
+    resetCompanionState(): void {
+      companionState = {
+        baseUrl: 'http://127.0.0.1:47317',
+        hasSecret: false,
+        status: 'idle',
+        version: null,
+        capabilities: null,
+        lastProbe: null,
+        history: [],
+        error: null,
+      } as CompanionState;
+      for (const subscriber of companionSubscribers) subscriber(companionState);
+    },
+    subscribeCompanion(run: (state: CompanionState) => void): () => void {
+      companionSubscribers.add(run);
+      run(companionState);
+      return () => {
+        companionSubscribers.delete(run);
+        companionUnsubscribe();
+      };
+    },
+  };
+});
 
 vi.mock('$lib/stores/remote-vantage', () => ({
   remoteVantageStore: {
@@ -21,6 +63,12 @@ vi.mock('$lib/stores/remote-vantage', () => ({
       return mocks.remoteUnsubscribe;
     },
     createHostedReport: mocks.createHostedReport,
+  },
+}));
+
+vi.mock('$lib/stores/companion', () => ({
+  companionStore: {
+    subscribe: mocks.subscribeCompanion,
   },
 }));
 
@@ -75,6 +123,7 @@ describe('SharePopover hosted support reports', () => {
     settingsStore.reset();
     uiStore.reset();
     uiStore.toggleShare();
+    mocks.resetCompanionState();
     Object.assign(navigator, {
       clipboard: {
         writeText: vi.fn().mockResolvedValue(),
@@ -101,6 +150,49 @@ describe('SharePopover hosted support reports', () => {
     expect(payload?.mode).toBe('results');
     expect(payload?.report?.reportKind).toBe('support');
     expect(payload?.results?.[0]?.samples).toHaveLength(4);
+    expect(payload?.localCompanion).toBeUndefined();
+  });
+
+  it('includes redacted local proof in support reports only after explicit opt-in', async () => {
+    seedResults();
+    mocks.createHostedReport.mockResolvedValue('https://chronoscope.dev/r/report_123');
+    mocks.setCompanionState({
+      status: 'connected',
+      lastProbe: {
+        ok: true,
+        id: 'probe-1',
+        targetHost: 'api.example.com',
+        createdAt: 1778352000000,
+        summary: 'DNS, TLS, route, and WiFi completed.',
+        results: {
+          wifi: {
+            ok: true,
+            durationMs: 5,
+            value: {
+              ssid: 'HomeNetwork',
+              bssid: 'aa:bb:cc:dd:ee:ff',
+              rssi: -51,
+              noise: -90,
+            },
+          },
+        },
+      },
+    });
+
+    const { getByLabelText, getByRole } = render(SharePopover);
+    await fireEvent.click(getByLabelText(/include redacted local proof/i));
+    await fireEvent.click(getByRole('button', { name: /create support report/i }));
+
+    await waitFor(() => {
+      expect(mocks.createHostedReport).toHaveBeenCalledTimes(1);
+    });
+    const payload = mocks.createHostedReport.mock.calls[0]?.[0];
+    expect(payload?.localCompanion).toMatchObject({
+      targetHost: 'api.example.com',
+      wifi: { ssid: 'redacted', bssid: 'redacted', rssi: -51, noise: -90 },
+    });
+    expect(JSON.stringify(payload)).not.toContain('HomeNetwork');
+    expect(JSON.stringify(payload)).not.toContain('aa:bb:cc:dd:ee:ff');
   });
 
   it('falls back to a compact results URL when hosted reports are unavailable', async () => {

--- a/tests/unit/share-payload-builder.test.ts
+++ b/tests/unit/share-payload-builder.test.ts
@@ -3,7 +3,13 @@ import {
   buildConfigSharePayload,
   buildResultsSharePayload,
 } from '../../src/lib/share/share-payload-builder';
-import type { Endpoint, MeasurementSample, MeasurementState, SampleBuffer } from '../../src/lib/types';
+import type {
+  Endpoint,
+  MeasurementSample,
+  MeasurementState,
+  SampleBuffer,
+  ShareLocalCompanionSnapshot,
+} from '../../src/lib/types';
 import { DEFAULT_SETTINGS } from '../../src/lib/types';
 
 function endpoint(id: string): Endpoint {
@@ -141,5 +147,55 @@ describe('share-payload-builder', () => {
 
     expect(built.payload.report?.keptSampleCount).toBe(12);
     expect(built.payload.report?.totalSampleCount).toBe(12);
+  });
+
+  it('does not include local companion proof in result shares by default', () => {
+    const ep = endpoint('api');
+    const built = buildResultsSharePayload(
+      [ep],
+      DEFAULT_SETTINGS,
+      measurementState(ep.id, [ok(1)]),
+      8000,
+      1778352000000,
+    );
+
+    expect(built.payload.localCompanion).toBeUndefined();
+  });
+
+  it('includes local companion proof only when a sanitized snapshot is explicitly passed', () => {
+    const ep = endpoint('api');
+    const localCompanion: ShareLocalCompanionSnapshot = {
+      generatedAt: 1778352000500,
+      targetHost: 'api.example.test',
+      summary: 'DNS, TLS, route, and WiFi completed.',
+      sections: [
+        {
+          name: 'wifi',
+          status: 'captured',
+          ok: true,
+          durationMs: 5,
+          detail: 'WiFi signal captured; private network names are redacted.',
+        },
+      ],
+      wifi: {
+        rssi: -51,
+        noise: -90,
+        ssid: 'redacted',
+        bssid: 'redacted',
+      },
+    };
+
+    const built = buildResultsSharePayload(
+      [ep],
+      DEFAULT_SETTINGS,
+      measurementState(ep.id, [ok(1)]),
+      8000,
+      1778352000000,
+      {},
+      null,
+      localCompanion,
+    );
+
+    expect(built.payload.localCompanion).toEqual(localCompanion);
   });
 });

--- a/tests/unit/share/hash-router.test.ts
+++ b/tests/unit/share/hash-router.test.ts
@@ -465,6 +465,36 @@ describe('hash-router: results-mode application', () => {
     expect(get(uiStore).sharedReportContext?.reportKind).toBe('snapshot');
   });
 
+  it('stores sanitized local companion evidence from shared reports', () => {
+    applySharePayload({
+      ...reportPayload(),
+      localCompanion: {
+        generatedAt: 1778352000500,
+        targetHost: 'victim-target.example.com',
+        summary: 'DNS, TLS, route, and WiFi completed.',
+        sections: [{
+          name: 'route',
+          status: 'captured',
+          ok: true,
+          durationMs: 25,
+          detail: 'traceroute captured 3 hops; raw hop details stay local.',
+        }],
+        wifi: {
+          rssi: -51,
+          noise: -90,
+          ssid: 'redacted',
+          bssid: 'redacted',
+        },
+      },
+    });
+
+    expect(get(uiStore).sharedLocalCompanion).toMatchObject({
+      targetHost: 'victim-target.example.com',
+      sections: [{ name: 'route', status: 'captured' }],
+      wifi: { ssid: 'redacted', bssid: 'redacted' },
+    });
+  });
+
   it('infers legacy v1 report context from results without threshold metadata', () => {
     applySharePayload(resultsPayload());
     const context = get(uiStore).sharedReportContext;

--- a/tests/unit/share/share-payload-rejects-unknown-keys.test.ts
+++ b/tests/unit/share/share-payload-rejects-unknown-keys.test.ts
@@ -4,7 +4,7 @@
 // harvesting, prototype-pollution surface, future round-trip footgun) at both
 // the top level and per-entry level. The validator must reject any payload
 // that contains keys outside the declared allowlists:
-//   - Top-level:  { v, mode, endpoints, settings, results, report, remoteVantage }
+//   - Top-level:  { v, mode, endpoints, settings, results, report, remoteVantage, localCompanion }
 //   - Per-entry:  { url, enabled }
 //
 // Uses the encodeSharePayload / decodeSharePayload round-trip so the full
@@ -179,6 +179,47 @@ describe('validateSharePayload: top-level unknown key rejection', () => {
     expect(decodeSharePayload(encoded)).not.toBeNull();
   });
 
+  it('accepts a bounded sanitized local companion snapshot in v2 results mode', () => {
+    const payload: SharePayload = {
+      v: 2,
+      mode: 'results',
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'no-cors' },
+      report: {
+        reportKind: 'support',
+        createdAt: 1778352000000,
+        healthThreshold: 120,
+        corsMode: 'no-cors',
+        roundCount: 1,
+        totalSampleCount: 1,
+        keptSampleCount: 1,
+        truncated: false,
+      },
+      localCompanion: {
+        generatedAt: 1778352000500,
+        targetHost: 'example.com',
+        summary: 'DNS, TLS, route, and WiFi completed.',
+        sections: [{
+          name: 'wifi',
+          status: 'captured',
+          ok: true,
+          durationMs: 5,
+          detail: 'WiFi signal captured; private network names are redacted.',
+        }],
+        wifi: {
+          rssi: -51,
+          noise: -90,
+          ssid: 'redacted',
+          bssid: 'redacted',
+        },
+      },
+      results: [{ samples: [{ round: 0, latency: 42, status: 'ok' }] }],
+    };
+
+    const encoded = encodeSharePayload(payload);
+    expect(decodeSharePayload(encoded)).not.toBeNull();
+  });
+
   it('accepts a bounded reportKind in v2 report metadata', () => {
     const payload: SharePayload = {
       v: 2,
@@ -259,6 +300,74 @@ describe('validateSharePayload: top-level unknown key rejection', () => {
     };
     const encoded = encodeSharePayload(payload as never);
     expect(decodeSharePayload(encoded)).toBeNull();
+  });
+
+  it('rejects local companion payloads that include private history or unknown keys', () => {
+    const payload = {
+      v: 2,
+      mode: 'results',
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'no-cors' as const },
+      report: {
+        createdAt: 1778352000000,
+        healthThreshold: 120,
+        corsMode: 'no-cors' as const,
+        roundCount: 1,
+        totalSampleCount: 1,
+        keptSampleCount: 1,
+        truncated: false,
+      },
+      localCompanion: {
+        generatedAt: 1778352000500,
+        targetHost: 'example.com',
+        summary: 'DNS completed.',
+        history: [{ id: 'private-local-history' }],
+        sections: [{
+          name: 'dns',
+          status: 'captured',
+          ok: true,
+          durationMs: 5,
+          detail: 'DNS captured.',
+          raw: ['private raw data'],
+        }],
+      },
+      results: [{ samples: [{ round: 0, latency: 42, status: 'ok' as const }] }],
+    };
+
+    expect(decodeSharePayload(encodeSharePayload(payload as never))).toBeNull();
+  });
+
+  it('rejects local companion target hosts that are not shared endpoints', () => {
+    const payload = {
+      v: 2,
+      mode: 'results',
+      endpoints: [{ url: 'https://example.com', enabled: true }],
+      settings: { timeout: 5000, delay: 0, cap: MAX_CAP, corsMode: 'no-cors' as const },
+      report: {
+        createdAt: 1778352000000,
+        healthThreshold: 120,
+        corsMode: 'no-cors' as const,
+        roundCount: 1,
+        totalSampleCount: 1,
+        keptSampleCount: 1,
+        truncated: false,
+      },
+      localCompanion: {
+        generatedAt: 1778352000500,
+        targetHost: '192.168.1.1',
+        summary: 'Route completed.',
+        sections: [{
+          name: 'route',
+          status: 'captured',
+          ok: true,
+          durationMs: 5,
+          detail: 'traceroute captured 1 hop; raw hop details stay local.',
+        }],
+      },
+      results: [{ samples: [{ round: 0, latency: 42, status: 'ok' as const }] }],
+    };
+
+    expect(decodeSharePayload(encodeSharePayload(payload as never))).toBeNull();
   });
 });
 

--- a/tests/unit/utils/evidence-trail.test.ts
+++ b/tests/unit/utils/evidence-trail.test.ts
@@ -298,4 +298,37 @@ describe('buildEvidenceTrail', () => {
       detail: 'This local agent was captured before the report snapshot. Run it again to refresh the evidence.',
     });
   });
+
+  it('summarizes sanitized local proof from a shared report payload', () => {
+    const trail = buildEvidenceTrail({
+      report: isolatedReport(),
+      remoteVantage: emptyRemote,
+      companion: emptyCompanion,
+      sharedLocalCompanion: {
+        generatedAt: 1778352000500,
+        targetHost: 'api.example.test',
+        summary: 'DNS, TLS, route, and WiFi completed.',
+        sections: [{
+          name: 'route',
+          status: 'captured',
+          ok: true,
+          durationMs: 25,
+          detail: 'traceroute captured 3 hops; raw hop details stay local.',
+        }],
+        wifi: {
+          rssi: -51,
+          noise: -90,
+          ssid: 'redacted',
+          bssid: 'redacted',
+        },
+      },
+    });
+
+    expect(trail.find((item) => item.id === 'local-agent')).toMatchObject({
+      status: 'Captured',
+      tone: 'good',
+      fact: 'api.example.test: DNS, TLS, route, and WiFi completed.',
+      detail: 'Shared report includes sanitized local-agent evidence only.',
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds a report-safe local companion sanitizer that exports section status/duration/details while keeping raw route hops and private WiFi identifiers out by default.
- Adds explicit "Include redacted local proof" opt-in controls for support report creation/copying, with shared-report hydration for sanitized local evidence.
- Extends share schema validation so local proof must be v2 results-mode, bounded, unknown-key-free, and tied to a shared endpoint host.

## Test Plan
- `npm test -- tests/unit/components/share-popover.test.ts tests/unit/components/report-view-actions.test.ts tests/unit/companion/sanitize.test.ts tests/unit/share-payload-builder.test.ts tests/unit/share/share-payload-rejects-unknown-keys.test.ts tests/unit/share/hash-router.test.ts tests/unit/utils/evidence-trail.test.ts`
- `npm run typecheck && npm run lint && npm run build && npm test`
- Rendered QA via Playwright fallback at `http://127.0.0.1:5174/#s=<share-payload>` across 1440x900 and 393x852; verified report rendered, sanitized local proof appeared, private WiFi/raw route details did not appear, and console had no warnings/errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now optionally include redacted local network proof in shared reports and support links, with privacy controls to exclude sensitive identifiers like WiFi names by default.

* **Documentation**
  * Added "Public Report Privacy" section explaining how local evidence is handled in public reports and snapshot links, including details on redaction and omission rules.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xaedyn/chronoscope/pull/133)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->