### PR TITLE
[codex] Add score explanation to Status

### DIFF
--- a/src/lib/components/CausalVerdictStrip.svelte
+++ b/src/lib/components/CausalVerdictStrip.svelte
@@ -4,6 +4,7 @@
 <script lang="ts">
   import type { DiagnosticNarrative } from '$lib/utils/diagnostic-narrative';
   import type { HistoryBaselineInsight } from '$lib/utils/history-baseline';
+  import type { ScoreExplanation } from '$lib/utils/score-explanation';
   import type { AutoStartSuppressionReason, Endpoint } from '$lib/types';
 
   interface Props {
@@ -13,6 +14,7 @@
     avgLoss: number | null;
     drillEndpoint: Endpoint | null;
     baselineInsight?: HistoryBaselineInsight | null;
+    scoreExplanation?: ScoreExplanation | null;
     autoStartSuppressionReason?: AutoStartSuppressionReason | null;
     contextLine?: string | null;
     variant?: 'normal' | 'hero';
@@ -27,6 +29,7 @@
     avgLoss,
     drillEndpoint,
     baselineInsight = null,
+    scoreExplanation = null,
     autoStartSuppressionReason = null,
     contextLine = null,
     variant = 'normal',
@@ -76,6 +79,8 @@
     (autoStartSuppressionReason === 'local-endpoint' || autoStartSuppressionReason === 'pending-share'),
   );
   const showMetrics = $derived(suppressionMessage === null);
+  const scoreContributions = $derived(scoreExplanation?.contributions.slice(0, 4) ?? []);
+  const hiddenScoreContributions = $derived(Math.max(0, (scoreExplanation?.contributions.length ?? 0) - scoreContributions.length));
 
   const fmtInt = (n: number | null): string => (n == null ? '—' : String(Math.round(n)));
   const fmt1 = (n: number | null): string => (n == null ? '—' : n.toFixed(1));
@@ -115,7 +120,29 @@
     <p class="verdict-explanation verdict-suppression">{suppressionMessage}</p>
   {/if}
 
