### PR TITLE
[codex] Clarify capped score reason

### DIFF
--- a/src/lib/components/OverviewView.svelte
+++ b/src/lib/components/OverviewView.svelte
@@ -232,6 +232,7 @@
     threshold,
     score,
     rawScore,
+    capReason: diagnosticNarrative.primaryAnswer.text,
   }));
   // Score history ring buffer — one entry per round, max 60 entries. Driven by
   // roundCounter changes and aligned to the diagnostic narrative so the trace

--- a/src/lib/utils/score-explanation.ts
+++ b/src/lib/utils/score-explanation.ts
@@ -33,6 +33,7 @@ interface ScoreExplanationInput {
   readonly threshold: number;
   readonly score: number | null;
   readonly rawScore?: number | null;
+  readonly capReason?: string | null;
 }
 
 const BUCKET_POINTS: Record<ScoredBucket, number> = {
@@ -69,7 +70,20 @@ function isVerb(count: number): string {
   return count === 1 ? 'is' : 'are';
 }
 
-function summarize(contributions: readonly ScoreContribution[], capped: boolean): string {
+function capReasonFragment(reason: string | null | undefined): string | null {
+  const trimmed = reason?.trim().replace(/[.!?]+$/, '') ?? '';
+  if (trimmed === '') return null;
+  if (/^[A-Z][a-z]/.test(trimmed)) {
+    return `${trimmed.charAt(0).toLowerCase()}${trimmed.slice(1)}`;
+  }
+  return trimmed;
+}
+
+function summarize(
+  contributions: readonly ScoreContribution[],
+  capped: boolean,
+  capReason: string | null | undefined,
+): string {
   const clean = contributions.filter((item) => item.reason === 'clean').length;
   const tail = contributions.filter((item) => item.reason === 'some slower checks').length;
   const consistentlySlow = contributions.filter((item) => item.reason === 'median above threshold').length;
@@ -86,7 +100,12 @@ function summarize(contributions: readonly ScoreContribution[], capped: boolean)
   if (other > 0) parts.push(`${other} ${isVerb(other)} outside the clean band`);
 
   const summary = `${parts.join('; ')}.`;
-  return capped ? `${summary} Score capped to match the diagnostic answer.` : summary;
+  if (!capped) return summary;
+
+  const reason = capReasonFragment(capReason);
+  return reason === null
+    ? `${summary} Score capped to match the diagnostic answer.`
+    : `${summary} Score capped because ${reason}.`;
 }
 
 export function buildScoreExplanation(input: ScoreExplanationInput): ScoreExplanation | null {
@@ -120,7 +139,7 @@ export function buildScoreExplanation(input: ScoreExplanationInput): ScoreExplan
     rawScore,
     verdict,
     headline,
-    summary: summarize(contributions, capped),
+    summary: summarize(contributions, capped, input.capReason),
     detail,
     contributions,
   };

--- a/tests/unit/utils/score-explanation.test.ts
+++ b/tests/unit/utils/score-explanation.test.ts
@@ -76,11 +76,27 @@ describe('buildScoreExplanation()', () => {
       threshold: 120,
       score: 79,
       rawScore: 87,
+      capReason: 'API is slower than the others in this test.',
     });
 
     expect(explanation?.headline).toBe('Score 79 · Degraded');
-    expect(explanation?.summary).toBe('2 sites clean; 1 is consistently above threshold. Score capped to match the diagnostic answer.');
+    expect(explanation?.summary).toBe('2 sites clean; 1 is consistently above threshold. Score capped because API is slower than the others in this test.');
     expect(explanation?.detail).toContain('API 60: median above threshold');
+  });
+
+  it('keeps capped-score reasons plain when the diagnostic answer starts with a normal word', () => {
+    const explanation = buildScoreExplanation({
+      rows: [
+        row('google', {}, 'Google'),
+        row('edge', {}, 'Edge'),
+      ],
+      threshold: 120,
+      score: 79,
+      rawScore: 100,
+      capReason: 'Latency is jumping around.',
+    });
+
+    expect(explanation?.summary).toBe('2 sites clean. Score capped because latency is jumping around.');
   });
 
   it('withholds explanation copy until a score can be shown', () => {


### PR DESCRIPTION
## Summary
- pass the diagnostic answer into score explanation when the displayed score is capped
- render capped-score copy as the specific reason, e.g. latency is jumping around
- keep fallback copy when no cap reason is available

## Verification
- npm run typecheck
- npm run lint
- npm test
- npm run build
- npx playwright test tests/visual/overview-no-scroll.spec.ts