### PR TITLE
Add privacy-safe intelligence payload builder

### DIFF
--- a/src/lib/intelligence/payload.ts
+++ b/src/lib/intelligence/payload.ts
@@ -1,0 +1,45 @@
+import { isSafeSharedUrl } from '../utils/url-safety';
+
+export type IntelligenceConsent = 'anonymous-aggregate' | 'named-public-endpoint';
+
+export interface IntelligencePayloadInput {
+  readonly endpointUrl: string;
+  readonly p50: number;
+  readonly p95: number;
+  readonly lossPercent: number;
+  readonly sampleCount: number;
+  readonly createdAt: number;
+  readonly consent: IntelligenceConsent;
+}
+
+export interface IntelligencePayload {
+  readonly v: 1;
+  readonly consent: IntelligenceConsent;
+  readonly originHost: string | null;
+  readonly publicOriginHash: string | null;
+  readonly p50: number;
+  readonly p95: number;
+  readonly lossPercent: number;
+  readonly sampleCount: number;
+  readonly createdAt: number;
+}
+
+function publicHostname(endpointUrl: string): string | null {
+  if (!isSafeSharedUrl(endpointUrl)) return null;
+  return new URL(endpointUrl).hostname.toLowerCase();
+}
+
+export function buildIntelligencePayload(input: IntelligencePayloadInput): IntelligencePayload {
+  const host = publicHostname(input.endpointUrl);
+  return {
+    v: 1,
+    consent: input.consent,
+    originHost: input.consent === 'named-public-endpoint' ? host : null,
+    publicOriginHash: null,
+    p50: Math.round(input.p50),
+    p95: Math.round(input.p95),
+    lossPercent: Number(input.lossPercent.toFixed(2)),
+    sampleCount: Math.round(input.sampleCount),
+    createdAt: input.createdAt,
+  };
+}

--- a/tests/unit/intelligence/payload.test.ts
+++ b/tests/unit/intelligence/payload.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { buildIntelligencePayload } from '../../../src/lib/intelligence/payload';
+
+describe('buildIntelligencePayload', () => {
+  it('strips path, query, fragment, and private fields for anonymous aggregate consent', () => {
+    const payload = buildIntelligencePayload({
+      endpointUrl: 'https://api.example.com/private/path?fixture=redacted#hash',
+      p50: 42,
+      p95: 80,
+      lossPercent: 0,
+      sampleCount: 35,
+      createdAt: 1778352000000,
+      consent: 'anonymous-aggregate',
+    });
+
+    expect(JSON.stringify(payload)).not.toContain('private');
+    expect(JSON.stringify(payload)).not.toContain('fixture=');
+    expect(JSON.stringify(payload)).not.toContain('https://');
+    expect(payload.originHost).toBeNull();
+    expect(payload.publicOriginHash).toBeNull();
+  });
+
+  it('includes named public endpoint only with named consent', () => {
+    const payload = buildIntelligencePayload({
+      endpointUrl: 'https://api.example.com/path',
+      p50: 42,
+      p95: 80,
+      lossPercent: 0,
+      sampleCount: 35,
+      createdAt: 1778352000000,
+      consent: 'named-public-endpoint',
+    });
+
+    expect(payload.originHost).toBe('api.example.com');
+    expect(JSON.stringify(payload)).not.toContain('/path');
+  });
+
+  it('does not include local or private hosts even with named consent', () => {
+    for (const endpointUrl of [
+      'http://localhost/status',
+      'http://192.168.1.1/admin',
+      'http://router.local/health',
+      'http://[::1]/probe',
+    ]) {
+      const payload = buildIntelligencePayload({
+        endpointUrl,
+        p50: 42,
+        p95: 80,
+        lossPercent: 0,
+        sampleCount: 35,
+        createdAt: 1778352000000,
+        consent: 'named-public-endpoint',
+      });
+
+      expect(payload.originHost).toBeNull();
+      expect(JSON.stringify(payload)).not.toContain(endpointUrl);
+    }
+  });
+
+  it('rounds timing and loss values to aggregate-safe precision', () => {
+    const payload = buildIntelligencePayload({
+      endpointUrl: 'https://api.example.com/path',
+      p50: 42.4,
+      p95: 80.6,
+      lossPercent: 1.234,
+      sampleCount: 35,
+      createdAt: 1778352000000,
+      consent: 'anonymous-aggregate',
+    });
+
+    expect(payload.p50).toBe(42);
+    expect(payload.p95).toBe(81);
+    expect(payload.lossPercent).toBe(1.23);
+  });
+});


### PR DESCRIPTION
## Summary
- add the local aggregate payload builder for Phase 6 intelligence
- keep anonymous aggregate payloads free of full URLs, paths, queries, fragments, and hostnames
- allow named public hostnames only with named endpoint consent, while still blocking local/private hosts

## Privacy Review
- New endpointUrl usage is local input only, immediately sanitized to a public hostname or null.
- Payload output does not contain full URLs, paths, queries, fragments, WiFi identifiers, local history, or private targets.
- Hash output intentionally remains null until salt rotation and lookup behavior are designed.

## Test Plan
- npm test -- tests/unit/intelligence/payload.test.ts
- npm run typecheck
- npm run lint
- rg -n "endpointUrl|url|ssid|bssid|history|localStorage|indexedDB" src/lib/intelligence tests/unit/intelligence docs/vision/collective-edge-intelligence-privacy.md
- npm run typecheck && npm run lint && npm run build && npm test
