### PR TITLE
[codex] Add outside resolver DNS evidence

### DIFF
--- a/functions/_shared/remote-vantage.ts
+++ b/functions/_shared/remote-vantage.ts
@@ -36,17 +36,30 @@ export interface SaturationOptions {
   readonly bucket?: SaturationBucket;
 }
 
+export type DohDnsRecordType = 'A' | 'AAAA';
+
+export interface DohDnsOptions {
+  readonly fetcher?: typeof fetch;
+  readonly now?: () => number;
+  readonly performanceNow?: () => number;
+}
+
 const MAX_TARGETS = 8;
 const MAX_REPORT_BYTES = 120_000;
 const REPORT_TTL_SECONDS = 60 * 60 * 24 * 30;
 const REPORT_ID_PATTERN = /^[a-zA-Z0-9_-]{8,80}$/;
 const PROBE_TIMEOUT_MS = 4500;
+const DOH_TIMEOUT_MS = 3000;
 const SLOW_REMOTE_MS = 500;
 const DEFAULT_SATURATION_BYTES = 25 * 1024 * 1024;
 const MAX_SATURATION_BYTES = 100 * 1024 * 1024;
 const CHUNK_BYTES = 64 * 1024;
 const PUBLIC_PORTS = new Set(['', '80', '443']);
 const EXPOSED_HEADERS = ['content-type', 'server', 'cache-control', 'cf-cache-status'];
+const DNS_TYPE_NUMBERS: Record<DohDnsRecordType, number> = {
+  A: 1,
+  AAAA: 28,
+};
 
 function json(status: number, payload: unknown, extraHeaders: HeadersInit = {}): Response {
   return new Response(status === 204 ? null : JSON.stringify(payload), {
@@ -176,6 +189,39 @@ function parseTargets(payload: unknown): RemoteVantageTarget[] {
   });
 }
 
+function parseDnsHostname(raw: unknown): string {
+  if (typeof raw !== 'string' || raw.length > 253) {
+    throw new Error('DNS lookup requires a public hostname.');
+  }
+
+  const trimmed = raw.trim().replace(/\.$/, '').toLowerCase();
+  if (
+    trimmed.length === 0 ||
+    trimmed.includes('/') ||
+    trimmed.includes('@') ||
+    trimmed.includes(':') ||
+    parseIPv4(trimmed) !== null ||
+    isBlockedHostname(trimmed)
+  ) {
+    throw new Error('DNS lookup requires a public hostname.');
+  }
+
+  const labels = trimmed.split('.');
+  const validLabels = labels.length >= 2 && labels.every((label) => (
+    label.length >= 1 &&
+    label.length <= 63 &&
+    /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label)
+  ));
+  if (!validLabels) throw new Error('DNS lookup requires a public hostname.');
+  return trimmed;
+}
+
+function parseDnsRecordType(raw: string | null): DohDnsRecordType {
+  const normalized = (raw ?? 'A').toUpperCase();
+  if (normalized === 'A' || normalized === 'AAAA') return normalized;
+  throw new Error('DNS lookup supports A and AAAA records.');
+}
+
 function edgeFrom(cf?: Partial<RemoteVantageEdge> | null): RemoteVantageEdge {
   return {
     ...(cf?.colo ? { colo: String(cf.colo) } : {}),
@@ -280,6 +326,98 @@ export async function handleRemoteProbe(request: Request, options: RemoteProbeOp
       error: error instanceof Error ? error.message : String(error),
     });
   }