-  {#if contextLine}
+  {#if scoreExplanation}
+    <div
+      class="verdict-score-explainer"
+      title={scoreExplanation.detail}
+      aria-label={scoreExplanation.detail}
+    >
+      <span class="verdict-score-headline">{scoreExplanation.headline}</span>
+      <span class="verdict-score-summary">{scoreExplanation.summary}</span>
+      <span class="verdict-score-chips" aria-hidden="true">
+        {#each scoreContributions as contribution (contribution.endpointId)}
+          <span
+            class="verdict-score-chip"
+            class:healthy={contribution.bucket === 'healthy'}
+            class:degraded={contribution.bucket === 'degraded'}
+            class:unhealthy={contribution.bucket === 'unhealthy'}
+          >{contribution.label} {contribution.points}</span>
+        {/each}
+        {#if hiddenScoreContributions > 0}
+          <span class="verdict-score-chip muted">+{hiddenScoreContributions}</span>
+        {/if}
+      </span>
+    </div>
+  {:else if contextLine}
     <p class="verdict-context">{contextLine}</p>
   {/if}
 
@@ -321,6 +348,64 @@
     font-size: var(--ts-xs);
     letter-spacing: var(--tr-label);
   }
+  .verdict-score-explainer {
+    grid-column: 1 / -1;
+    margin: -6px 0 0 18px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    overflow: hidden;
+    color: var(--t2);
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-label);
+    white-space: nowrap;
+  }
+  .verdict-score-headline {
+    flex: 0 0 auto;
+    color: var(--t1);
+    font-weight: 600;
+  }
+  .verdict-score-summary {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .verdict-score-chips {
+    display: flex;
+    gap: 4px;
+    min-width: 0;
+    overflow: hidden;
+    flex: 0 1 auto;
+  }
+  .verdict-score-chip {
+    flex: 0 0 auto;
+    padding: 2px 5px;
+    border-radius: 999px;
+    border: 1px solid var(--border-mid);
+    color: var(--t3);
+    background: rgba(255, 255, 255, 0.03);
+    font-variant-numeric: tabular-nums;
+  }
+  .verdict-score-chip.healthy {
+    color: var(--accent-green);
+    border-color: rgba(134, 239, 172, 0.2);
+    background: rgba(134, 239, 172, 0.045);
+  }
+  .verdict-score-chip.degraded {
+    color: var(--accent-amber);
+    border-color: rgba(251, 191, 36, 0.22);
+    background: rgba(251, 191, 36, 0.05);
+  }
+  .verdict-score-chip.unhealthy {
+    color: var(--accent-pink);
+    border-color: rgba(249, 168, 212, 0.22);
+    background: rgba(249, 168, 212, 0.05);
+  }
+  .verdict-score-chip.muted {
+    color: var(--t4);
+  }
 
   .verdict-metrics {
     grid-column: 1;
@@ -453,6 +538,12 @@
       line-height: 1.25;
     }
     .verdict-context { margin-left: 0; }
+    .verdict-score-explainer {
+      margin-left: 0;
+      gap: 6px;
+      font-size: 10px;
+    }
+    .verdict-score-chips { display: none; }
     .verdict-metrics { flex-wrap: wrap; gap: 10px 14px; padding-top: 6px; }
     .verdict-metric-num { font-size: var(--ts-lg); }
     .verdict-extra { display: none; }
@@ -490,7 +581,8 @@
       font-size: var(--ts-lg);
     }
     .verdict.hero .verdict-explanation,
-    .verdict.hero .verdict-context {
+    .verdict.hero .verdict-context,
+    .verdict.hero .verdict-score-explainer {
       display: none;
     }
     .verdict-metrics {

--- a/src/lib/components/OverviewView.svelte
+++ b/src/lib/components/OverviewView.svelte
@@ -15,6 +15,7 @@
   import { networkQualityStore, monitoredEndpointsStore } from '$lib/stores/derived';
   import { buildDiagnosticNarrative, type DiagnosticNarrative } from '$lib/utils/diagnostic-narrative';
   import { diagnosticAlignedScore } from '$lib/utils/classify';
+  import { buildScoreExplanation } from '$lib/utils/score-explanation';
   import { buildHistoryBaselineInsight, type HistoryBaselineInsight } from '$lib/utils/history-baseline';
   import type { VerdictRow } from '$lib/utils/verdict';
   import { tokens } from '$lib/tokens';
@@ -226,6 +227,12 @@
     monitoredEndpointCount: monitored.length,
   }));
   const score = $derived(diagnosticAlignedScore(rawScore, diagnosticNarrative.severity));
+  const scoreExplanation = $derived(buildScoreExplanation({
+    rows: verdictRows,
+    threshold,
+    score,
+    rawScore,
+  }));
   // Score history ring buffer — one entry per round, max 60 entries. Driven by
   // roundCounter changes and aligned to the diagnostic narrative so the trace
   // never trends "healthy" while the answer says the run needs attention.
@@ -315,6 +322,7 @@
       {avgLoss}
       {drillEndpoint}
       baselineInsight={historyBaselineInsight}
+      {scoreExplanation}
       autoStartSuppressionReason={$uiStore.autoStartSuppressionReason}
       contextLine={runContextLine}
       onDrill={handleEnrichedDrill}

--- a/src/lib/utils/score-explanation.ts
+++ b/src/lib/utils/score-explanation.ts
@@ -1,0 +1,127 @@
+import type { EndpointStatistics } from '../types';
+import type { VerdictRow } from './verdict';
+import {
+  classify,
+  overviewVerdict,
+  VERDICT_STYLES,
+  type HealthBucket,
+  type OverviewVerdict,
+} from './classify';
+
+type ScoredBucket = Exclude<HealthBucket, 'unknown'>;
+
+export interface ScoreContribution {
+  readonly endpointId: string;
+  readonly label: string;
+  readonly bucket: ScoredBucket;
+  readonly points: number;
+  readonly reason: string;
+}
+
+export interface ScoreExplanation {
+  readonly score: number;
+  readonly rawScore: number | null;
+  readonly verdict: OverviewVerdict;
+  readonly headline: string;
+  readonly summary: string;
+  readonly detail: string;
+  readonly contributions: readonly ScoreContribution[];
+}
+
+interface ScoreExplanationInput {
+  readonly rows: readonly VerdictRow[];
+  readonly threshold: number;
+  readonly score: number | null;
+  readonly rawScore?: number | null;
+}
+
+const BUCKET_POINTS: Record<ScoredBucket, number> = {
+  healthy: 100,
+  degraded: 60,
+  unhealthy: 20,
+};
+
+function valueOrInfinity(value: number): number {
+  return Number.isFinite(value) ? value : Infinity;
+}
+
+function contributionReason(stats: EndpointStatistics, threshold: number, bucket: ScoredBucket): string {
+  const p50 = valueOrInfinity(stats.p50);
+  const p95 = valueOrInfinity(stats.p95);
+
+  if (bucket === 'healthy') return 'clean';
+  if (bucket === 'unhealthy') return 'far above threshold';
+  if (p50 > threshold) return 'median above threshold';
+  if (p95 > threshold) return 'some slower checks';
+  if (p50 > threshold / 2) return 'median above clean band';
+  return 'outside clean band';
+}
+
+function plural(count: number, singular: string, pluralForm = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : pluralForm}`;
+}
+
+function hasVerb(count: number): string {
+  return count === 1 ? 'has' : 'have';
+}
+
+function isVerb(count: number): string {
+  return count === 1 ? 'is' : 'are';
+}
+
+function summarize(contributions: readonly ScoreContribution[], capped: boolean): string {
+  const clean = contributions.filter((item) => item.reason === 'clean').length;
+  const tail = contributions.filter((item) => item.reason === 'some slower checks').length;
+  const consistentlySlow = contributions.filter((item) => item.reason === 'median above threshold').length;
+  const highMedian = contributions.filter((item) => item.reason === 'median above clean band').length;
+  const farAbove = contributions.filter((item) => item.reason === 'far above threshold').length;
+  const other = contributions.length - clean - tail - consistentlySlow - highMedian - farAbove;
+
+  const parts: string[] = [];
+  if (clean > 0) parts.push(`${plural(clean, 'site')} clean`);
+  if (tail > 0) parts.push(`${tail} ${hasVerb(tail)} some slower checks`);
+  if (consistentlySlow > 0) parts.push(`${consistentlySlow} ${isVerb(consistentlySlow)} consistently above threshold`);
+  if (highMedian > 0) parts.push(`${highMedian} ${hasVerb(highMedian)} a higher median than the clean band`);
+  if (farAbove > 0) parts.push(`${farAbove} ${isVerb(farAbove)} far above threshold`);
+  if (other > 0) parts.push(`${other} ${isVerb(other)} outside the clean band`);
+
+  const summary = `${parts.join('; ')}.`;
+  return capped ? `${summary} Score capped to match the diagnostic answer.` : summary;
+}
+
+export function buildScoreExplanation(input: ScoreExplanationInput): ScoreExplanation | null {
+  const { rows, threshold, score } = input;
+  if (score === null) return null;
+
+  const contributions = rows.flatMap((row): ScoreContribution[] => {
+    const bucket = classify(row.stats, threshold);
+    if (bucket === 'unknown') return [];
+    return [{
+      endpointId: row.ep.id,
+      label: row.ep.label,
+      bucket,
+      points: BUCKET_POINTS[bucket],
+      reason: contributionReason(row.stats, threshold, bucket),
+    }];
+  });
+  if (contributions.length === 0) return null;
+
+  const rawScore = input.rawScore ?? score;
+  const capped = rawScore !== null && score < rawScore;
+  const verdict = overviewVerdict(score);
+  const headline = `Score ${score} · ${VERDICT_STYLES[verdict].label}`;
+  const detail = [
+    `Endpoint scores: ${contributions.map((item) => `${item.label} ${item.points}: ${item.reason}`).join('; ')}.`,
+    'Ready endpoints are weighted equally; endpoints without enough data are excluded.',
+  ].join(' ');
+
+  return {
+    score,
+    rawScore,
+    verdict,
+    headline,
+    summary: summarize(contributions, capped),
+    detail,
+    contributions,
+  };
+}

--- a/tests/unit/components/CausalVerdictStrip.test.ts
+++ b/tests/unit/components/CausalVerdictStrip.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render } from '@testing-library/svelte';
 import CausalVerdictStrip from '../../../src/lib/components/CausalVerdictStrip.svelte';
 import type { DiagnosticNarrative } from '../../../src/lib/utils/diagnostic-narrative';
+import type { ScoreExplanation } from '../../../src/lib/utils/score-explanation';
 import type { Endpoint } from '../../../src/lib/types';
 
 const collectingDiagnosis = {
@@ -93,6 +94,21 @@ const drillEndpoint: Endpoint = {
   label: 'API',
   enabled: true,
   color: '#67e8f9',
+};
+
+const scoreExplanation: ScoreExplanation = {
+  score: 80,
+  rawScore: 80,
+  verdict: 'good',
+  headline: 'Score 80 · Good',
+  summary: '2 sites clean; 2 have some slower checks.',
+  detail: 'Endpoint scores: Google 100: clean; Cloudflare 100: clean; AWS 60: some slower checks; API 60: some slower checks.',
+  contributions: [
+    { endpointId: 'google', label: 'Google', bucket: 'healthy', points: 100, reason: 'clean' },
+    { endpointId: 'cloudflare', label: 'Cloudflare', bucket: 'healthy', points: 100, reason: 'clean' },
+    { endpointId: 'aws', label: 'AWS', bucket: 'degraded', points: 60, reason: 'some slower checks' },
+    { endpointId: 'api', label: 'API', bucket: 'degraded', points: 60, reason: 'some slower checks' },
+  ],
 };
 
 function renderStrip(overrides: Partial<Record<string, unknown>> = {}) {
@@ -214,5 +230,30 @@ describe('CausalVerdictStrip start CTA', () => {
     expect(getByRole('heading', { name: /API is slower than the others/i })).toBeTruthy();
     expect(queryByText(/likely that site/i)).toBeNull();
     expect(getByText(/Compare this test from outside your network/i)).toBeTruthy();
+  });
+
+  it('renders compact score evidence without hiding the diagnostic answer', () => {
+    const { getByRole, getByText } = renderStrip({
+      diagnosis: {
+        ...degradedDiagnosis,
+        verdict: { tone: 'good', headline: 'All links within tolerance.' },
+        kind: 'healthy',
+        severity: 'healthy',
+        primaryAnswer: {
+          ...degradedDiagnosis.primaryAnswer,
+          id: 'healthy',
+          kind: 'measured',
+          text: 'Looks good, with minor variation.',
+        },
+        supportingSummary: 'Good browser-visible run with variation: no site is consistently slow; 40+ successful checks across 4 sites.',
+      },
+      scoreExplanation,
+    });
+
+    expect(getByRole('heading', { name: /Looks good, with minor variation/i })).toBeTruthy();
+    expect(getByText('Score 80 · Good')).toBeTruthy();
+    expect(getByText('2 sites clean; 2 have some slower checks.')).toBeTruthy();
+    expect(getByText('Google 100')).toBeTruthy();
+    expect(getByText('API 60')).toBeTruthy();
   });
 });

--- a/tests/unit/utils/score-explanation.test.ts
+++ b/tests/unit/utils/score-explanation.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { buildScoreExplanation } from '../../../src/lib/utils/score-explanation';
+import type { Endpoint, EndpointStatistics } from '../../../src/lib/types';
+import type { VerdictRow } from '../../../src/lib/utils/verdict';
+
+function endpoint(id: string, label = id): Endpoint {
+  return {
+    id,
+    label,
+    url: `https://${id}.example.test`,
+    enabled: true,
+    color: '#67e8f9',
+  };
+}
+
+function stats(over: Partial<EndpointStatistics> = {}): EndpointStatistics {
+  return {
+    endpointId: over.endpointId ?? 'ep',
+    sampleCount: 40,
+    p50: 40,
+    p95: 80,
+    p99: 100,
+    p25: 32,
+    p75: 52,
+    p90: 70,
+    min: 25,
+    max: 110,
+    stddev: 6,
+    ci95: { lower: 36, upper: 44, margin: 4 },
+    connectionReuseDelta: null,
+    lossPercent: 0,
+    ready: true,
+    ...over,
+  };
+}
+
+function row(id: string, statOver: Partial<EndpointStatistics> = {}, label = id): VerdictRow {
+  const ep = endpoint(id, label);
+  return { ep, stats: stats({ endpointId: ep.id, ...statOver }) };
+}
+
+describe('buildScoreExplanation()', () => {
+  it('explains an 80 good score through visible endpoint contributions', () => {
+    const explanation = buildScoreExplanation({
+      rows: [
+        row('google', {}, 'Google'),
+        row('cloudflare', {}, 'Cloudflare'),
+        row('aws', { p50: 48, p95: 175 }, 'AWS'),
+        row('api', { p50: 52, p95: 170 }, 'API'),
+      ],
+      threshold: 120,
+      score: 80,
+      rawScore: 80,
+    });
+
+    expect(explanation).not.toBeNull();
+    expect(explanation?.headline).toBe('Score 80 · Good');
+    expect(explanation?.summary).toBe('2 sites clean; 2 have some slower checks.');
+    expect(explanation?.contributions.map((item) => `${item.label} ${item.points}`)).toEqual([
+      'Google 100',
+      'Cloudflare 100',
+      'AWS 60',
+      'API 60',
+    ]);
+    expect(explanation?.detail).toContain('AWS 60: some slower checks');
+    expect(explanation?.detail).not.toMatch(/cause|ISP|server is/i);
+  });
+
+  it('calls out when the displayed score is capped by a degraded diagnosis', () => {
+    const explanation = buildScoreExplanation({
+      rows: [
+        row('google', {}, 'Google'),
+        row('cloudflare', {}, 'Cloudflare'),
+        row('api', { p50: 180, p95: 240 }, 'API'),
+      ],
+      threshold: 120,
+      score: 79,
+      rawScore: 87,
+    });
+
+    expect(explanation?.headline).toBe('Score 79 · Degraded');
+    expect(explanation?.summary).toBe('2 sites clean; 1 is consistently above threshold. Score capped to match the diagnostic answer.');
+    expect(explanation?.detail).toContain('API 60: median above threshold');
+  });
+
+  it('withholds explanation copy until a score can be shown', () => {
+    const explanation = buildScoreExplanation({
+      rows: [row('google', { ready: false }, 'Google')],
+      threshold: 120,
+      score: null,
+      rawScore: null,
+    });
+
+    expect(explanation).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add a score-explanation utility that turns endpoint bucket scores into plain-language score evidence
- show a compact Status score line with the visible score band, summary, and endpoint contribution chips
- keep capped diagnostic scores explicit when the diagnostic answer forces the dial out of the healthy/good band

## Verification
- npm run typecheck
- npm run lint
- npm test
- npm run build
- npx playwright test tests/visual/overview-no-scroll.spec.ts