### PR TITLE
[codex] Classify browser loss patterns

### DIFF
--- a/src/lib/loss/patterns.ts
+++ b/src/lib/loss/patterns.ts
@@ -1,0 +1,94 @@
+import type { MeasurementSample } from '../types';
+
+export type LossPatternKind = 'none' | 'insufficient-data' | 'random' | 'burst' | 'periodic';
+
+export interface LossPattern {
+  readonly kind: LossPatternKind;
+  readonly failedCount: number;
+  readonly totalCount: number;
+  readonly safeSummary: string;
+}
+
+const MINIMUM_CLASSIFICATION_SAMPLES = 10;
+const MINIMUM_PERIODIC_FAILURES = 4;
+const MINIMUM_BURST_LENGTH = 3;
+const PERIODIC_GAP_TOLERANCE = 1;
+
+export function classifyLossPattern(samples: readonly MeasurementSample[]): LossPattern {
+  const failedSamples = samples.filter((sample) => sample.status !== 'ok');
+  const failedRounds = [...new Set(failedSamples.map((sample) => sample.round))]
+    .sort((left, right) => left - right);
+
+  if (samples.length < MINIMUM_CLASSIFICATION_SAMPLES) {
+    return {
+      kind: 'insufficient-data',
+      failedCount: failedSamples.length,
+      totalCount: samples.length,
+      safeSummary: 'More samples are needed before classifying failed requests.',
+    };
+  }
+
+  if (failedRounds.length === 0) {
+    return {
+      kind: 'none',
+      failedCount: 0,
+      totalCount: samples.length,
+      safeSummary: 'No failed requests in this sample window.',
+    };
+  }
+
+  if (longestConsecutiveRun(failedRounds) >= MINIMUM_BURST_LENGTH) {
+    return {
+      kind: 'burst',
+      failedCount: failedSamples.length,
+      totalCount: samples.length,
+      safeSummary: 'Failed requests are clustered in a short burst.',
+    };
+  }
+
+  if (hasRegularFailureGap(failedRounds)) {
+    return {
+      kind: 'periodic',
+      failedCount: failedSamples.length,
+      totalCount: samples.length,
+      safeSummary: 'Failed requests appear at a repeating interval.',
+    };
+  }
+
+  return {
+    kind: 'random',
+    failedCount: failedSamples.length,
+    totalCount: samples.length,
+    safeSummary: 'Failed requests are scattered across the sample window.',
+  };
+}
+
+function longestConsecutiveRun(rounds: readonly number[]): number {
+  let longest = 0;
+  let current = 0;
+  let previousRound: number | null = null;
+
+  for (const round of rounds) {
+    if (previousRound !== null && round === previousRound + 1) {
+      current += 1;
+    } else {
+      current = 1;
+    }
+
+    longest = Math.max(longest, current);
+    previousRound = round;
+  }
+
+  return longest;
+}
+
+function hasRegularFailureGap(rounds: readonly number[]): boolean {
+  if (rounds.length < MINIMUM_PERIODIC_FAILURES) {
+    return false;
+  }
+
+  const gaps = rounds.slice(1).map((round, index) => round - rounds[index]);
+  const referenceGap = gaps[0];
+
+  return gaps.every((gap) => Math.abs(gap - referenceGap) <= PERIODIC_GAP_TOLERANCE);
+}

--- a/src/lib/utils/diagnostic-narrative.ts
+++ b/src/lib/utils/diagnostic-narrative.ts
@@ -3,6 +3,7 @@
 // confidence, supporting evidence, browser visibility limits, and next steps.
 
 import type { MeasurementSample, Settings } from '../types';
+import { classifyLossPattern } from '../loss/patterns';
 import { renderClaim, type ClaimEvidenceState, type ClaimId } from './claim-registry';
 import { computeCausalVerdict, PHASE_LABELS, type Verdict, type VerdictRow } from './verdict';
 
