### PR TITLE
Add collective intelligence consent contract

### DIFF
--- a/docs/vision/collective-edge-intelligence-privacy.md
+++ b/docs/vision/collective-edge-intelligence-privacy.md
@@ -1,0 +1,28 @@
+# Collective Edge Intelligence Privacy Contract
+
+Chronoscope may eventually show population-level internet health context from opted-in reports. This feature must stay useful without turning the product into hidden telemetry.
+
+## Consent Rules
+
+- No collection happens without explicit opt-in.
+- Users can create, view, and share reports without contributing aggregate data.
+- Named public endpoint contribution requires a separate visible consent choice.
+- Consent copy must describe the contribution as optional anonymous aggregate evidence.
+
+## Data That Must Not Be Sent
+
+- No full URLs, including paths, queries, fragments, or credentials.
+- No local or private hosts, including localhost, `.local`, RFC 1918, loopback, link-local, or unique-local IPv6 targets.
+- No WiFi SSID or BSSID values.
+- No companion/local-agent browser history or SQLite history.
+- No raw IP addresses in public summaries.
+
+## Allowed Aggregate Shape
+
+- Rounded timing buckets such as p50, p95, loss percentage, and sample count.
+- Coarse timestamp buckets when needed for trend summaries.
+- Public endpoint hostnames only when the user chooses named public endpoint consent.
+
+## Product Boundary
+
+Aggregate context is population-level context, not proof about the current user's path, local DNS resolver, WiFi, ISP, router, or device. The UI must say that plainly wherever aggregate context appears.

--- a/src/lib/intelligence/consent.ts
+++ b/src/lib/intelligence/consent.ts
@@ -1,0 +1,12 @@
+export interface IntelligenceConsentInput {
+  readonly optedIn: boolean;
+  readonly reportHasResults: boolean;
+}
+
+export function canContributeIntelligence(input: IntelligenceConsentInput): boolean {
+  return input.optedIn && input.reportHasResults;
+}
+
+export function contributionCopy(): string {
+  return 'This is optional: contribute anonymous aggregate timing evidence. Chronoscope will not send full URLs, WiFi identifiers, local history, or private network targets.';
+}

--- a/tests/unit/intelligence/consent.test.ts
+++ b/tests/unit/intelligence/consent.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { canContributeIntelligence, contributionCopy } from '../../../src/lib/intelligence/consent';
+
+describe('collective intelligence consent', () => {
+  it('blocks contribution when explicit opt-in is absent', () => {
+    expect(canContributeIntelligence({ optedIn: false, reportHasResults: true })).toBe(false);
+  });
+
+  it('blocks contribution when no measured results exist', () => {
+    expect(canContributeIntelligence({ optedIn: true, reportHasResults: false })).toBe(false);
+  });
+
+  it('allows contribution only when consent and measured results are present', () => {
+    expect(canContributeIntelligence({ optedIn: true, reportHasResults: true })).toBe(true);
+  });
+
+  it('uses explicit consent copy', () => {
+    expect(contributionCopy()).toContain('optional');
+    expect(contributionCopy()).toContain('anonymous aggregate');
+    expect(contributionCopy()).toContain('will not send full URLs');
+  });
+});


### PR DESCRIPTION
## Summary
- add the Phase 6 privacy contract for collective edge intelligence
- add a pure consent helper that blocks contribution without explicit opt-in and measured results
- lock the consent copy to optional anonymous aggregate wording and no private-field claims

## Privacy Review
- This PR adds no collection, ingest, storage, network call, or UI opt-in path.
- The required privacy scan is currently noisy from existing app surfaces: endpoint URLs, share payloads, local-only history, companion WiFi types, and remote-vantage URL parsing. No new egress path appears in this PR.

## Test Plan
- npm test -- tests/unit/intelligence/consent.test.ts
- npm run typecheck
- npm run lint
- rg -n "endpointUrl|url|ssid|bssid|history|localStorage|indexedDB" src functions tests docs/vision/collective-edge-intelligence-privacy.md
- npm run typecheck && npm run lint && npm run build && npm test
