### PR TITLE
Refine good-score verdict copy

### DIFF
--- a/src/lib/utils/classify.ts
+++ b/src/lib/utils/classify.ts
@@ -115,7 +115,7 @@ export function diagnosticAlignedScore(
   return score;
 }
 
-export type OverviewVerdict = 'unknown' | 'healthy' | 'degraded' | 'unhealthy';
+export type OverviewVerdict = 'unknown' | 'healthy' | 'good' | 'degraded' | 'unhealthy';
 
 interface VerdictStyle {
   readonly color:  string;
@@ -125,16 +125,18 @@ interface VerdictStyle {
 }
 
 /**
- * Coarse 3-bucket label for the Overview dial and diagnosis strip.
+ * Coarse label for the Overview dial and diagnosis strip.
  *
  *   null    → unknown   (Awaiting samples)
- *   ≥ 80    → healthy
+ *   ≥ 95    → healthy   (clean top-band score)
+ *   ≥ 80    → good      (passing, but not pristine)
  *   ≥ 50    → degraded
  *   <  50   → unhealthy
  */
 export function overviewVerdict(score: number | null): OverviewVerdict {
   if (score === null) return 'unknown';
-  if (score >= 80) return 'healthy';
+  if (score >= 95) return 'healthy';
+  if (score >= 80) return 'good';
   if (score >= 50) return 'degraded';
   return 'unhealthy';
 }
@@ -142,6 +144,7 @@ export function overviewVerdict(score: number | null): OverviewVerdict {
 export const VERDICT_STYLES: Record<OverviewVerdict, VerdictStyle> = {
   unknown:   { color: 'var(--t4)',           glow: 'transparent',              label: 'Awaiting samples', kicker: '···' },
   healthy:   { color: 'var(--accent-cyan)',  glow: 'var(--accent-cyan-glow)',  label: 'Healthy',          kicker: 'HEALTHY' },
+  good:      { color: 'var(--accent-green)', glow: 'var(--green-glow)',        label: 'Good',             kicker: 'GOOD' },
   degraded:  { color: 'var(--accent-amber)', glow: 'var(--accent-amber-glow)', label: 'Degraded',         kicker: 'DEGRADED' },
   unhealthy: { color: 'var(--accent-pink)',  glow: 'var(--accent-pink-glow)',  label: 'Unhealthy',        kicker: 'CRITICAL' },
 };

--- a/src/lib/utils/diagnostic-narrative.ts
+++ b/src/lib/utils/diagnostic-narrative.ts
@@ -5,6 +5,7 @@
 import type { MeasurementSample, Settings } from '../types';
 import { classifyLossPattern } from '../loss/patterns';
 import { renderClaim, type ClaimEvidenceState, type ClaimId } from './claim-registry';
+import { classify } from './classify';
 import { computeCausalVerdict, PHASE_LABELS, type Verdict, type VerdictRow } from './verdict';
 
 export type DiagnosticKind =
@@ -254,6 +255,13 @@ function severityFor(kind: DiagnosticKind): DiagnosticSeverity {
   return 'degraded';
 }
 
+function hasHealthyVariation(rows: readonly VerdictRow[], threshold: number): boolean {
+  return rows.some((row) => {
+    const bucket = classify(row.stats, threshold);
+    return bucket === 'degraded' || bucket === 'unhealthy';
+  });
+}
+
 function confidenceFor(input: {
   readonly kind: DiagnosticKind;
   readonly rows: readonly VerdictRow[];
@@ -318,7 +326,9 @@ function explanationFor(
     case 'collecting':
       return 'Collecting enough data to call this test.';
     case 'healthy':
-      return 'This test looks healthy.';
+      return hasHealthyVariation(rows, threshold)
+        ? 'Looks good, with minor variation.'
+        : 'This test looks healthy.';
     case 'isolated-endpoint': {
       const bad = rows.find((row) => row.ep.id === verdict.worstEpId) ?? overRows[0];
       const label = bad?.ep.label ?? 'One site';
@@ -614,10 +624,11 @@ function triageActionsFor(input: {
   readonly kind: DiagnosticKind;
   readonly verdict: Verdict;
   readonly rows: readonly VerdictRow[];
+  readonly threshold: number;
   readonly timingVisibility: TimingVisibility;
   readonly primaryAnswer: DiagnosticClaim;
 }): readonly DiagnosticTriageAction[] {
-  const { kind, verdict, rows, timingVisibility, primaryAnswer } = input;
+  const { kind, verdict, rows, threshold, timingVisibility, primaryAnswer } = input;
   const visibility = browserVisibilityAction(timingVisibility);
   const endpointLabel = endpointLabelFor(verdict, rows);
   const endpointId = verdict.worstEpId;
@@ -634,13 +645,18 @@ function triageActionsFor(input: {
   }
 
   if (kind === 'healthy') {
+    const withVariation = hasHealthyVariation(rows, threshold);
     return [
       {
         id: 'share-snapshot',
         label: 'Share result',
-        action: 'Share this clean measured run.',
-        why: 'Every enabled site has mature checks and Chronoscope did not see slow medians or failed requests in this browser run.',
-        watchFor: 'If the issue returns later, compare the new run against this clean snapshot.',
+        action: withVariation ? 'Share this measured run with the variation visible.' : 'Share this clean measured run.',
+        why: withVariation
+          ? 'No enabled site is consistently slow or failing, but higher-latency checks are visible in the measurements.'
+          : 'Every enabled site has mature checks and Chronoscope did not see slow medians or failed requests in this browser run.',
+        watchFor: withVariation
+          ? 'If one site or several sites start crossing the threshold, use the changed report instead of this measured snapshot.'
+          : 'If the issue returns later, compare the new run against this clean snapshot.',
         requiredEvidence: ['all-enabled-ready', 'sample-mature', 'total-timing'],
       },
       {
@@ -808,10 +824,11 @@ function snapshotEligibilityFor(input: {
   readonly kind: DiagnosticKind;
   readonly confidence: DiagnosticConfidence;
   readonly rows: readonly VerdictRow[];
+  readonly threshold: number;
   readonly evidence: readonly DiagnosticEvidence[];
   readonly readiness: ReturnType<typeof sampleReadiness>;
 }): SnapshotEligibility {
-  const { kind, confidence, rows, evidence, readiness } = input;
+  const { kind, confidence, rows, threshold, evidence, readiness } = input;
   if (kind !== 'healthy') {
     return {
       eligible: false,
@@ -844,7 +861,9 @@ function snapshotEligibilityFor(input: {
   }
   return {
     eligible: true,
-    reason: 'This run has enough clean checks for a snapshot link.',
+    reason: hasHealthyVariation(rows, threshold)
+      ? 'This run has enough checks for a measured snapshot, with the variation included.'
+      : 'This run has enough clean checks for a snapshot link.',
     facts: evidence.filter((item) => (
       item.id === 'ready-endpoints' || item.id === 'slow-endpoints' || item.id === 'timing-visibility'
     )),
@@ -983,15 +1002,20 @@ function supportingSummaryFor(input: {
   readonly kind: DiagnosticKind;
   readonly confidence: DiagnosticConfidence;
   readonly rows: readonly VerdictRow[];
+  readonly threshold: number;
   readonly monitoredEndpointCount: number;
   readonly timingVisibility: TimingVisibility;
   readonly readiness: ReturnType<typeof sampleReadiness>;
 }): string {
-  const { kind, confidence, rows, monitoredEndpointCount, timingVisibility, readiness } = input;
+  const { kind, confidence, rows, threshold, monitoredEndpointCount, timingVisibility, readiness } = input;
   const sampleScope = sampleScopeFor(rows, monitoredEndpointCount, readiness);
 
   if (kind === 'collecting') {
     return `Collecting: ${sampleScope}.`;
+  }
+
+  if (kind === 'healthy' && confidence === 'high' && readiness.allEnabledMature && hasHealthyVariation(rows, threshold)) {
+    return `Good browser-visible run with variation: no site is consistently slow; ${sampleScope}.`;
   }
 
   if (kind === 'healthy' && confidence === 'high' && readiness.allEnabledMature) {
@@ -1046,6 +1070,7 @@ export function buildDiagnosticNarrative(input: DiagnosticInput): DiagnosticNarr
     kind,
     confidence,
     rows: input.rows,
+    threshold: input.threshold,
     evidence,
     readiness,
   });
@@ -1064,6 +1089,7 @@ export function buildDiagnosticNarrative(input: DiagnosticInput): DiagnosticNarr
     kind,
     verdict,
     rows: input.rows,
+    threshold: input.threshold,
     timingVisibility,
     primaryAnswer,
   });
@@ -1083,6 +1109,7 @@ export function buildDiagnosticNarrative(input: DiagnosticInput): DiagnosticNarr
       kind,
       confidence,
       rows: input.rows,
+      threshold: input.threshold,
       monitoredEndpointCount: input.monitoredEndpointCount,
       timingVisibility,
       readiness,

--- a/tests/unit/classify.test.ts
+++ b/tests/unit/classify.test.ts
@@ -137,9 +137,13 @@ describe('overviewVerdict()', () => {
   it('returns "unknown" for null score', () => {
     expect(overviewVerdict(null)).toBe('unknown');
   });
-  it('returns "healthy" at 80 and above', () => {
+  it('returns "healthy" only for clean top-band scores', () => {
     expect(overviewVerdict(100)).toBe('healthy');
-    expect(overviewVerdict(80)).toBe('healthy');
+    expect(overviewVerdict(95)).toBe('healthy');
+  });
+  it('returns "good" for non-clean passing scores', () => {
+    expect(overviewVerdict(94)).toBe('good');
+    expect(overviewVerdict(80)).toBe('good');
   });
   it('returns "degraded" between 50 and 79', () => {
     expect(overviewVerdict(79)).toBe('degraded');
@@ -153,14 +157,14 @@ describe('overviewVerdict()', () => {
 
 describe('VERDICT_STYLES', () => {
   it('defines an entry for every verdict including kicker text', () => {
-    for (const v of ['unknown', 'healthy', 'degraded', 'unhealthy'] as const) {
+    for (const v of ['unknown', 'healthy', 'good', 'degraded', 'unhealthy'] as const) {
       expect(VERDICT_STYLES[v].color).toBeTruthy();
       expect(VERDICT_STYLES[v].label).toBeTruthy();
       expect(VERDICT_STYLES[v].kicker).toBeTruthy();
     }
   });
   it('uses CSS custom properties rather than raw hex', () => {
-    for (const v of ['healthy', 'degraded', 'unhealthy'] as const) {
+    for (const v of ['healthy', 'good', 'degraded', 'unhealthy'] as const) {
       expect(VERDICT_STYLES[v].color).toMatch(/^var\(--/);
     }
   });

--- a/tests/unit/components/ChronographDial.test.ts
+++ b/tests/unit/components/ChronographDial.test.ts
@@ -208,7 +208,7 @@ describe('ChronographDial — overlap polish · verdict+LIVE merged strip', () =
     expect(tspans).toHaveLength(3);
     // Segment 1: verdict kicker. Segment 2: live median prefix.
     // Segment 3: band label.
-    expect(tspans[0].textContent).toBe('HEALTHY');
+    expect(tspans[0].textContent).toBe('GOOD');
     expect(tspans[1].textContent?.trim().startsWith('· LIVE')).toBe(true);
     expect(tspans[2].textContent?.trim()).toBe('· WITHIN BAND');
   });
@@ -219,7 +219,7 @@ describe('ChronographDial — overlap polish · verdict+LIVE merged strip', () =
       'text[data-role="merged-verdict-live"]',
     );
     const tspans = Array.from(merged?.querySelectorAll('tspan') ?? []);
-    // Verdict tspan inherits verdictStyle.color for its state (healthy = cyan).
+    // Verdict tspan inherits verdictStyle.color for its state (score 85 = good).
     expect(tspans[0].getAttribute('fill')).toMatch(/cyan|accent|#67/);
     // Live-median tspan uses t3 grey.
     expect(tspans[1].getAttribute('fill')).toBe('var(--t3)');

--- a/tests/unit/utils/diagnostic-narrative.test.ts
+++ b/tests/unit/utils/diagnostic-narrative.test.ts
@@ -155,6 +155,35 @@ describe('buildDiagnosticNarrative', () => {
     expect(narrative.triageActions[0].why).toContain('mature checks');
   });
 
+  it('does not call a good run clean when tail latency lowers the score', () => {
+    const rows = [
+      row('google', { p50: 48, p95: 175, sampleCount: 35 }, 'Google'),
+      row('cloudflare', { p50: 44, p95: 72, sampleCount: 35 }, 'Cloudflare'),
+      row('aws', { p50: 46, p95: 74, sampleCount: 35 }, 'AWS'),
+    ];
+    const narrative = buildDiagnosticNarrative({
+      rows,
+      threshold: 120,
+      corsMode: 'cors',
+      samplesByEndpoint: {
+        google: samples(35, 48, true),
+        cloudflare: samples(35, 44, true),
+        aws: samples(35, 46, true),
+      },
+      monitoredEndpointCount: 3,
+    });
+
+    expect(narrative.kind).toBe('healthy');
+    expect(narrative.severity).toBe('healthy');
+    expect(narrative.primaryAnswer.text).toBe('Looks good, with minor variation.');
+    expect(narrative.supportingSummary).toBe(
+      'Good browser-visible run with variation: no site is consistently slow; 35+ successful checks across 3 sites.',
+    );
+    expect(narrative.safeSummary).toContain('Looks good, with minor variation.');
+    expect(narrative.triageActions[0].action).toBe('Share this measured run with the variation visible.');
+    expect(narrative.triageActions[0].why).toContain('higher-latency checks');
+  });
+
   it('explains isolated endpoint slowness with evidence-labeled endpoint and next validation step', () => {
     const rows = [
       row('api', { p50: 240, sampleCount: 18 }, 'API'),


### PR DESCRIPTION
## Summary
- split the overview verdict band so 80-94 shows Good instead of Healthy
- make healthy-but-imperfect tail latency read as minor variation instead of clean
- adjust snapshot/share guidance so non-pristine runs stay measured and accurate

## Verification
- npm run typecheck
- npm run lint
- npm test
- npm run build
- npx playwright test tests/visual/overview-no-scroll.spec.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced "Good" verdict status for systems performing above minimum threshold.
  * Refined verdict classification into four tiers: Healthy (≥95), Good (≥80), Degraded (≥50), Unhealthy (<50).
  * Enhanced diagnostic messaging to differentiate clean runs from those with minor performance variation.
  * Updated snapshot eligibility and action messaging to account for performance variation patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xaedyn/chronoscope/pull/147)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->