### PR TITLE
Add intelligence ingest guardrails

### DIFF
--- a/functions/_shared/intelligence.ts
+++ b/functions/_shared/intelligence.ts
@@ -1,0 +1,233 @@
+export interface IntelligenceStore {
+  get(key: string): Promise<string | null>;
+  put(key: string, value: string): Promise<void>;
+}
+
+export interface IntelligenceIngestOptions {
+  readonly store?: IntelligenceStore;
+  readonly now?: () => number;
+}
+
+type IntelligenceConsent = 'anonymous-aggregate' | 'named-public-endpoint';
+
+interface ValidIntelligencePayload {
+  readonly v: 1;
+  readonly consent: IntelligenceConsent;
+  readonly originHost: string | null;
+  readonly publicOriginHash: null;
+  readonly p50: number;
+  readonly p95: number;
+  readonly lossPercent: number;
+  readonly sampleCount: number;
+  readonly createdAt: number;
+}
+
+interface IntelligenceAggregate {
+  readonly v: 1;
+  readonly bucket: string;
+  readonly consent: IntelligenceConsent;
+  readonly originHost: string | null;
+  readonly count: number;
+  readonly sampleCount: number;
+  readonly p50Sum: number;
+  readonly p95Sum: number;
+  readonly lossPercentSum: number;
+  readonly updatedAt: number;
+}
+
+const PRIVATE_FIELD_KEYS = new Set([
+  'url',
+  'endpointurl',
+  'wifi',
+  'ssid',
+  'bssid',
+  'history',
+  'localstorage',
+  'indexeddb',
+]);
+const MAX_SAMPLE_COUNT = 10_000;
+const MAX_LATENCY_MS = 600_000;
+
+function json(status: number, payload: unknown, extraHeaders: HeadersInit = {}): Response {
+  return new Response(status === 204 ? null : JSON.stringify(payload), {
+    status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'no-store',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'POST,OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+      ...extraHeaders,
+    },
+  });
+}
+
+function hasPrivateField(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false;
+  if (Array.isArray(value)) return value.some((item) => hasPrivateField(item));
+  for (const [key, nested] of Object.entries(value)) {
+    if (PRIVATE_FIELD_KEYS.has(key.toLowerCase())) return true;
+    if (hasPrivateField(nested)) return true;
+  }
+  return false;
+}
+
+function finiteNumber(value: unknown, min: number, max: number): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= min && value <= max;
+}
+
+function isPrivateHost(hostname: string): boolean {
+  const h = hostname.toLowerCase().replace(/\.$/, '');
+  if (h === 'localhost' || h === '0.0.0.0') return true;
+  if (h.endsWith('.localhost') || h.endsWith('.local') || h.endsWith('.internal')) return true;
+  if (/^127\./.test(h) || /^10\./.test(h) || /^192\.168\./.test(h)) return true;
+  if (/^172\.(1[6-9]|2[0-9]|3[01])\./.test(h)) return true;
+  if (/^169\.254\./.test(h) || /^0\./.test(h)) return true;
+  const stripped = h.startsWith('[') && h.endsWith(']') ? h.slice(1, -1) : h;
+  if (stripped === '::1' || stripped === '::' || stripped === '0:0:0:0:0:0:0:1') return true;
+  if (/^f[cd][0-9a-f]{2}:/.test(stripped)) return true;
+  return /^fe[89ab][0-9a-f]:/.test(stripped);
+}
+
+function isIpLiteral(hostname: string): boolean {
+  const h = hostname.toLowerCase().replace(/^\[/, '').replace(/\]$/, '');
+  return /^\d{1,3}(?:\.\d{1,3}){3}$/.test(h) || h.includes(':');
+}
+
+function isPublicNamedHost(value: unknown): value is string {
+  return typeof value === 'string'
+    && value.length > 0
+    && value.length <= 253
+    && !value.includes('/')
+    && !isPrivateHost(value)
+    && !isIpLiteral(value);
+}
+
+function parseAggregate(value: string | null, fallback: IntelligenceAggregate): IntelligenceAggregate {
+  if (value === null) return fallback;
+  try {
+    const parsed = JSON.parse(value) as Partial<IntelligenceAggregate>;
+    return {
+      ...fallback,
+      count: finiteNumber(parsed.count, 0, Number.MAX_SAFE_INTEGER) ? parsed.count : fallback.count,
+      sampleCount: finiteNumber(parsed.sampleCount, 0, Number.MAX_SAFE_INTEGER) ? parsed.sampleCount : fallback.sampleCount,
+      p50Sum: finiteNumber(parsed.p50Sum, 0, Number.MAX_SAFE_INTEGER) ? parsed.p50Sum : fallback.p50Sum,
+      p95Sum: finiteNumber(parsed.p95Sum, 0, Number.MAX_SAFE_INTEGER) ? parsed.p95Sum : fallback.p95Sum,
+      lossPercentSum: finiteNumber(parsed.lossPercentSum, 0, Number.MAX_SAFE_INTEGER) ? parsed.lossPercentSum : fallback.lossPercentSum,
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+function bucketDay(createdAt: number): string {
+  return new Date(createdAt).toISOString().slice(0, 10);
+}
+
+function aggregateKey(payload: ValidIntelligencePayload): string {
+  const hostKey = payload.originHost === null ? 'anonymous' : `host:${payload.originHost}`;
+  return `intelligence:v1:${bucketDay(payload.createdAt)}:${payload.consent}:${hostKey}`;
+}
+
+async function recordAggregate(
+  store: IntelligenceStore,
+  payload: ValidIntelligencePayload,
+  updatedAt: number,
+): Promise<void> {
+  const key = aggregateKey(payload);
+  const fallback: IntelligenceAggregate = {
+    v: 1,
+    bucket: bucketDay(payload.createdAt),
+    consent: payload.consent,
+    originHost: payload.originHost,
+    count: 0,
+    sampleCount: 0,
+    p50Sum: 0,
+    p95Sum: 0,
+    lossPercentSum: 0,
+    updatedAt,
+  };
+  const current = parseAggregate(await store.get(key), fallback);
+  await store.put(key, JSON.stringify({
+    ...fallback,
+    count: current.count + 1,
+    sampleCount: current.sampleCount + payload.sampleCount,
+    p50Sum: current.p50Sum + payload.p50,
+    p95Sum: current.p95Sum + payload.p95,
+    lossPercentSum: Number((current.lossPercentSum + payload.lossPercent).toFixed(2)),
+    updatedAt,
+  } satisfies IntelligenceAggregate));
+}
+
+export function validateIntelligencePayload(
+  value: unknown,
+): { readonly ok: true; readonly payload: ValidIntelligencePayload } | { readonly ok: false; readonly error: string } {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return { ok: false, error: 'Invalid payload.' };
+  const record = value as Record<string, unknown>;
+  if (hasPrivateField(record)) return { ok: false, error: 'Payload contains private fields.' };
+  if (record.v !== 1) return { ok: false, error: 'Invalid version.' };
+  if (record.consent !== 'anonymous-aggregate' && record.consent !== 'named-public-endpoint') {
+    return { ok: false, error: 'Consent is required.' };
+  }
+  if (!finiteNumber(record.sampleCount, 1, MAX_SAMPLE_COUNT) || !Number.isInteger(record.sampleCount)) {
+    return { ok: false, error: 'Invalid sample count.' };
+  }
+  if (!finiteNumber(record.p50, 0, MAX_LATENCY_MS) || !finiteNumber(record.p95, 0, MAX_LATENCY_MS)) {
+    return { ok: false, error: 'Invalid timing values.' };
+  }
+  if (!finiteNumber(record.lossPercent, 0, 100)) {
+    return { ok: false, error: 'Invalid loss value.' };
+  }
+  if (!finiteNumber(record.createdAt, 0, Number.MAX_SAFE_INTEGER)) {
+    return { ok: false, error: 'Invalid timestamp.' };
+  }
+  if (record.publicOriginHash !== null) {
+    return { ok: false, error: 'Origin hash is not supported yet.' };
+  }
+  let originHost: string | null = null;
+  if (record.consent === 'anonymous-aggregate') {
+    if (record.originHost !== null) return { ok: false, error: 'Anonymous payload cannot include a named endpoint.' };
+  } else {
+    if (!isPublicNamedHost(record.originHost)) return { ok: false, error: 'Named endpoint must be a public hostname.' };
+    originHost = record.originHost;
+  }
+  return {
+    ok: true,
+    payload: {
+      v: 1,
+      consent: record.consent,
+      originHost,
+      publicOriginHash: null,
+      p50: record.p50,
+      p95: record.p95,
+      lossPercent: record.lossPercent,
+      sampleCount: record.sampleCount,
+      createdAt: record.createdAt,
+    },
+  };
+}
+
+export async function handleIntelligenceIngest(
+  request: Request,
+  options: IntelligenceIngestOptions = {},
+): Promise<Response> {
+  if (request.method === 'OPTIONS') return json(204, null);
+  if (request.method !== 'POST') return json(405, { ok: false, error: 'Method not allowed.' }, { Allow: 'POST, OPTIONS' });
+  if (!request.headers.get('content-type')?.includes('application/json')) {
+    return json(400, { ok: false, error: 'Expected application/json.' });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return json(400, { ok: false, error: 'Invalid JSON.' });
+  }
+
+  const validated = validateIntelligencePayload(body);
+  if (!validated.ok) return json(400, { ok: false, error: validated.error });
+  if (!options.store) return json(503, { ok: false, error: 'Intelligence storage is not configured.' });
+
+  await recordAggregate(options.store, validated.payload, options.now?.() ?? Date.now());
+  return json(202, { ok: true, accepted: true });
+}

--- a/functions/api/intelligence/ingest.ts
+++ b/functions/api/intelligence/ingest.ts
@@ -1,0 +1,15 @@
+import { handleIntelligenceIngest, type IntelligenceStore } from '../../_shared/intelligence';
+
+interface Env {
+  CHRONOSCOPE_INTELLIGENCE?: IntelligenceStore;
+}
+
+export const onRequestPost: PagesFunction<Env> = (context) => {
+  return handleIntelligenceIngest(context.request, {
+    store: context.env.CHRONOSCOPE_INTELLIGENCE,
+  });
+};
+
+export const onRequestOptions: PagesFunction<Env> = (context) => {
+  return handleIntelligenceIngest(context.request);
+};

--- a/tests/unit/intelligence/functions.test.ts
+++ b/tests/unit/intelligence/functions.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment node
+
+import { describe, expect, it } from 'vitest';
+import {
+  handleIntelligenceIngest,
+  validateIntelligencePayload,
+  type IntelligenceStore,
+} from '../../../functions/_shared/intelligence';
+
+class FakeIntelligenceStore implements IntelligenceStore {
+  readonly values = new Map<string, string>();
+
+  get(key: string): Promise<string | null> {
+    return Promise.resolve(this.values.get(key) ?? null);
+  }
+
+  put(key: string, value: string): Promise<void> {
+    this.values.set(key, value);
+    return Promise.resolve();
+  }
+}
+
+function validPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    v: 1,
+    consent: 'anonymous-aggregate',
+    originHost: null,
+    publicOriginHash: null,
+    p50: 42,
+    p95: 80,
+    lossPercent: 0,
+    sampleCount: 35,
+    createdAt: 1778352000000,
+    ...overrides,
+  };
+}
+
+function ingestRequest(body: unknown, headers: Record<string, string> = { 'Content-Type': 'application/json' }): Request {
+  return new Request('https://chronoscope.dev/api/intelligence/ingest', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+describe('collective intelligence functions', () => {
+  it('rejects missing consent', () => {
+    expect(validateIntelligencePayload(validPayload({ consent: undefined }))).toEqual({
+      ok: false,
+      error: 'Consent is required.',
+    });
+  });
+
+  it('rejects full URL and private fields', () => {
+    for (const privateField of [
+      { url: 'https://api.example.com/path' },
+      { endpointUrl: 'https://api.example.com/private?token=secret' },
+      { wifi: { ssid: 'HomeNetwork' } },
+      { history: [{ url: 'https://private.example' }] },
+      { localStorage: { chronoscope_settings: '{}' } },
+      { indexedDB: { history: [] } },
+    ]) {
+      expect(validateIntelligencePayload(validPayload(privateField))).toEqual({
+        ok: false,
+        error: 'Payload contains private fields.',
+      });
+    }
+  });
+
+  it('rejects localhost and private named hosts', () => {
+    for (const originHost of ['localhost', '192.168.1.1', 'router.local', '[::1]']) {
+      expect(validateIntelligencePayload(validPayload({
+        consent: 'named-public-endpoint',
+        originHost,
+      }))).toMatchObject({
+        ok: false,
+        error: 'Named endpoint must be a public hostname.',
+      });
+    }
+  });
+
+  it('rejects sample counts over the bounded limit', () => {
+    expect(validateIntelligencePayload(validPayload({ sampleCount: 10001 }))).toEqual({
+      ok: false,
+      error: 'Invalid sample count.',
+    });
+  });
+
+  it('returns 503 when aggregate storage is not configured', async () => {
+    const response = await handleIntelligenceIngest(ingestRequest(validPayload()));
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: 'Intelligence storage is not configured.',
+    });
+  });
+
+  it('accepts aggregate-safe payloads and stores only counters', async () => {
+    const store = new FakeIntelligenceStore();
+    const response = await handleIntelligenceIngest(
+      ingestRequest(validPayload({
+        consent: 'named-public-endpoint',
+        originHost: 'api.example.com',
+      })),
+      { store, now: () => 1778352060000 },
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({ ok: true, accepted: true });
+    expect(store.values.size).toBe(1);
+    const stored = [...store.values.values()][0]!;
+    expect(stored).toContain('"count":1');
+    expect(stored).toContain('"sampleCount":35');
+    expect(stored).not.toMatch(/https?:\/\//);
+    expect(stored).not.toMatch(/endpointUrl|ssid|bssid|history|localStorage|indexedDB/i);
+  });
+
+  it('answers CORS preflight without storage', async () => {
+    const response = await handleIntelligenceIngest(new Request('https://chronoscope.dev/api/intelligence/ingest', {
+      method: 'OPTIONS',
+    }));
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+  });
+});


### PR DESCRIPTION
## Summary
- add the Phase 6 intelligence ingest validator and Cloudflare Pages route
- reject missing consent, raw URL/private fields, local/private named hosts, raw IP hosts, unsupported hashes, and oversized sample counts
- store only aggregate counters when a storage binding exists, and return a clear 503 when storage is not configured

## Privacy Review
- Ingest recursively rejects url, endpointUrl, WiFi, SSID/BSSID, history, localStorage, and indexedDB fields.
- Anonymous aggregate payloads cannot include originHost.
- Named endpoint payloads require a public hostname and reject localhost, RFC1918, .local/.internal, IPv6 loopback/local, and raw IP literals.
- Stored values are aggregate counters and do not include full URLs or private local evidence.

## Test Plan
- npm test -- tests/unit/intelligence/functions.test.ts
- npm run typecheck:functions
- rg -n "endpointUrl|url|ssid|bssid|history|localStorage|indexedDB" functions/_shared/intelligence.ts functions/api/intelligence tests/unit/intelligence docs/vision/collective-edge-intelligence-privacy.md src/lib/intelligence
- npm run typecheck && npm run lint && npm run build && npm test
