### PR TITLE
Fix topology DNS lookup headers

### DIFF
--- a/functions/_shared/remote-vantage.ts
+++ b/functions/_shared/remote-vantage.ts
@@ -376,7 +376,7 @@ async function runDohLookup(input: {
     const durationMs = Math.max(0, Math.round(input.performanceNow() - startedAt));
 
     if (!response.ok) {
-      return json(502, {
+      return json(424, {
         ok: false,
         error: `Cloudflare DNS-over-HTTPS returned HTTP ${response.status}.`,
       });
@@ -392,7 +392,7 @@ async function runDohLookup(input: {
       checkedAt: input.now(),
     });
   } catch {
-    return json(502, {
+    return json(424, {
       ok: false,
       error: 'Cloudflare DNS-over-HTTPS lookup did not complete.',
     });
@@ -457,11 +457,12 @@ async function fetchJson(input: {
   readonly url: string;
   readonly fetcher: typeof fetch;
   readonly signal: AbortSignal;
+  readonly accept?: string;
 }): Promise<unknown> {
   const response = await input.fetcher(input.url, {
     method: 'GET',
     signal: input.signal,
-    headers: { Accept: 'application/json' },
+    headers: { Accept: input.accept ?? 'application/json' },
     cf: {
       cacheTtl: 0,
       cacheEverything: false,
@@ -489,6 +490,7 @@ async function runTopologyLookup(input: {
       url: dnsEndpoint.toString(),
       fetcher: input.fetcher,
       signal: controller.signal,
+      accept: 'application/dns-json',
     });
     const ip = firstPublicARecord(dnsPayload);
     if (ip === null) {
@@ -527,7 +529,7 @@ async function runTopologyLookup(input: {
       checkedAt: input.now(),
     });
   } catch {
-    return json(502, {
+    return json(424, {
       ok: false,
       error: 'Topology context lookup did not complete.',
     });

--- a/tests/unit/remote-vantage/functions.test.ts
+++ b/tests/unit/remote-vantage/functions.test.ts
@@ -327,7 +327,7 @@ describe('Cloudflare remote vantage functions', () => {
     );
     const payload = await response.json();
 
-    expect(response.status).toBe(502);
+    expect(response.status).toBe(424);
     expect(payload.error).toBe('Cloudflare DNS-over-HTTPS lookup did not complete.');
     expect(payload.error).not.toContain('internal path');
   });
@@ -370,7 +370,10 @@ describe('Cloudflare remote vantage functions', () => {
     expect(fetcher).toHaveBeenNthCalledWith(
       1,
       'https://cloudflare-dns.com/dns-query?name=example.com&type=A',
-      expect.objectContaining({ method: 'GET' }),
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({ Accept: 'application/dns-json' }),
+      }),
     );
     expect(fetcher).toHaveBeenNthCalledWith(
       2,
@@ -409,6 +412,20 @@ describe('Cloudflare remote vantage functions', () => {
     expect(response.status).toBe(400);
     expect(payload.error).toBe('No public DNS A record was available for topology context.');
     expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns structured topology dependency failures without an edge 5xx status', async () => {
+    const response = await handleTopologyRequest(
+      new Request('https://chronoscope.dev/api/vantage/topology?hostname=example.com'),
+      {
+        fetcher: vi.fn(() => Promise.reject(new Error('raw topology source detail'))),
+      },
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(424);
+    expect(payload.error).toBe('Topology context lookup did not complete.');
+    expect(payload.error).not.toContain('raw topology source detail');
   });
 
   it('answers topology CORS preflight requests', async () => {


### PR DESCRIPTION
## Summary
- send the required `Accept: application/dns-json` header for topology DNS resolution
- return structured `424 Failed Dependency` JSON when diagnostic dependency lookups fail
- add regression coverage for topology DNS headers and sanitized dependency failures

## Test Plan
- `npm test -- tests/unit/remote-vantage/functions.test.ts`
- `npm run typecheck:functions`
- `npm run typecheck && npm run lint && npm run build && npm test`