### PR TITLE
Return unavailable intelligence summaries without errors

### DIFF
--- a/functions/_shared/intelligence.ts
+++ b/functions/_shared/intelligence.ts
@@ -298,7 +298,12 @@ export async function handleIntelligenceSummary(
     'Access-Control-Allow-Methods': 'GET,OPTIONS',
   });
   if (!options.store?.list) {
-    return json(503, { ok: false, error: 'Intelligence summary storage is not configured.' }, {
+    return json(200, {
+      ok: true,
+      buckets: [],
+      unavailable: true,
+      message: 'Aggregate context is not available yet.',
+    }, {
       'Access-Control-Allow-Methods': 'GET,OPTIONS',
     });
   }

--- a/src/lib/components/IntelligencePanel.svelte
+++ b/src/lib/components/IntelligencePanel.svelte
@@ -16,6 +16,8 @@
   interface IntelligenceSummaryResponse {
     readonly ok: true;
     readonly buckets: readonly IntelligenceSummaryBucket[];
+    readonly unavailable?: boolean;
+    readonly message?: string;
   }
 
   type LoadStatus = 'idle' | 'loading' | 'ready' | 'unavailable' | 'error';
@@ -90,17 +92,12 @@
         payload = null;
       }
 
-      if (response.status === 503) {
-        buckets = [];
-        status = 'unavailable';
-        return;
-      }
       if (!response.ok || !isSummaryResponse(payload)) {
         throw new Error('Invalid aggregate context response.');
       }
 
       buckets = payload.buckets;
-      status = 'ready';
+      status = payload.unavailable === true ? 'unavailable' : 'ready';
     } catch {
       buckets = [];
       errorMessage = 'Could not load aggregate context.';

--- a/tests/unit/components/intelligence-panel.test.ts
+++ b/tests/unit/components/intelligence-panel.test.ts
@@ -60,10 +60,12 @@ describe('IntelligencePanel', () => {
 
   it('treats missing storage as unavailable rather than an alarming diagnosis', async () => {
     stubFetch(new Response(JSON.stringify({
-      ok: false,
-      error: 'Intelligence summary storage is not configured.',
+      ok: true,
+      buckets: [],
+      unavailable: true,
+      message: 'Aggregate context is not available yet.',
     }), {
-      status: 503,
+      status: 200,
       headers: { 'Content-Type': 'application/json' },
     }));
     const { getByRole, getByText } = render(IntelligencePanel);

--- a/tests/unit/intelligence/functions.test.ts
+++ b/tests/unit/intelligence/functions.test.ts
@@ -177,13 +177,15 @@ describe('collective intelligence functions', () => {
     expect(JSON.stringify(payload)).not.toMatch(/ssid|bssid|history/i);
   });
 
-  it('returns 503 for summaries when aggregate storage cannot be listed', async () => {
+  it('returns a non-error unavailable summary when aggregate storage cannot be listed', async () => {
     const response = await handleIntelligenceSummary(new Request('https://chronoscope.dev/api/intelligence/summary'));
 
-    expect(response.status).toBe(503);
-    await expect(response.json()).resolves.toMatchObject({
-      ok: false,
-      error: 'Intelligence summary storage is not configured.',
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      buckets: [],
+      unavailable: true,
+      message: 'Aggregate context is not available yet.',
     });
   });
 });


### PR DESCRIPTION
## Summary
- Return a 200 unavailable summary payload when aggregate storage is not configured.
- Keep the Investigate panel's friendly unavailable state without producing normal browser console resource errors.
- Update function and component tests for the non-error optional-state contract.

## Test Plan
- `npm test -- tests/unit/intelligence/functions.test.ts tests/unit/components/intelligence-panel.test.ts`
- `npm run typecheck && npm run lint`
- `npm run typecheck && npm run lint && npm run build && npm test`
- `npm run test:visual -- tests/visual/ac-verification.spec.ts`
- `git diff --check`