@@ -401,6 +402,7 @@ function evidenceFor(input: {
   readonly overRows: readonly VerdictRow[];
   readonly verdict: Verdict;
   readonly timingVisibility: TimingVisibility;
+  readonly samplesByEndpoint: Readonly<Record<string, readonly MeasurementSample[]>>;
 }): DiagnosticEvidence[] {
   const { rows, monitoredEndpointCount, threshold, overRows, verdict, timingVisibility } = input;
   const evidence: DiagnosticEvidence[] = [
@@ -447,7 +449,18 @@ function evidenceFor(input: {
 
   const avgLoss = mean(rows.map((row) => row.stats.lossPercent));
   if (avgLoss > LOSS_WARN_PERCENT) {
-    evidence.push({ id: 'failed-requests', label: 'Failed requests', value: fmtPct(avgLoss) });
+    const lossySamples = rows
+      .filter((row) => row.stats.lossPercent > LOSS_WARN_PERCENT)
+      .flatMap((row) => input.samplesByEndpoint[row.ep.id] ?? []);
+    const lossPattern = classifyLossPattern(lossySamples);
+    evidence.push({
+      id: 'failed-requests',
+      label: 'Failed requests',
+      value: fmtPct(avgLoss),
+      ...(lossPattern.kind === 'none' || lossPattern.totalCount === 0
+        ? {}
+        : { detail: lossPattern.safeSummary }),
+    });
   }
 
   const avgJitter = mean(rows.map((row) => row.stats.stddev));
@@ -1027,6 +1040,7 @@ export function buildDiagnosticNarrative(input: DiagnosticInput): DiagnosticNarr
     overRows,
     verdict,
     timingVisibility,
+    samplesByEndpoint: input.samplesByEndpoint,
   });
   const snapshotEligibility = snapshotEligibilityFor({
     kind,

--- a/tests/unit/loss/patterns.test.ts
+++ b/tests/unit/loss/patterns.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+
+import { classifyLossPattern } from '../../../src/lib/loss/patterns';
+import type { MeasurementSample } from '../../../src/lib/types';
+
+const ok = (round: number): MeasurementSample => ({
+  round,
+  latency: 40,
+  status: 'ok',
+  timestamp: round,
+});
+
+const timeout = (round: number): MeasurementSample => ({
+  round,
+  latency: 5000,
+  status: 'timeout',
+  timestamp: round,
+});
+
+describe('classifyLossPattern', () => {
+  it('returns insufficient data for short runs', () => {
+    expect(classifyLossPattern([ok(1), timeout(2)])).toMatchObject({
+      kind: 'insufficient-data',
+      failedCount: 1,
+      totalCount: 2,
+      safeSummary: 'More samples are needed before classifying failed requests.',
+    });
+  });
+
+  it('reports no loss when every sample succeeds', () => {
+    const samples = Array.from({ length: 12 }, (_, index) => ok(index + 1));
+
+    expect(classifyLossPattern(samples)).toMatchObject({
+      kind: 'none',
+      failedCount: 0,
+      totalCount: 12,
+      safeSummary: 'No failed requests in this sample window.',
+    });
+  });
+
+  it('classifies burst failures without implying cause', () => {
+    const samples = [
+      ok(1),
+      ok(2),
+      timeout(3),
+      timeout(4),
+      timeout(5),
+      ok(6),
+      ok(7),
+      ok(8),
+      ok(9),
+      ok(10),
+    ];
+
+    expect(classifyLossPattern(samples)).toMatchObject({
+      kind: 'burst',
+      failedCount: 3,
+      totalCount: 10,
+      safeSummary: 'Failed requests are clustered in a short burst.',
+    });
+  });
+
+  it('keeps duplicate failed rounds counted when classifying aggregate samples', () => {
+    const samples = [
+      ok(1),
+      ok(2),
+      timeout(3),
+      timeout(3),
+      timeout(4),
+      timeout(4),
+      timeout(5),
+      timeout(5),
+      ok(6),
+      ok(7),
+      ok(8),
+      ok(9),
+    ];
+
+    expect(classifyLossPattern(samples)).toMatchObject({
+      kind: 'burst',
+      failedCount: 6,
+      totalCount: 12,
+      safeSummary: 'Failed requests are clustered in a short burst.',
+    });
+  });
+
+  it('classifies periodic failures when gaps are regular', () => {
+    const samples = Array.from({ length: 30 }, (_, index) =>
+      (index + 1) % 5 === 0 ? timeout(index + 1) : ok(index + 1),
+    );
+
+    expect(classifyLossPattern(samples)).toMatchObject({
+      kind: 'periodic',
+      failedCount: 6,
+      totalCount: 30,
+      safeSummary: 'Failed requests appear at a repeating interval.',
+    });
+  });
+
+  it('classifies scattered failures as random without guessing why', () => {
+    const samples = Array.from({ length: 20 }, (_, index) =>
+      [3, 9, 17].includes(index + 1) ? timeout(index + 1) : ok(index + 1),
+    );
+
+    expect(classifyLossPattern(samples)).toMatchObject({
+      kind: 'random',
+      failedCount: 3,
+      totalCount: 20,
+      safeSummary: 'Failed requests are scattered across the sample window.',
+    });
+  });
+});

--- a/tests/unit/utils/diagnostic-narrative.test.ts
+++ b/tests/unit/utils/diagnostic-narrative.test.ts
@@ -61,6 +61,15 @@ function ok(round: number, latency = 50, sampleOver: Partial<MeasurementSample> 
   };
 }
 
+function timeout(round: number): MeasurementSample {
+  return {
+    round,
+    latency: 5000,
+    status: 'timeout',
+    timestamp: 0,
+  };
+}
+
 function samples(count: number, latency = 50, withTier2 = false): MeasurementSample[] {
   return Array.from({ length: count }, (_, i) => ok(i + 1, latency, withTier2 ? { tier2 } : {}));
 }
@@ -257,6 +266,29 @@ describe('buildDiagnosticNarrative', () => {
     expect(narrative.primaryValidation.id).toBe('explain-browser-visibility');
     expect(narrative.primaryValidation.reason).toBe('Chronoscope can compare total load time, but not every DNS, TCP, TLS, or server timing detail is visible.');
     expect(narrative.confidenceReason).toBe('Based on 12+ successful checks across 2 sites.');
+  });
+
+  it('adds a compact loss pattern detail without guessing the cause', () => {
+    const narrative = buildDiagnosticNarrative({
+      rows: [
+        row('google', { lossPercent: 20, sampleCount: 10 }),
+        row('cloudflare', { lossPercent: 0, sampleCount: 10 }),
+      ],
+      threshold: 120,
+      corsMode: 'no-cors',
+      samplesByEndpoint: {
+        google: [ok(1), ok(2), timeout(3), timeout(4), timeout(5), ok(6), ok(7), ok(8), ok(9), ok(10)],
+        cloudflare: samples(10, 55),
+      },
+      monitoredEndpointCount: 2,
+    });
+
+    const lossEvidence = narrative.evidence.find((item) => item.id === 'failed-requests');
+    expect(lossEvidence).toMatchObject({
+      label: 'Failed requests',
+      detail: 'Failed requests are clustered in a short burst.',
+    });
+    expect(lossEvidence?.detail).not.toMatch(/cause|because|router|ISP|Wi[- ]?Fi|server/i);
   });
 
   it('estimates successful samples from loss when raw samples are unavailable', () => {


### PR DESCRIPTION
## Summary
- add a browser-safe loss pattern classifier for none, insufficient data, burst, periodic, and scattered failures
- surface the classifier as a compact failed-request evidence detail in the diagnostic narrative
- keep all pattern language evidence-scoped so Chronoscope describes what it measured without naming a cause

## Validation
- npm test -- tests/unit/utils/diagnostic-narrative.test.ts tests/unit/loss/patterns.test.ts
- npm run typecheck && npm run lint && npm run build && npm test