### PR TITLE
[codex] Add public topology context

### DIFF
--- a/functions/_shared/remote-vantage.ts
+++ b/functions/_shared/remote-vantage.ts
@@ -44,12 +44,19 @@ export interface DohDnsOptions {
   readonly performanceNow?: () => number;
 }
 
+export interface TopologyOptions {
+  readonly fetcher?: typeof fetch;
+  readonly now?: () => number;
+  readonly performanceNow?: () => number;
+}
+
 const MAX_TARGETS = 8;
 const MAX_REPORT_BYTES = 120_000;
 const REPORT_TTL_SECONDS = 60 * 60 * 24 * 30;
 const REPORT_ID_PATTERN = /^[a-zA-Z0-9_-]{8,80}$/;
 const PROBE_TIMEOUT_MS = 4500;
 const DOH_TIMEOUT_MS = 3000;
+const TOPOLOGY_TIMEOUT_MS = 5500;
 const SLOW_REMOTE_MS = 500;
 const DEFAULT_SATURATION_BYTES = 25 * 1024 * 1024;
 const MAX_SATURATION_BYTES = 100 * 1024 * 1024;
@@ -414,6 +421,138 @@ export function handleDohDnsRequest(request: Request, options: DohDnsOptions = {
   return runDohLookup({
     hostname,
     recordType,
+    fetcher: options.fetcher ?? globalThis.fetch.bind(globalThis),
+    now: options.now ?? Date.now,
+    performanceNow: options.performanceNow ?? performance.now.bind(performance),
+  });
+}
+
+function firstPublicARecord(payload: unknown): string | null {
+  const records = parseDohRecords(payload, 'A');
+  for (const record of records) {
+    if (parseIPv4(record) !== null && !isBlockedIPv4(record)) return record;
+  }
+  return null;
+}
+
+function parseAsn(value: unknown): number | null {
+  const raw = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+  return Number.isInteger(raw) && raw > 0 && raw <= 4_294_967_295 ? raw : null;
+}
+
+function parseNetworkInfo(payload: unknown): { readonly asn: number | null; readonly prefix: string | null } {
+  const data = isRecord(payload) && isRecord(payload.data) ? payload.data : {};
+  const rawAsns = Array.isArray(data.asns) ? data.asns : [];
+  const asn = rawAsns.map(parseAsn).find((candidate) => candidate !== null) ?? null;
+  const prefix = typeof data.prefix === 'string' ? data.prefix.slice(0, 80) : null;
+  return { asn, prefix };
+}
+
+function parseAsOverviewHolder(payload: unknown): string | null {
+  const data = isRecord(payload) && isRecord(payload.data) ? payload.data : {};
+  return typeof data.holder === 'string' ? data.holder.slice(0, 160) : null;
+}
+
+async function fetchJson(input: {
+  readonly url: string;
+  readonly fetcher: typeof fetch;
+  readonly signal: AbortSignal;
+}): Promise<unknown> {
+  const response = await input.fetcher(input.url, {
+    method: 'GET',
+    signal: input.signal,
+    headers: { Accept: 'application/json' },
+    cf: {
+      cacheTtl: 0,
+      cacheEverything: false,
+    },
+  } as RequestInit & { cf: Record<string, unknown> });
+  if (!response.ok) throw new Error(`Topology source returned HTTP ${response.status}.`);
+  return response.json() as Promise<unknown>;
+}
+
+async function runTopologyLookup(input: {
+  readonly hostname: string;
+  readonly fetcher: typeof fetch;
+  readonly now: () => number;
+  readonly performanceNow: () => number;
+}): Promise<Response> {
+  const startedAt = input.performanceNow();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TOPOLOGY_TIMEOUT_MS);
+
+  try {
+    const dnsEndpoint = new URL('https://cloudflare-dns.com/dns-query');
+    dnsEndpoint.searchParams.set('name', input.hostname);
+    dnsEndpoint.searchParams.set('type', 'A');
+    const dnsPayload = await fetchJson({
+      url: dnsEndpoint.toString(),
+      fetcher: input.fetcher,
+      signal: controller.signal,
+    });
+    const ip = firstPublicARecord(dnsPayload);
+    if (ip === null) {
+      return json(400, {
+        ok: false,
+        error: 'No public DNS A record was available for topology context.',
+      });
+    }
+
+    const networkInfoUrl = `https://stat.ripe.net/data/network-info/data.json?resource=${encodeURIComponent(ip)}`;
+    const networkInfo = parseNetworkInfo(await fetchJson({
+      url: networkInfoUrl,
+      fetcher: input.fetcher,
+      signal: controller.signal,
+    }));
+
+    let organization: string | null = null;
+    if (networkInfo.asn !== null) {
+      const asOverviewUrl = `https://stat.ripe.net/data/as-overview/data.json?resource=AS${networkInfo.asn}`;
+      organization = parseAsOverviewHolder(await fetchJson({
+        url: asOverviewUrl,
+        fetcher: input.fetcher,
+        signal: controller.signal,
+      }));
+    }
+
+    return json(200, {
+      ok: true,
+      vantage: 'public-topology',
+      hostname: input.hostname,
+      ip,
+      prefix: networkInfo.prefix,
+      asn: networkInfo.asn,
+      organization,
+      durationMs: Math.max(0, Math.round(input.performanceNow() - startedAt)),
+      checkedAt: input.now(),
+    });
+  } catch {
+    return json(502, {
+      ok: false,
+      error: 'Topology context lookup did not complete.',
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function handleTopologyRequest(request: Request, options: TopologyOptions = {}): Response | Promise<Response> {
+  if (request.method === 'OPTIONS') return json(204, {});
+  if (request.method !== 'GET') return json(405, { ok: false, error: 'Method not allowed.' });
+
+  let hostname: string;
+  try {
+    const url = new URL(request.url);
+    hostname = parseDnsHostname(url.searchParams.get('hostname'));
+  } catch {
+    return json(400, {
+      ok: false,
+      error: 'Topology context requires a public hostname.',
+    });
+  }
+
+  return runTopologyLookup({
+    hostname,
     fetcher: options.fetcher ?? globalThis.fetch.bind(globalThis),
     now: options.now ?? Date.now,
     performanceNow: options.performanceNow ?? performance.now.bind(performance),

--- a/functions/api/vantage/topology.ts
+++ b/functions/api/vantage/topology.ts
@@ -1,0 +1,11 @@
+import { handleTopologyRequest } from '../../_shared/remote-vantage';
+
+type Env = Record<string, never>;
+
+export const onRequestGet: PagesFunction<Env> = (context) => {
+  return handleTopologyRequest(context.request);
+};
+
+export const onRequestOptions: PagesFunction<Env> = (context) => {
+  return handleTopologyRequest(context.request);
+};

--- a/src/lib/topology/asn-context.ts
+++ b/src/lib/topology/asn-context.ts
@@ -1,0 +1,14 @@
+export interface TopologyContextInput {
+  readonly hostname: string;
+  readonly asn: number | null;
+  readonly organization: string | null;
+}
+
+export function describeTopologyContext(input: TopologyContextInput): string {
+  if (input.asn === null) {
+    return `No ASN context was found for ${input.hostname}. This does not prove reachability or route health.`;
+  }
+
+  const organization = input.organization ? ` (${input.organization})` : '';
+  return `${input.hostname} maps to AS${input.asn}${organization}. This is topology context, not active path proof.`;
+}

--- a/tests/unit/remote-vantage/functions.test.ts
+++ b/tests/unit/remote-vantage/functions.test.ts
@@ -7,6 +7,7 @@ import {
   handleGetHostedReport,
   handleRemoteProbe,
   handleSaturationRequest,
+  handleTopologyRequest,
 } from '../../../functions/_shared/remote-vantage';
 import type { SharePayload } from '../../../src/lib/types';
 
@@ -334,6 +335,85 @@ describe('Cloudflare remote vantage functions', () => {
   it('answers DNS CORS preflight requests', async () => {
     const response = await handleDohDnsRequest(
       new Request('https://chronoscope.dev/api/vantage/dns', { method: 'OPTIONS' }),
+      {},
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+  });
+
+  it('returns ASN topology context for a public hostname and public resolved IP', async () => {
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        Answer: [{ type: 1, data: '104.20.23.154' }],
+      }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        data: { asns: ['13335'], prefix: '104.20.16.0/20' },
+      }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        data: { holder: 'CLOUDFLARENET - Cloudflare, Inc.' },
+      }), { status: 200 }));
+
+    const response = await handleTopologyRequest(
+      new Request('https://chronoscope.dev/api/vantage/topology?hostname=example.com'),
+      {
+        fetcher,
+        now: () => 1778352000000,
+        performanceNow: vi.fn()
+          .mockReturnValueOnce(100)
+          .mockReturnValueOnce(128),
+      },
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(fetcher).toHaveBeenNthCalledWith(
+      1,
+      'https://cloudflare-dns.com/dns-query?name=example.com&type=A',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(fetcher).toHaveBeenNthCalledWith(
+      2,
+      'https://stat.ripe.net/data/network-info/data.json?resource=104.20.23.154',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(fetcher).toHaveBeenNthCalledWith(
+      3,
+      'https://stat.ripe.net/data/as-overview/data.json?resource=AS13335',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(payload).toMatchObject({
+      ok: true,
+      vantage: 'public-topology',
+      hostname: 'example.com',
+      ip: '104.20.23.154',
+      prefix: '104.20.16.0/20',
+      asn: 13335,
+      organization: 'CLOUDFLARENET - Cloudflare, Inc.',
+      durationMs: 28,
+      checkedAt: 1778352000000,
+    });
+  });
+
+  it('rejects topology lookups when DNS only returns private IPs', async () => {
+    const fetcher = vi.fn(() => Promise.resolve(new Response(JSON.stringify({
+      Answer: [{ type: 1, data: '10.0.0.10' }],
+    }), { status: 200 })));
+
+    const response = await handleTopologyRequest(
+      new Request('https://chronoscope.dev/api/vantage/topology?hostname=example.com'),
+      { fetcher },
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe('No public DNS A record was available for topology context.');
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('answers topology CORS preflight requests', async () => {
+    const response = await handleTopologyRequest(
+      new Request('https://chronoscope.dev/api/vantage/topology', { method: 'OPTIONS' }),
       {},
     );
 

--- a/tests/unit/topology/asn-context.test.ts
+++ b/tests/unit/topology/asn-context.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { describeTopologyContext } from '../../../src/lib/topology/asn-context';
+
+describe('describeTopologyContext', () => {
+  it('labels ASN data as topology context, not active path proof', () => {
+    const text = describeTopologyContext({
+      hostname: 'api.example.com',
+      asn: 64500,
+      organization: 'Example Network',
+    });
+
+    expect(text).toBe('api.example.com maps to AS64500 (Example Network). This is topology context, not active path proof.');
+    expect(text).toContain('topology context');
+    expect(text).not.toMatch(/route is healthy|reachable from you|local path/i);
+  });
+
+  it('keeps missing ASN context from sounding diagnostic', () => {
+    expect(describeTopologyContext({
+      hostname: 'missing.example.com',
+      asn: null,
+      organization: null,
+    })).toBe('No ASN context was found for missing.example.com. This does not prove reachability or route health.');
+  });
+});


### PR DESCRIPTION
## Summary
- add ASN topology copy that explicitly avoids active-path claims
- add `/api/vantage/topology` for public-hostname topology context using Cloudflare DoH plus RIPEstat network/as overview data
- reject private hostnames and private resolved IPs before returning topology context

## Validation
- npm test -- tests/unit/topology/asn-context.test.ts tests/unit/remote-vantage/functions.test.ts
- npm run typecheck:functions
- npm run typecheck && npm run lint && npm run build && npm test