### PR TITLE
Add intelligence summary context

### DIFF
--- a/functions/_shared/intelligence.ts
+++ b/functions/_shared/intelligence.ts
@@ -1,6 +1,7 @@
 export interface IntelligenceStore {
   get(key: string): Promise<string | null>;
   put(key: string, value: string): Promise<void>;
+  list?(options?: { readonly prefix?: string; readonly limit?: number }): Promise<{ readonly keys: readonly { readonly name: string }[] }>;
 }
 
 export interface IntelligenceIngestOptions {
@@ -35,6 +36,18 @@ interface IntelligenceAggregate {
   readonly updatedAt: number;
 }
 
+interface IntelligenceSummaryBucket {
+  readonly bucket: string;
+  readonly consent: IntelligenceConsent;
+  readonly originHost: string | null;
+  readonly count: number;
+  readonly sampleCount: number;
+  readonly p50Avg: number;
+  readonly p95Avg: number;
+  readonly lossPercentAvg: number;
+  readonly updatedAt: number;
+}
+
 const PRIVATE_FIELD_KEYS = new Set([
   'url',
   'endpointurl',
@@ -47,6 +60,7 @@ const PRIVATE_FIELD_KEYS = new Set([
 ]);
 const MAX_SAMPLE_COUNT = 10_000;
 const MAX_LATENCY_MS = 600_000;
+const INTELLIGENCE_KEY_PREFIX = 'intelligence:v1:';
 
 function json(status: number, payload: unknown, extraHeaders: HeadersInit = {}): Response {
   return new Response(status === 204 ? null : JSON.stringify(payload), {
@@ -127,6 +141,48 @@ function bucketDay(createdAt: number): string {
 function aggregateKey(payload: ValidIntelligencePayload): string {
   const hostKey = payload.originHost === null ? 'anonymous' : `host:${payload.originHost}`;
   return `intelligence:v1:${bucketDay(payload.createdAt)}:${payload.consent}:${hostKey}`;
+}
+
+function summaryBucketFromAggregate(value: string | null): IntelligenceSummaryBucket | null {
+  if (value === null) return null;
+  let record: Record<string, unknown>;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return null;
+    record = parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  if (record.v !== 1) return null;
+  if (record.consent !== 'anonymous-aggregate' && record.consent !== 'named-public-endpoint') return null;
+  if (typeof record.bucket !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(record.bucket)) return null;
+  if (!finiteNumber(record.count, 1, Number.MAX_SAFE_INTEGER)) return null;
+  if (!finiteNumber(record.sampleCount, 1, Number.MAX_SAFE_INTEGER)) return null;
+  if (!finiteNumber(record.p50Sum, 0, Number.MAX_SAFE_INTEGER)) return null;
+  if (!finiteNumber(record.p95Sum, 0, Number.MAX_SAFE_INTEGER)) return null;
+  if (!finiteNumber(record.lossPercentSum, 0, Number.MAX_SAFE_INTEGER)) return null;
+  if (!finiteNumber(record.updatedAt, 0, Number.MAX_SAFE_INTEGER)) return null;
+
+  let originHost: string | null = null;
+  if (record.consent === 'named-public-endpoint') {
+    if (!isPublicNamedHost(record.originHost)) return null;
+    originHost = record.originHost;
+  } else if (record.originHost !== null) {
+    return null;
+  }
+
+  return {
+    bucket: record.bucket,
+    consent: record.consent,
+    originHost,
+    count: record.count,
+    sampleCount: record.sampleCount,
+    p50Avg: Math.round(record.p50Sum / record.count),
+    p95Avg: Math.round(record.p95Sum / record.count),
+    lossPercentAvg: Number((record.lossPercentSum / record.count).toFixed(2)),
+    updatedAt: record.updatedAt,
+  };
 }
 
 async function recordAggregate(
@@ -230,4 +286,32 @@ export async function handleIntelligenceIngest(
 
   await recordAggregate(options.store, validated.payload, options.now?.() ?? Date.now());
   return json(202, { ok: true, accepted: true });
+}
+
+export async function handleIntelligenceSummary(
+  request: Request,
+  options: IntelligenceIngestOptions = {},
+): Promise<Response> {
+  if (request.method === 'OPTIONS') return json(204, null, { 'Access-Control-Allow-Methods': 'GET,OPTIONS' });
+  if (request.method !== 'GET') return json(405, { ok: false, error: 'Method not allowed.' }, {
+    Allow: 'GET, OPTIONS',
+    'Access-Control-Allow-Methods': 'GET,OPTIONS',
+  });
+  if (!options.store?.list) {
+    return json(503, { ok: false, error: 'Intelligence summary storage is not configured.' }, {
+      'Access-Control-Allow-Methods': 'GET,OPTIONS',
+    });
+  }
+
+  const listed = await options.store.list({ prefix: INTELLIGENCE_KEY_PREFIX, limit: 50 });
+  const buckets = (await Promise.all(
+    listed.keys.map(async (key) => summaryBucketFromAggregate(await options.store?.get(key.name) ?? null)),
+  ))
+    .filter((bucket): bucket is IntelligenceSummaryBucket => bucket !== null)
+    .sort((a, b) => b.updatedAt - a.updatedAt)
+    .slice(0, 20);
+
+  return json(200, { ok: true, buckets }, {
+    'Access-Control-Allow-Methods': 'GET,OPTIONS',
+  });
 }

--- a/functions/api/intelligence/summary.ts
+++ b/functions/api/intelligence/summary.ts
@@ -1,0 +1,15 @@
+import { handleIntelligenceSummary, type IntelligenceStore } from '../../_shared/intelligence';
+
+interface Env {
+  CHRONOSCOPE_INTELLIGENCE?: IntelligenceStore;
+}
+
+export const onRequestGet: PagesFunction<Env> = (context) => {
+  return handleIntelligenceSummary(context.request, {
+    store: context.env.CHRONOSCOPE_INTELLIGENCE,
+  });
+};
+
+export const onRequestOptions: PagesFunction<Env> = (context) => {
+  return handleIntelligenceSummary(context.request);
+};

--- a/src/lib/components/DiagnoseView.svelte
+++ b/src/lib/components/DiagnoseView.svelte
@@ -6,6 +6,7 @@
 <!-- auto-selects an investigation target when focus is missing or stale.       -->
 <script lang="ts">
   import { monitoredEndpointsStore } from '$lib/stores/derived';
+  import IntelligencePanel from '$lib/components/IntelligencePanel.svelte';
   import { bufferbloatStore } from '$lib/stores/bufferbloat';
   import { measurementStore } from '$lib/stores/measurements';
   import { networkContextStore } from '$lib/stores/network-context';
@@ -722,6 +723,8 @@
         </table>
       </section>
     {/if}
+
+    <IntelligencePanel />
   {/if}
 </section>
 

--- a/src/lib/components/IntelligencePanel.svelte
+++ b/src/lib/components/IntelligencePanel.svelte
@@ -1,0 +1,291 @@
+<script lang="ts">
+  type IntelligenceConsent = 'anonymous-aggregate' | 'named-public-endpoint';
+
+  interface IntelligenceSummaryBucket {
+    readonly bucket: string;
+    readonly consent: IntelligenceConsent;
+    readonly originHost: string | null;
+    readonly count: number;
+    readonly sampleCount: number;
+    readonly p50Avg: number;
+    readonly p95Avg: number;
+    readonly lossPercentAvg: number;
+    readonly updatedAt: number;
+  }
+
+  interface IntelligenceSummaryResponse {
+    readonly ok: true;
+    readonly buckets: readonly IntelligenceSummaryBucket[];
+  }
+
+  type LoadStatus = 'idle' | 'loading' | 'ready' | 'unavailable' | 'error';
+
+  let status = $state<LoadStatus>('idle');
+  let buckets = $state<readonly IntelligenceSummaryBucket[]>([]);
+  let errorMessage = $state('');
+
+  const isBusy = $derived(status === 'loading');
+  const topBuckets = $derived(buckets.slice(0, 3));
+
+  function isFiniteNumber(value: unknown): value is number {
+    return typeof value === 'number' && Number.isFinite(value);
+  }
+
+  function isSafeHost(value: unknown): value is string {
+    return typeof value === 'string'
+      && value.length > 0
+      && value.length <= 253
+      && !/[/:?#]/.test(value);
+  }
+
+  function isBucket(value: unknown): value is IntelligenceSummaryBucket {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+    const record = value as Record<string, unknown>;
+    if (record.consent !== 'anonymous-aggregate' && record.consent !== 'named-public-endpoint') return false;
+    if (typeof record.bucket !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(record.bucket)) return false;
+    if (record.consent === 'named-public-endpoint' && !isSafeHost(record.originHost)) return false;
+    if (record.consent === 'anonymous-aggregate' && record.originHost !== null) return false;
+    return isFiniteNumber(record.count)
+      && isFiniteNumber(record.sampleCount)
+      && isFiniteNumber(record.p50Avg)
+      && isFiniteNumber(record.p95Avg)
+      && isFiniteNumber(record.lossPercentAvg)
+      && isFiniteNumber(record.updatedAt);
+  }
+
+  function isSummaryResponse(value: unknown): value is IntelligenceSummaryResponse {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+    const record = value as Record<string, unknown>;
+    return record.ok === true
+      && Array.isArray(record.buckets)
+      && record.buckets.every(isBucket);
+  }
+
+  function endpointLabel(bucket: IntelligenceSummaryBucket): string {
+    return bucket.originHost ?? 'Anonymous endpoint group';
+  }
+
+  function reportLabel(count: number): string {
+    return `${count} ${count === 1 ? 'report' : 'reports'}`;
+  }
+
+  function formatLoss(value: number): string {
+    return value === 0 ? '0%' : `${value.toFixed(value < 1 ? 2 : 1)}%`;
+  }
+
+  async function handleLoad(): Promise<void> {
+    status = 'loading';
+    errorMessage = '';
+
+    try {
+      const response = await fetch('/api/intelligence/summary', {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+        cache: 'no-store',
+      });
+      let payload: unknown = null;
+      try {
+        payload = await response.json();
+      } catch {
+        payload = null;
+      }
+
+      if (response.status === 503) {
+        buckets = [];
+        status = 'unavailable';
+        return;
+      }
+      if (!response.ok || !isSummaryResponse(payload)) {
+        throw new Error('Invalid aggregate context response.');
+      }
+
+      buckets = payload.buckets;
+      status = 'ready';
+    } catch {
+      buckets = [];
+      errorMessage = 'Could not load aggregate context.';
+      status = 'error';
+    }
+  }
+</script>
+
+<section class="intelligence-panel" aria-label="Aggregate context">
+  <div class="intelligence-head">
+    <div>
+      <div class="intelligence-kicker">Aggregate context</div>
+      <p class="intelligence-headline">Opted-in reports from other runs</p>
+    </div>
+    <button
+      type="button"
+      class="intelligence-button"
+      disabled={isBusy}
+      aria-disabled={isBusy}
+      onclick={handleLoad}
+    >
+      {isBusy ? 'Checking...' : 'Check context'}
+    </button>
+  </div>
+
+  <p class="intelligence-detail">
+    Population-level context from consented reports. It shows recent aggregate buckets only; it does not prove what is happening on your path.
+  </p>
+
+  <div class="intelligence-body" aria-live="polite">
+    {#if status === 'idle'}
+      <p class="intelligence-action">No aggregate context loaded for this investigation yet.</p>
+    {:else if status === 'loading'}
+      <p class="intelligence-action">Checking privacy-safe aggregate buckets...</p>
+    {:else if status === 'unavailable'}
+      <p class="intelligence-action">Aggregate context is not available yet.</p>
+    {:else if status === 'error'}
+      <p class="intelligence-error">{errorMessage}</p>
+    {:else if topBuckets.length === 0}
+      <p class="intelligence-action">No opted-in aggregate reports are available yet.</p>
+    {:else}
+      <dl class="intelligence-buckets">
+        {#each topBuckets as bucket (`${bucket.bucket}:${bucket.consent}:${bucket.originHost ?? 'anonymous'}`)}
+          <div>
+            <dt>{endpointLabel(bucket)}</dt>
+            <dd>{reportLabel(bucket.count)} / {bucket.sampleCount} samples</dd>
+            <p>avg P50 {Math.round(bucket.p50Avg)} ms / avg P95 {Math.round(bucket.p95Avg)} ms / avg loss {formatLoss(bucket.lossPercentAvg)}</p>
+          </div>
+        {/each}
+      </dl>
+    {/if}
+  </div>
+</section>
+
+<style>
+  .intelligence-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 16px;
+    background: rgba(255, 255, 255, 0.025);
+    border: 1px solid var(--border-mid);
+    border-radius: 10px;
+  }
+
+  .intelligence-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+
+  .intelligence-kicker {
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-kicker);
+    color: var(--t3);
+    text-transform: uppercase;
+    margin-bottom: 8px;
+  }
+
+  .intelligence-headline,
+  .intelligence-detail,
+  .intelligence-action,
+  .intelligence-error,
+  .intelligence-buckets p {
+    margin: 0;
+  }
+
+  .intelligence-headline {
+    color: var(--t1);
+    font-size: var(--ts-md);
+    line-height: 1.4;
+  }
+
+  .intelligence-detail,
+  .intelligence-action,
+  .intelligence-error,
+  .intelligence-buckets p {
+    color: var(--t3);
+    font-size: var(--ts-sm);
+    line-height: 1.45;
+  }
+
+  .intelligence-action {
+    color: var(--accent-cyan);
+  }
+
+  .intelligence-error {
+    color: var(--accent-amber);
+  }
+
+  .intelligence-button {
+    padding: 6px 12px;
+    border-radius: 5px;
+    background: transparent;
+    border: 1px solid var(--border-mid);
+    color: var(--t2);
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: 0.06em;
+    cursor: pointer;
+    transition: color 160ms ease, background 160ms ease, border-color 160ms ease, opacity 160ms ease;
+  }
+
+  .intelligence-button:hover:not(:disabled) {
+    color: var(--t1);
+    border-color: var(--border-bright);
+  }
+
+  .intelligence-button:disabled {
+    cursor: default;
+    opacity: 0.62;
+  }
+
+  .intelligence-button:focus-visible {
+    outline: 1.5px solid var(--accent-cyan);
+    outline-offset: 2px;
+  }
+
+  .intelligence-buckets {
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 10px;
+  }
+
+  .intelligence-buckets div {
+    min-width: 0;
+    padding-top: 8px;
+    border-top: 1px solid var(--border-mid);
+  }
+
+  .intelligence-buckets dt {
+    margin: 0 0 3px;
+    color: var(--t2);
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-kicker);
+    text-transform: uppercase;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .intelligence-buckets dd {
+    margin: 0 0 4px;
+    color: var(--t1);
+    font-family: var(--mono);
+    font-size: var(--ts-sm);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  @media (max-width: 767px) {
+    .intelligence-buckets {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .intelligence-button {
+      transition: none;
+    }
+  }
+</style>

--- a/tests/unit/components/intelligence-panel.test.ts
+++ b/tests/unit/components/intelligence-panel.test.ts
@@ -1,0 +1,77 @@
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import IntelligencePanel from '../../../src/lib/components/IntelligencePanel.svelte';
+
+function stubFetch(response: Response): ReturnType<typeof vi.fn> {
+  const fetcher = vi.fn().mockResolvedValue(response);
+  vi.stubGlobal('fetch', fetcher);
+  return fetcher;
+}
+
+describe('IntelligencePanel', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders the proof boundary before loading aggregate context', () => {
+    const { getByText, getByRole } = render(IntelligencePanel);
+
+    expect(getByText(/population-level context from consented reports/i)).toBeTruthy();
+    expect(getByText(/does not prove what is happening on your path/i)).toBeTruthy();
+    expect(getByRole('button', { name: /check context/i })).toBeTruthy();
+  });
+
+  it('loads and renders privacy-safe aggregate buckets', async () => {
+    const fetcher = stubFetch(new Response(JSON.stringify({
+      ok: true,
+      buckets: [{
+        bucket: '2026-05-13',
+        consent: 'named-public-endpoint',
+        originHost: 'api.example.com',
+        count: 2,
+        sampleCount: 70,
+        p50Avg: 45,
+        p95Avg: 85,
+        lossPercentAvg: 0.75,
+        updatedAt: 1778352060000,
+      }],
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+    const { container, getByRole, getByText } = render(IntelligencePanel);
+
+    await fireEvent.click(getByRole('button', { name: /check context/i }));
+
+    await waitFor(() => {
+      expect(fetcher).toHaveBeenCalledWith('/api/intelligence/summary', expect.objectContaining({
+        method: 'GET',
+        cache: 'no-store',
+      }));
+      expect(getByText('api.example.com')).toBeTruthy();
+      expect(getByText(/2 reports \/ 70 samples/i)).toBeTruthy();
+      expect(getByText(/avg P50 45 ms \/ avg P95 85 ms \/ avg loss 0.75%/i)).toBeTruthy();
+    });
+    expect(container.textContent).not.toMatch(/https?:\/\//);
+    expect(container.textContent).not.toMatch(/ssid|bssid|history/i);
+  });
+
+  it('treats missing storage as unavailable rather than an alarming diagnosis', async () => {
+    stubFetch(new Response(JSON.stringify({
+      ok: false,
+      error: 'Intelligence summary storage is not configured.',
+    }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+    const { getByRole, getByText } = render(IntelligencePanel);
+
+    await fireEvent.click(getByRole('button', { name: /check context/i }));
+
+    await waitFor(() => {
+      expect(getByText(/aggregate context is not available yet/i)).toBeTruthy();
+    });
+  });
+});

--- a/tests/unit/intelligence/functions.test.ts
+++ b/tests/unit/intelligence/functions.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   handleIntelligenceIngest,
+  handleIntelligenceSummary,
   validateIntelligencePayload,
   type IntelligenceStore,
 } from '../../../functions/_shared/intelligence';
@@ -17,6 +18,14 @@ class FakeIntelligenceStore implements IntelligenceStore {
   put(key: string, value: string): Promise<void> {
     this.values.set(key, value);
     return Promise.resolve();
+  }
+
+  list(options?: { readonly prefix?: string; readonly limit?: number }): Promise<{ readonly keys: readonly { readonly name: string }[] }> {
+    const keys = [...this.values.keys()]
+      .filter((name) => options?.prefix === undefined || name.startsWith(options.prefix))
+      .slice(0, options?.limit ?? 1000)
+      .map((name) => ({ name }));
+    return Promise.resolve({ keys });
   }
 }
 
@@ -123,5 +132,58 @@ describe('collective intelligence functions', () => {
 
     expect(response.status).toBe(204);
     expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+  });
+
+  it('returns aggregate summary buckets only', async () => {
+    const store = new FakeIntelligenceStore();
+    await store.put('intelligence:v1:2026-05-13:named-public-endpoint:host:api.example.com', JSON.stringify({
+      v: 1,
+      bucket: '2026-05-13',
+      consent: 'named-public-endpoint',
+      originHost: 'api.example.com',
+      count: 2,
+      sampleCount: 70,
+      p50Sum: 90,
+      p95Sum: 170,
+      lossPercentSum: 1.5,
+      updatedAt: 1778352060000,
+    }));
+    await store.put('unrelated', JSON.stringify({
+      url: 'https://private.example/path',
+      ssid: 'HomeNetwork',
+    }));
+
+    const response = await handleIntelligenceSummary(new Request('https://chronoscope.dev/api/intelligence/summary'), {
+      store,
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({
+      ok: true,
+      buckets: [{
+        bucket: '2026-05-13',
+        consent: 'named-public-endpoint',
+        originHost: 'api.example.com',
+        count: 2,
+        sampleCount: 70,
+        p50Avg: 45,
+        p95Avg: 85,
+        lossPercentAvg: 0.75,
+        updatedAt: 1778352060000,
+      }],
+    });
+    expect(JSON.stringify(payload)).not.toMatch(/https?:\/\//);
+    expect(JSON.stringify(payload)).not.toMatch(/ssid|bssid|history/i);
+  });
+
+  it('returns 503 for summaries when aggregate storage cannot be listed', async () => {
+    const response = await handleIntelligenceSummary(new Request('https://chronoscope.dev/api/intelligence/summary'));
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: 'Intelligence summary storage is not configured.',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add a privacy-safe `/api/intelligence/summary` endpoint that lists aggregate buckets only.
- Add a compact Investigate panel that loads aggregate context on demand and states the proof boundary plainly.
- Cover summary validation, missing storage behavior, and UI fetch states.

## Test Plan
- `npm run typecheck && npm run lint && npm run build && npm test`
- `npm run test:visual -- tests/visual/ac-verification.spec.ts`
- `git diff --check`