+}
+
+function parseDohRecords(payload: unknown, recordType: DohDnsRecordType): string[] {
+  if (!isRecord(payload) || !Array.isArray(payload.Answer)) return [];
+  const typeNumber = DNS_TYPE_NUMBERS[recordType];
+  return payload.Answer
+    .filter((answer): answer is Record<string, unknown> => isRecord(answer))
+    .filter((answer) => answer.type === typeNumber && typeof answer.data === 'string')
+    .map((answer) => String(answer.data).slice(0, 255))
+    .slice(0, 16);
+}
+
+async function runDohLookup(input: {
+  readonly hostname: string;
+  readonly recordType: DohDnsRecordType;
+  readonly fetcher: typeof fetch;
+  readonly now: () => number;
+  readonly performanceNow: () => number;
+}): Promise<Response> {
+  const endpoint = new URL('https://cloudflare-dns.com/dns-query');
+  endpoint.searchParams.set('name', input.hostname);
+  endpoint.searchParams.set('type', input.recordType);
+
+  const startedAt = input.performanceNow();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DOH_TIMEOUT_MS);
+
+  try {
+    const response = await input.fetcher(endpoint.toString(), {
+      method: 'GET',
+      signal: controller.signal,
+      headers: {
+        Accept: 'application/dns-json',
+      },
+      cf: {
+        cacheTtl: 0,
+        cacheEverything: false,
+      },
+    } as RequestInit & { cf: Record<string, unknown> });
+    const payload = await response.json() as unknown;
+    const durationMs = Math.max(0, Math.round(input.performanceNow() - startedAt));
+
+    if (!response.ok) {
+      return json(502, {
+        ok: false,
+        error: `Cloudflare DNS-over-HTTPS returned HTTP ${response.status}.`,
+      });
+    }
+
+    return json(200, {
+      ok: true,
+      resolver: 'cloudflare-doh',
+      hostname: input.hostname,
+      recordType: input.recordType,
+      records: parseDohRecords(payload, input.recordType),
+      durationMs,
+      checkedAt: input.now(),
+    });
+  } catch {
+    return json(502, {
+      ok: false,
+      error: 'Cloudflare DNS-over-HTTPS lookup did not complete.',
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function handleDohDnsRequest(request: Request, options: DohDnsOptions = {}): Response | Promise<Response> {
+  if (request.method === 'OPTIONS') return json(204, {});
+  if (request.method !== 'GET') return json(405, { ok: false, error: 'Method not allowed.' });
+
+  let hostname: string;
+  let recordType: DohDnsRecordType;
+  try {
+    const url = new URL(request.url);
+    hostname = parseDnsHostname(url.searchParams.get('hostname'));
+    recordType = parseDnsRecordType(url.searchParams.get('type'));
+  } catch {
+    return json(400, {
+      ok: false,
+      error: 'DNS lookup requires a public hostname and A or AAAA record type.',
+    });
+  }
+
+  return runDohLookup({
+    hostname,
+    recordType,
+    fetcher: options.fetcher ?? globalThis.fetch.bind(globalThis),
+    now: options.now ?? Date.now,
+    performanceNow: options.performanceNow ?? performance.now.bind(performance),
+  });
 }
 
 function isSharePayloadLike(value: unknown): value is SharePayload {

--- a/functions/api/vantage/dns.ts
+++ b/functions/api/vantage/dns.ts
@@ -1,0 +1,11 @@
+import { handleDohDnsRequest } from '../../_shared/remote-vantage';
+
+type Env = Record<string, never>;
+
+export const onRequestGet: PagesFunction<Env> = (context) => {
+  return handleDohDnsRequest(context.request);
+};
+
+export const onRequestOptions: PagesFunction<Env> = (context) => {
+  return handleDohDnsRequest(context.request);
+};

--- a/src/lib/dns/doh-insight.ts
+++ b/src/lib/dns/doh-insight.ts
@@ -1,0 +1,33 @@
+export interface DohInsightInput {
+  readonly hostname: string;
+  readonly resolver: 'cloudflare-doh';
+  readonly records: readonly string[];
+  readonly durationMs: number;
+}
+
+export interface DohInsight {
+  readonly vantage: 'outside-resolver';
+  readonly headline: string;
+  readonly detail: string;
+}
+
+function plural(count: number, singular: string, pluralForm = `${singular}s`): string {
+  return count === 1 ? singular : pluralForm;
+}
+
+export function describeDohInsight(input: DohInsightInput): DohInsight {
+  const duration = Math.round(input.durationMs);
+  if (input.records.length === 0) {
+    return {
+      vantage: 'outside-resolver',
+      headline: `Cloudflare DNS-over-HTTPS found no records for ${input.hostname}`,
+      detail: `No DNS records were returned in ${duration} ms. This is outside resolver evidence, not your local DNS path.`,
+    };
+  }
+
+  return {
+    vantage: 'outside-resolver',
+    headline: `Cloudflare DNS-over-HTTPS resolved ${input.hostname}`,
+    detail: `${input.records.length} DNS ${plural(input.records.length, 'record')} returned in ${duration} ms. This is outside resolver evidence, not your local DNS path.`,
+  };
+}

--- a/tests/unit/dns/doh-insight.test.ts
+++ b/tests/unit/dns/doh-insight.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { describeDohInsight } from '../../../src/lib/dns/doh-insight';
+
+describe('describeDohInsight', () => {
+  it('labels DNS-over-HTTPS as outside resolver evidence', () => {
+    expect(describeDohInsight({
+      hostname: 'api.example.com',
+      resolver: 'cloudflare-doh',
+      records: ['203.0.113.10'],
+      durationMs: 35,
+    })).toMatchObject({
+      vantage: 'outside-resolver',
+      headline: 'Cloudflare DNS-over-HTTPS resolved api.example.com',
+      detail: '1 DNS record returned in 35 ms. This is outside resolver evidence, not your local DNS path.',
+    });
+  });
+
+  it('keeps empty answers evidence-scoped', () => {
+    const insight = describeDohInsight({
+      hostname: 'missing.example.com',
+      resolver: 'cloudflare-doh',
+      records: [],
+      durationMs: 22,
+    });
+
+    expect(insight).toMatchObject({
+      vantage: 'outside-resolver',
+      headline: 'Cloudflare DNS-over-HTTPS found no records for missing.example.com',
+    });
+    expect(insight.detail).toContain('outside resolver evidence');
+    expect(insight.detail).not.toMatch(/your DNS|local resolver failed|ISP/i);
+  });
+});

--- a/tests/unit/remote-vantage/functions.test.ts
+++ b/tests/unit/remote-vantage/functions.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   handleCreateHostedReport,
+  handleDohDnsRequest,
   handleGetHostedReport,
   handleRemoteProbe,
   handleSaturationRequest,
@@ -255,5 +256,88 @@ describe('Cloudflare remote vantage functions', () => {
 
     expect(response.headers.get('Content-Length')).toBe('1024');
     expect((await response.arrayBuffer()).byteLength).toBe(1024);
+  });
+
+  it('resolves public hostnames through bounded Cloudflare DNS-over-HTTPS evidence', async () => {
+    const fetcher = vi.fn(() => Promise.resolve(new Response(JSON.stringify({
+      Status: 0,
+      Answer: [
+        { type: 1, data: '203.0.113.10' },
+        { type: 28, data: '2001:db8::10' },
+      ],
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/dns-json' },
+    })));
+    const response = await handleDohDnsRequest(
+      new Request('https://chronoscope.dev/api/vantage/dns?hostname=api.example.com'),
+      {
+        fetcher,
+        now: () => 1778352000000,
+        performanceNow: vi.fn()
+          .mockReturnValueOnce(100)
+          .mockReturnValueOnce(137),
+      },
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(fetcher).toHaveBeenCalledWith(
+      'https://cloudflare-dns.com/dns-query?name=api.example.com&type=A',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({ Accept: 'application/dns-json' }),
+      }),
+    );
+    expect(payload).toMatchObject({
+      ok: true,
+      resolver: 'cloudflare-doh',
+      hostname: 'api.example.com',
+      recordType: 'A',
+      records: ['203.0.113.10'],
+      durationMs: 37,
+      checkedAt: 1778352000000,
+    });
+  });
+
+  it('rejects private names and IP literals before DNS-over-HTTPS fetch', async () => {
+    const fetcher = vi.fn();
+
+    const local = await handleDohDnsRequest(
+      new Request('https://chronoscope.dev/api/vantage/dns?hostname=router.local'),
+      { fetcher },
+    );
+    const ipLiteral = await handleDohDnsRequest(
+      new Request('https://chronoscope.dev/api/vantage/dns?hostname=1.1.1.1'),
+      { fetcher },
+    );
+
+    expect(local.status).toBe(400);
+    expect(ipLiteral.status).toBe(400);
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it('does not expose raw resolver exception details in DNS responses', async () => {
+    const response = await handleDohDnsRequest(
+      new Request('https://chronoscope.dev/api/vantage/dns?hostname=api.example.com'),
+      {
+        fetcher: vi.fn(() => Promise.reject(new Error('stack detail with internal path'))),
+      },
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(payload.error).toBe('Cloudflare DNS-over-HTTPS lookup did not complete.');
+    expect(payload.error).not.toContain('internal path');
+  });
+
+  it('answers DNS CORS preflight requests', async () => {
+    const response = await handleDohDnsRequest(
+      new Request('https://chronoscope.dev/api/vantage/dns', { method: 'OPTIONS' }),
+      {},
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
   });
 });


### PR DESCRIPTION
## Summary
- add a DNS-over-HTTPS insight helper that labels Cloudflare results as outside resolver evidence
- add `/api/vantage/dns` for bounded Cloudflare DoH lookups of public hostnames
- reject private names and IP literals before any resolver fetch

## Validation
- npm test -- tests/unit/dns/doh-insight.test.ts tests/unit/remote-vantage/functions.test.ts
- npm run typecheck:functions
- npm run typecheck && npm run lint && npm run build && npm test