### PR TITLE
[codex] Add browser loaded latency check

### DIFF
--- a/src/lib/bufferbloat/bufferbloat-test.ts
+++ b/src/lib/bufferbloat/bufferbloat-test.ts
@@ -1,0 +1,45 @@
+export type BufferbloatGrade = 'clean' | 'watch' | 'loaded-latency-high' | 'insufficient-data';
+
+export interface BufferbloatGradeInput {
+  readonly idleMedianMs: number | null;
+  readonly loadedMedianMs: number | null;
+}
+
+export interface BufferbloatGradeResult {
+  readonly grade: BufferbloatGrade;
+  readonly deltaMs: number | null;
+  readonly summary: string;
+}
+
+export function median(values: readonly number[]): number | null {
+  const finite = values.filter((value) => Number.isFinite(value)).sort((left, right) => left - right);
+  if (finite.length === 0) return null;
+  const middle = Math.floor(finite.length / 2);
+  if (finite.length % 2 === 1) return Math.round(finite[middle] ?? 0);
+  const left = finite[middle - 1] ?? 0;
+  const right = finite[middle] ?? left;
+  return Math.round((left + right) / 2);
+}
+
+export function gradeBufferbloat(input: BufferbloatGradeInput): BufferbloatGradeResult {
+  if (input.idleMedianMs === null || input.loadedMedianMs === null) {
+    return {
+      grade: 'insufficient-data',
+      deltaMs: null,
+      summary: 'Run idle and loaded checks before grading loaded latency.',
+    };
+  }
+
+  const deltaMs = Math.max(0, Math.round(input.loadedMedianMs - input.idleMedianMs));
+  const summary = `Latency rose by ${deltaMs} ms during download load.`;
+
+  if (deltaMs >= 100) {
+    return { grade: 'loaded-latency-high', deltaMs, summary };
+  }
+
+  if (deltaMs >= 40) {
+    return { grade: 'watch', deltaMs, summary };
+  }
+
+  return { grade: 'clean', deltaMs, summary };
+}

--- a/src/lib/components/DiagnoseView.svelte
+++ b/src/lib/components/DiagnoseView.svelte
@@ -6,6 +6,7 @@
 <!-- auto-selects an investigation target when focus is missing or stale.       -->
 <script lang="ts">
   import { monitoredEndpointsStore } from '$lib/stores/derived';
+  import { bufferbloatStore } from '$lib/stores/bufferbloat';
   import { measurementStore } from '$lib/stores/measurements';
   import { remoteVantageStore } from '$lib/stores/remote-vantage';
   import { settingsStore } from '$lib/stores/settings';
@@ -24,6 +25,7 @@
   const stats = $derived($statisticsStore);
   const measurements = $derived($measurementStore);
   const settings = $derived($settingsStore);
+  const bufferbloat = $derived($bufferbloatStore);
   const remoteVantage = $derived($remoteVantageStore);
   const focusedId = $derived($uiStore.focusedEndpointId);
 
@@ -52,6 +54,21 @@
     threshold: settings.healthThreshold,
     probe: remoteVantage.lastProbe,
   }));
+  const bufferbloatBusy = $derived(bufferbloat.status === 'running');
+  const bufferbloatStatusLabel = $derived.by(() => {
+    if (bufferbloat.status === 'running') return 'Running';
+    if (bufferbloat.status === 'stopped') return 'Stopped';
+    switch (bufferbloat.grade.grade) {
+      case 'clean':
+        return 'Clean';
+      case 'watch':
+        return 'Watch';
+      case 'loaded-latency-high':
+        return 'High';
+      case 'insufficient-data':
+        return bufferbloat.status === 'error' ? 'Needs data' : 'Not run';
+    }
+  });
   const remoteBusy = $derived(remoteVantage.status === 'checking' || remoteVantage.status === 'probing');
 
   // ── Mode toggle ──────────────────────────────────────────────────────────
@@ -231,6 +248,26 @@
 
   async function handleRemoteCheck(): Promise<void> {
     await remoteVantageStore.runProbe(focusedEndpoint ? [focusedEndpoint] : monitored);
+  }
+
+  async function handleLoadedLatencyCheck(): Promise<void> {
+    if (!focusedEndpoint) return;
+    await bufferbloatStore.run({
+      endpoint: focusedEndpoint,
+      idleSamples: focusedAllSamples,
+      settings: {
+        corsMode: settings.corsMode,
+        timeout: settings.timeout,
+      },
+    });
+  }
+
+  function handleLoadedLatencyStop(): void {
+    bufferbloatStore.stop();
+  }
+
+  function loadedLatencyMetric(value: number | null): string {
+    return value === null ? '—' : `${fmt(value)} ms`;
   }
 
   // ── Accessibility summary for the hero bar ────────────────────────────────
@@ -413,6 +450,60 @@
         <p class="remote-error">{remoteVantage.error}</p>
       {:else}
         <p class="remote-action">{remoteInsight.action}</p>
+      {/if}
+    </section>
+
+    <section
+      class="diagnose-loaded"
+      class:clean={bufferbloat.grade.grade === 'clean'}
+      class:watch={bufferbloat.grade.grade === 'watch'}
+      class:high={bufferbloat.grade.grade === 'loaded-latency-high'}
+      aria-label="Loaded latency"
+    >
+      <div class="loaded-head">
+        <div>
+          <div class="diagnose-section-kicker">Loaded latency</div>
+          <p class="loaded-headline">Browser latency while the connection is busy</p>
+        </div>
+        {#if bufferbloatBusy}
+          <button
+            type="button"
+            class="diagnose-chip diagnose-chip-action"
+            onclick={handleLoadedLatencyStop}
+          >Stop loaded check</button>
+        {:else}
+          <button
+            type="button"
+            class="diagnose-chip diagnose-chip-action"
+            disabled={!distroStats}
+            aria-disabled={!distroStats}
+            onclick={handleLoadedLatencyCheck}
+          >Run loaded check</button>
+        {/if}
+      </div>
+      <p class="loaded-detail">
+        This measures browser-visible latency while a download is running. It is loaded-latency evidence, not packet-level proof.
+      </p>
+      <dl class="loaded-evidence">
+        <div>
+          <dt>Idle median</dt>
+          <dd>{loadedLatencyMetric(bufferbloat.idleMedianMs)}</dd>
+        </div>
+        <div>
+          <dt>Loaded median</dt>
+          <dd>{loadedLatencyMetric(bufferbloat.loadedMedianMs)}</dd>
+        </div>
+        <div>
+          <dt>Status</dt>
+          <dd>{bufferbloatStatusLabel}</dd>
+        </div>
+      </dl>
+      {#if bufferbloat.error}
+        <p class="loaded-error">{bufferbloat.error}</p>
+      {:else if bufferbloat.status === 'running'}
+        <p class="loaded-action">Downloading a bounded Cloudflare response and timing this endpoint from the browser.</p>
+      {:else}
+        <p class="loaded-action">{bufferbloat.grade.summary}</p>
       {/if}
     </section>
 
@@ -676,7 +767,8 @@
   /* ── Diagnostic answer + browser visibility ───────────────────────────── */
   .diagnose-answer,
   .diagnose-visibility,
-  .diagnose-remote {
+  .diagnose-remote,
+  .diagnose-loaded {
     display: flex;
     flex-direction: column;
     gap: 10px;
@@ -831,6 +923,78 @@
     text-transform: uppercase;
   }
   .remote-evidence dd {
+    margin: 0;
+    color: var(--t1);
+    font-family: var(--mono);
+    font-size: var(--ts-sm);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .diagnose-loaded.clean {
+    border-color: rgba(134, 239, 172, 0.24);
+    background: rgba(134, 239, 172, 0.035);
+  }
+  .diagnose-loaded.watch {
+    border-color: rgba(251, 191, 36, 0.28);
+    background: rgba(251, 191, 36, 0.04);
+  }
+  .diagnose-loaded.high {
+    border-color: rgba(249, 168, 212, 0.3);
+    background: rgba(249, 168, 212, 0.045);
+  }
+  .loaded-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+  .loaded-headline,
+  .loaded-detail,
+  .loaded-action,
+  .loaded-error {
+    margin: 0;
+  }
+  .loaded-headline {
+    color: var(--t1);
+    font-size: var(--ts-md);
+    line-height: 1.4;
+  }
+  .loaded-detail,
+  .loaded-action,
+  .loaded-error {
+    color: var(--t3);
+    font-size: var(--ts-sm);
+    line-height: 1.45;
+  }
+  .loaded-action {
+    color: var(--accent-cyan);
+  }
+  .loaded-error {
+    color: var(--accent-amber);
+  }
+  .loaded-evidence {
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 10px;
+  }
+  .loaded-evidence div {
+    min-width: 0;
+    padding-top: 8px;
+    border-top: 1px solid var(--border-mid);
+  }
+  .loaded-evidence dt {
+    margin: 0 0 3px;
+    color: var(--t2);
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-kicker);
+    text-transform: uppercase;
+  }
+  .loaded-evidence dd {
     margin: 0;
     color: var(--t1);
     font-family: var(--mono);
@@ -1289,6 +1453,7 @@
     .diagnose { padding: 12px; gap: 12px; }
     .diagnose-header { flex-direction: column; align-items: flex-start; }
     .diagnose-answer-evidence { grid-template-columns: 1fr; }
+    .loaded-evidence { grid-template-columns: 1fr; }
     .diagnose-evidence-row { grid-template-columns: 10px 110px 70px 1fr 40px; }
   }
 </style>

--- a/src/lib/stores/bufferbloat.ts
+++ b/src/lib/stores/bufferbloat.ts
@@ -1,0 +1,250 @@
+import { writable } from 'svelte/store';
+import {
+  gradeBufferbloat,
+  median,
+  type BufferbloatGradeResult,
+} from '../bufferbloat/bufferbloat-test';
+import type { Endpoint, MeasurementSample, Settings } from '../types';
+
+export type BufferbloatStatus = 'idle' | 'running' | 'complete' | 'stopped' | 'error';
+
+export interface BufferbloatState {
+  readonly status: BufferbloatStatus;
+  readonly idleMedianMs: number | null;
+  readonly loadedMedianMs: number | null;
+  readonly grade: BufferbloatGradeResult;
+  readonly error: string | null;
+}
+
+export interface BufferbloatRunRequest {
+  readonly endpoint: Endpoint;
+  readonly idleSamples: readonly MeasurementSample[];
+  readonly settings: Pick<Settings, 'corsMode' | 'timeout'>;
+}
+
+export interface MeasureLatencyOptions {
+  readonly corsMode: Settings['corsMode'];
+  readonly timeout: number;
+  readonly signal: AbortSignal;
+  readonly fetcher: typeof fetch;
+}
+
+type MeasureLatency = (url: string, options: MeasureLatencyOptions) => Promise<number | null>;
+
+export interface BufferbloatStoreOptions {
+  readonly fetcher?: typeof fetch;
+  readonly measureLatency?: MeasureLatency;
+  readonly saturationBytes?: number;
+  readonly loadedSampleTarget?: number;
+  readonly sampleDelayMs?: number;
+  readonly now?: () => number;
+}
+
+export interface BufferbloatStore {
+  subscribe: ReturnType<typeof writable<BufferbloatState>>['subscribe'];
+  run(request: BufferbloatRunRequest): Promise<BufferbloatGradeResult | null>;
+  stop(): void;
+  reset(): void;
+}
+
+const DEFAULT_SATURATION_BYTES = 26_214_400;
+const DEFAULT_LOADED_SAMPLE_TARGET = 6;
+const DEFAULT_SAMPLE_DELAY_MS = 120;
+
+const initialGrade = gradeBufferbloat({ idleMedianMs: null, loadedMedianMs: null });
+
+const initialState: BufferbloatState = {
+  status: 'idle',
+  idleMedianMs: null,
+  loadedMedianMs: null,
+  grade: initialGrade,
+  error: null,
+};
+
+function messageFrom(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError';
+}
+
+function idleMedian(samples: readonly MeasurementSample[]): number | null {
+  return median(
+    samples
+      .filter((sample) => sample.status === 'ok' && Number.isFinite(sample.latency))
+      .map((sample) => sample.latency),
+  );
+}
+
+function wait(ms: number, signal: AbortSignal): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  if (signal.aborted) return Promise.reject(new DOMException('Aborted', 'AbortError'));
+  return new Promise((resolve, reject) => {
+    const timeoutId = window.setTimeout(resolve, ms);
+    signal.addEventListener('abort', () => {
+      window.clearTimeout(timeoutId);
+      reject(new DOMException('Aborted', 'AbortError'));
+    }, { once: true });
+  });
+}
+
+async function consumeResponse(response: Response): Promise<void> {
+  if (!response.body) {
+    await response.arrayBuffer();
+    return;
+  }
+
+  const reader = response.body.getReader();
+  try {
+    for (;;) {
+      const chunk = await reader.read();
+      if (chunk.done) return;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+export async function measureBrowserLatency(
+  url: string,
+  options: MeasureLatencyOptions,
+): Promise<number | null> {
+  const controller = new AbortController();
+  const abort = (): void => controller.abort();
+  options.signal.addEventListener('abort', abort, { once: true });
+  const timeoutId = window.setTimeout(() => controller.abort(), options.timeout);
+  const start = performance.now();
+
+  try {
+    await options.fetcher(url, {
+      method: 'GET',
+      mode: options.corsMode,
+      cache: 'no-store',
+      signal: controller.signal,
+    });
+    return performance.now() - start;
+  } catch (error) {
+    if (isAbortError(error)) return null;
+    return null;
+  } finally {
+    window.clearTimeout(timeoutId);
+    options.signal.removeEventListener('abort', abort);
+  }
+}
+
+export function createBufferbloatStore(options: BufferbloatStoreOptions = {}): BufferbloatStore {
+  const { subscribe, set, update } = writable<BufferbloatState>(initialState);
+  const fetcher = options.fetcher ?? fetch;
+  const measureLatency = options.measureLatency ?? measureBrowserLatency;
+  const saturationBytes = options.saturationBytes ?? DEFAULT_SATURATION_BYTES;
+  const loadedSampleTarget = options.loadedSampleTarget ?? DEFAULT_LOADED_SAMPLE_TARGET;
+  const sampleDelayMs = options.sampleDelayMs ?? DEFAULT_SAMPLE_DELAY_MS;
+
+  let activeAbortController: AbortController | null = null;
+  let runSerial = 0;
+
+  async function run(request: BufferbloatRunRequest): Promise<BufferbloatGradeResult | null> {
+    activeAbortController?.abort();
+    const controller = new AbortController();
+    activeAbortController = controller;
+    const serial = runSerial + 1;
+    runSerial = serial;
+
+    const idleMedianMs = idleMedian(request.idleSamples);
+    const startingGrade = gradeBufferbloat({ idleMedianMs, loadedMedianMs: null });
+    update((state) => ({
+      ...state,
+      status: 'running',
+      idleMedianMs,
+      loadedMedianMs: null,
+      grade: startingGrade,
+      error: null,
+    }));
+
+    if (idleMedianMs === null) {
+      update((state) => ({
+        ...state,
+        status: 'error',
+        error: 'Run the browser test long enough to collect idle latency samples first.',
+      }));
+      activeAbortController = null;
+      return null;
+    }
+
+    const saturation = fetcher(`/api/vantage/saturation?bytes=${saturationBytes}`, {
+      method: 'GET',
+      cache: 'no-store',
+      signal: controller.signal,
+    })
+      .then(consumeResponse)
+      .then(() => null, (error: unknown) => error);
+
+    try {
+      const loadedLatencies: number[] = [];
+      for (let index = 0; index < loadedSampleTarget; index++) {
+        if (controller.signal.aborted) throw new DOMException('Aborted', 'AbortError');
+        const latency = await measureLatency(request.endpoint.url, {
+          corsMode: request.settings.corsMode,
+          timeout: request.settings.timeout,
+          signal: controller.signal,
+          fetcher,
+        });
+        if (latency !== null && Number.isFinite(latency)) {
+          loadedLatencies.push(latency);
+        }
+        if (index < loadedSampleTarget - 1) {
+          await wait(sampleDelayMs, controller.signal);
+        }
+      }
+
+      const saturationError = await saturation;
+      if (saturationError !== null) throw saturationError;
+
+      if (serial !== runSerial) return null;
+      const loadedMedianMs = median(loadedLatencies);
+      const grade = gradeBufferbloat({ idleMedianMs, loadedMedianMs });
+      update((state) => ({
+        ...state,
+        status: 'complete',
+        loadedMedianMs,
+        grade,
+        error: null,
+      }));
+      return grade;
+    } catch (error) {
+      if (serial !== runSerial) return null;
+      const wasAborted = isAbortError(error) || controller.signal.aborted;
+      controller.abort();
+      await saturation;
+      if (wasAborted) {
+        update((state) => ({ ...state, status: 'stopped', error: null }));
+        return null;
+      }
+      update((state) => ({ ...state, status: 'error', error: messageFrom(error) }));
+      return null;
+    } finally {
+      if (activeAbortController === controller) activeAbortController = null;
+    }
+  }
+
+  function stop(): void {
+    activeAbortController?.abort();
+  }
+
+  function reset(): void {
+    activeAbortController?.abort();
+    activeAbortController = null;
+    runSerial += 1;
+    set(initialState);
+  }
+
+  return {
+    subscribe,
+    run,
+    stop,
+    reset,
+  };
+}
+
+export const bufferbloatStore = createBufferbloatStore();

--- a/tests/unit/bufferbloat/bufferbloat-test.test.ts
+++ b/tests/unit/bufferbloat/bufferbloat-test.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { gradeBufferbloat } from '../../../src/lib/bufferbloat/bufferbloat-test';
+
+describe('gradeBufferbloat', () => {
+  it('returns insufficient data until both idle and loaded medians exist', () => {
+    expect(gradeBufferbloat({ idleMedianMs: 30, loadedMedianMs: null })).toMatchObject({
+      grade: 'insufficient-data',
+      deltaMs: null,
+      summary: 'Run idle and loaded checks before grading loaded latency.',
+    });
+  });
+
+  it('grades low latency increase as clean', () => {
+    expect(gradeBufferbloat({ idleMedianMs: 30, loadedMedianMs: 42 })).toMatchObject({
+      grade: 'clean',
+      deltaMs: 12,
+      summary: 'Latency rose by 12 ms during download load.',
+    });
+  });
+
+  it('grades moderate latency increase as watch evidence', () => {
+    expect(gradeBufferbloat({ idleMedianMs: 30, loadedMedianMs: 85 })).toMatchObject({
+      grade: 'watch',
+      deltaMs: 55,
+      summary: 'Latency rose by 55 ms during download load.',
+    });
+  });
+
+  it('grades high latency increase as loaded-latency evidence', () => {
+    expect(gradeBufferbloat({ idleMedianMs: 30, loadedMedianMs: 180 })).toMatchObject({
+      grade: 'loaded-latency-high',
+      deltaMs: 150,
+      summary: 'Latency rose by 150 ms during download load.',
+    });
+  });
+
+  it('does not report a negative rise when loaded latency is lower', () => {
+    expect(gradeBufferbloat({ idleMedianMs: 30, loadedMedianMs: 24 })).toMatchObject({
+      grade: 'clean',
+      deltaMs: 0,
+      summary: 'Latency rose by 0 ms during download load.',
+    });
+  });
+});

--- a/tests/unit/components/diagnose-view.test.ts
+++ b/tests/unit/components/diagnose-view.test.ts
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, waitFor } from '@testing-library/svelte';
 import { get } from 'svelte/store';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import DiagnoseView from '../../../src/lib/components/DiagnoseView.svelte';
+import { bufferbloatStore } from '../../../src/lib/stores/bufferbloat';
 import { endpointStore } from '../../../src/lib/stores/endpoints';
 import { measurementStore } from '../../../src/lib/stores/measurements';
 import { remoteVantageStore } from '../../../src/lib/stores/remote-vantage';
@@ -107,6 +108,7 @@ describe('DiagnoseView investigation focus', () => {
     endpointStore.setEndpoints([]);
     measurementStore.reset();
     resetStatisticsCache();
+    bufferbloatStore.reset();
     remoteVantageStore.reset();
     settingsStore.reset();
     uiStore.reset();
@@ -197,6 +199,31 @@ describe('DiagnoseView investigation focus', () => {
 
     await waitFor(() => {
       expect(runProbe).toHaveBeenCalledWith([api]);
+    });
+  });
+
+  it('runs a loaded latency check from Investigate with proof-scoped copy', async () => {
+    const api = endpoint('api', 'API');
+    endpointStore.setEndpoints([api]);
+    seedReadySamples({ api: 35 });
+    uiStore.setActiveView('diagnose');
+    uiStore.setFocusedEndpoint('api');
+    const runLoadedLatency = vi.spyOn(bufferbloatStore, 'run').mockResolvedValue(null);
+
+    const { getByRole, getByText } = render(DiagnoseView);
+
+    expect(getByText(/loaded-latency evidence, not packet-level proof/i)).toBeTruthy();
+    await fireEvent.click(getByRole('button', { name: /run loaded check/i }));
+
+    await waitFor(() => {
+      expect(runLoadedLatency).toHaveBeenCalledWith({
+        endpoint: api,
+        idleSamples: expect.arrayContaining([expect.objectContaining({ latency: 35 })]),
+        settings: expect.objectContaining({
+          corsMode: 'no-cors',
+          timeout: 5000,
+        }),
+      });
     });
   });
 });

--- a/tests/unit/stores/bufferbloat.test.ts
+++ b/tests/unit/stores/bufferbloat.test.ts
@@ -1,0 +1,102 @@
+import { get } from 'svelte/store';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createBufferbloatStore } from '../../../src/lib/stores/bufferbloat';
+import type { Endpoint, MeasurementSample, Settings } from '../../../src/lib/types';
+
+const endpoint: Endpoint = {
+  id: 'api',
+  label: 'API',
+  url: 'https://api.example.test',
+  enabled: true,
+  color: '#67e8f9',
+};
+
+const settings: Pick<Settings, 'corsMode' | 'timeout'> = {
+  corsMode: 'no-cors',
+  timeout: 5000,
+};
+
+function ok(round: number, latency: number): MeasurementSample {
+  return {
+    round,
+    latency,
+    status: 'ok',
+    timestamp: round,
+  };
+}
+
+describe('bufferbloatStore', () => {
+  it('downloads saturation bytes and grades loaded latency against idle samples', async () => {
+    const fetcher = vi.fn(() => Promise.resolve(new Response(new Uint8Array([1, 2, 3, 4]))));
+    const measureLatency = vi.fn()
+      .mockResolvedValueOnce(120)
+      .mockResolvedValueOnce(140)
+      .mockResolvedValueOnce(160);
+    const store = createBufferbloatStore({
+      fetcher,
+      measureLatency,
+      saturationBytes: 1024,
+      loadedSampleTarget: 3,
+    });
+
+    await store.run({
+      endpoint,
+      idleSamples: [ok(1, 20), ok(2, 30), ok(3, 40)],
+      settings,
+    });
+
+    expect(fetcher).toHaveBeenCalledWith('/api/vantage/saturation?bytes=1024', expect.objectContaining({
+      method: 'GET',
+      cache: 'no-store',
+    }));
+    expect(measureLatency).toHaveBeenCalledTimes(3);
+    expect(measureLatency).toHaveBeenCalledWith(endpoint.url, expect.objectContaining({
+      corsMode: 'no-cors',
+      timeout: 5000,
+    }));
+    expect(get(store)).toMatchObject({
+      status: 'complete',
+      idleMedianMs: 30,
+      loadedMedianMs: 140,
+      grade: {
+        grade: 'loaded-latency-high',
+        deltaMs: 110,
+      },
+      error: null,
+    });
+  });
+
+  it('aborts an in-flight saturation download without leaving an error state', async () => {
+    let capturedSignal: AbortSignal | null = null;
+    const fetcher = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      capturedSignal = init?.signal ?? null;
+      return new Promise<Response>((_resolve, reject) => {
+        capturedSignal?.addEventListener('abort', () => {
+          reject(new DOMException('Aborted', 'AbortError'));
+        });
+      });
+    });
+    const store = createBufferbloatStore({
+      fetcher,
+      measureLatency: vi.fn(() => Promise.resolve(50)),
+      loadedSampleTarget: 1,
+    });
+
+    const run = store.run({
+      endpoint,
+      idleSamples: [ok(1, 30), ok(2, 40), ok(3, 50)],
+      settings,
+    });
+
+    await vi.waitFor(() => expect(fetcher).toHaveBeenCalled());
+    store.stop();
+    await run;
+
+    expect(capturedSignal?.aborted).toBe(true);
+    expect(get(store)).toMatchObject({
+      status: 'stopped',
+      error: null,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a pure loaded-latency grader that compares idle and under-download medians without claiming packet-level proof
- add an abortable browser store that downloads the bounded saturation endpoint while timing the focused endpoint
- surface the check in Investigate with compact proof-scoped copy and status metrics

## Validation
- npm test -- tests/unit/bufferbloat/bufferbloat-test.test.ts tests/unit/stores/bufferbloat.test.ts tests/unit/components/diagnose-view.test.ts
- npm run typecheck && npm run lint && npm run build && npm test
- Playwright rendered smoke on local Vite desktop 1440x900 and mobile 393x852 with no console warnings/errors