### PR TITLE
Add Status run storyline timeline

### DIFF
--- a/docs/superpowers/plans/2026-05-13-run-storyline-implementation.md
+++ b/docs/superpowers/plans/2026-05-13-run-storyline-implementation.md
@@ -38,7 +38,9 @@ The utility must:
 - Use the latest five minutes.
 - Render at most 120 recent rounds.
 - Classify `slow` only when latency exceeds threshold.
-- Classify below-threshold `elevated` only after eight previous ok samples and both spike gates.
+- Classify below-threshold `elevated` only after eight previous ok samples and both spike gates:
+  - Absolute gate: the sample is at least 75 ms above that endpoint's median over the previous eight ok samples.
+  - Relative gate: the sample is at least 1.75x that same median.
 - Separate failures from slow samples.
 - Require two of the last three slow samples for slowdown markers.
 - Require three consecutive ok/elevated samples after a problem for recovery.
@@ -159,4 +161,3 @@ Expected: no whitespace errors; diff only touches storyline, Status integration,
 - [ ] **Step 3: Commit implementation**
 
 Commit the implementation with a clear message after verification passes.
-

--- a/docs/superpowers/plans/2026-05-13-run-storyline-implementation.md
+++ b/docs/superpowers/plans/2026-05-13-run-storyline-implementation.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Pure Run Storyline Derivation
+## Task 1: Pure Run Storyline Derivation
 
 **Files:**
 - Create: `src/lib/utils/run-storyline.ts`
@@ -54,7 +54,7 @@ Run: `npx vitest run tests/unit/utils/run-storyline.test.ts`
 
 Expected: PASS.
 
-### Task 2: Run Storyline Card Component
+## Task 2: Run Storyline Card Component
 
 **Files:**
 - Create: `src/lib/components/RunStorylineCard.svelte`
@@ -91,7 +91,7 @@ Run: `npx vitest run tests/unit/components/RunStorylineCard.test.ts`
 
 Expected: PASS.
 
-### Task 3: Status Integration And Layout Guardrails
+## Task 3: Status Integration And Layout Guardrails
 
 **Files:**
 - Modify: `src/lib/components/OverviewView.svelte`
@@ -131,7 +131,7 @@ npx playwright test tests/visual/overview-no-scroll.spec.ts
 
 Expected: all pass.
 
-### Task 4: Final Verification
+## Task 4: Final Verification
 
 **Files:**
 - All changed implementation and test files.

--- a/docs/superpowers/plans/2026-05-13-run-storyline-implementation.md
+++ b/docs/superpowers/plans/2026-05-13-run-storyline-implementation.md
@@ -1,0 +1,162 @@
+# Run Storyline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Status `Recent events` card with a compact, evidence-bound `What happened` run storyline that shows recent changes over time without copying `s80`.
+
+**Architecture:** Add a pure `buildRunStoryline` utility that turns endpoint samples into phases, endpoint micro-traces, markers, confidence, and summary copy. Render that model in a focused Svelte card, then wire it into `OverviewView` while preserving the fixed Status layout and short-height visibility.
+
+**Tech Stack:** Svelte 5, TypeScript, Vitest, Testing Library Svelte, Playwright visual tests.
+
+---
+
+### Task 1: Pure Run Storyline Derivation
+
+**Files:**
+- Create: `src/lib/utils/run-storyline.ts`
+- Create: `tests/unit/utils/run-storyline.test.ts`
+
+- [ ] **Step 1: Write failing unit tests**
+
+Create `tests/unit/utils/run-storyline.test.ts` with tests for collecting state, clean state, isolated slowdown, shared slowdown, failure markers, recovery, below-threshold elevated samples, low-confidence copy, and endpoint overflow.
+
+Run: `npx vitest run tests/unit/utils/run-storyline.test.ts`
+
+Expected: FAIL because `src/lib/utils/run-storyline.ts` does not exist.
+
+- [ ] **Step 2: Implement the pure utility**
+
+Create `src/lib/utils/run-storyline.ts` exporting:
+
+```ts
+export function buildRunStoryline(input: BuildRunStorylineInput): RunStoryline
+```
+
+The utility must:
+
+- Use only the current run window.
+- Use the latest five minutes.
+- Render at most 120 recent rounds.
+- Classify `slow` only when latency exceeds threshold.
+- Classify below-threshold `elevated` only after eight previous ok samples and both spike gates.
+- Separate failures from slow samples.
+- Require two of the last three slow samples for slowdown markers.
+- Require three consecutive ok/elevated samples after a problem for recovery.
+- Require a 15-second window for isolated/shared correlation.
+- Use confidence to choose assertive vs cautious copy.
+- Show at most four endpoint rows and summarize overflow without hiding eventful endpoints.
+
+- [ ] **Step 3: Verify utility tests pass**
+
+Run: `npx vitest run tests/unit/utils/run-storyline.test.ts`
+
+Expected: PASS.
+
+### Task 2: Run Storyline Card Component
+
+**Files:**
+- Create: `src/lib/components/RunStorylineCard.svelte`
+- Create: `tests/unit/components/RunStorylineCard.test.ts`
+
+- [ ] **Step 1: Write failing component tests**
+
+Create `tests/unit/components/RunStorylineCard.test.ts` that renders a supplied `RunStoryline` model and asserts:
+
+- The card heading is `What happened`.
+- The summary line is visible.
+- Endpoint rows render with accessible button names.
+- Overflow text renders when provided.
+- Clicking an endpoint row calls `onDrill(endpointId)`.
+
+Run: `npx vitest run tests/unit/components/RunStorylineCard.test.ts`
+
+Expected: FAIL because the component does not exist.
+
+- [ ] **Step 2: Implement the component**
+
+Create `src/lib/components/RunStorylineCard.svelte` with:
+
+- Current Chronoscope glass-card styling.
+- Header `What happened`, subtitle `Recent run timeline`, and hint `Click a moment -> Diagnose`.
+- Story rail phase segments.
+- Up to four endpoint micro-trace rows with SVG sparklines and failure markers.
+- Compact summary and overflow text.
+- Accessible labels that do not depend on color alone.
+
+- [ ] **Step 3: Verify component tests pass**
+
+Run: `npx vitest run tests/unit/components/RunStorylineCard.test.ts`
+
+Expected: PASS.
+
+### Task 3: Status Integration And Layout Guardrails
+
+**Files:**
+- Modify: `src/lib/components/OverviewView.svelte`
+- Modify: `src/lib/components/OverviewSubtabStrip.svelte`
+- Modify: `tests/visual/overview-no-scroll.spec.ts`
+
+- [ ] **Step 1: Write failing visual/layout assertions**
+
+Update `tests/visual/overview-no-scroll.spec.ts` with a short desktop assertion that the Status timeline remains reachable at `1366x768` and that `What happened` is visible or available through the visible subtab path.
+
+Run: `npx playwright test tests/visual/overview-no-scroll.spec.ts -g "recent timeline"`
+
+Expected: FAIL before wiring because `What happened` is absent.
+
+- [ ] **Step 2: Wire the new card**
+
+Modify `OverviewView.svelte` to:
+
+- Import `RunStorylineCard` and `buildRunStoryline`.
+- Build a full sample map for storyline derivation without changing the existing RacingStrip tail behavior.
+- Replace `EventFeed` with `RunStorylineCard`.
+- Route row/marker clicks to Diagnose.
+- Stop hiding the timeline card on short desktop heights; keep compact layout instead.
+
+Modify `OverviewSubtabStrip.svelte` to label the second subtab `Timeline` while preserving the internal `events` id for compatibility.
+
+- [ ] **Step 3: Verify integration**
+
+Run:
+
+```bash
+npx vitest run tests/unit/utils/run-storyline.test.ts tests/unit/components/RunStorylineCard.test.ts
+npm run typecheck
+npm run lint
+npx playwright test tests/visual/overview-no-scroll.spec.ts
+```
+
+Expected: all pass.
+
+### Task 4: Final Verification
+
+**Files:**
+- All changed implementation and test files.
+
+- [ ] **Step 1: Run focused and broad verification**
+
+Run:
+
+```bash
+npm test
+npm run build
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Review final diff**
+
+Run:
+
+```bash
+git diff --stat
+git diff --check
+```
+
+Expected: no whitespace errors; diff only touches storyline, Status integration, tests, and plan/spec docs.
+
+- [ ] **Step 3: Commit implementation**
+
+Commit the implementation with a clear message after verification passes.
+

--- a/docs/superpowers/specs/2026-05-13-run-storyline-design.md
+++ b/docs/superpowers/specs/2026-05-13-run-storyline-design.md
@@ -61,6 +61,8 @@ The card contains:
    - Example: `Click a moment -> Diagnose`.
    - Clicking a row or marker focuses the endpoint and routes to Diagnose or Live with existing store/navigation behavior.
 
+The card must remain available on the Status view at all supported desktop heights. The current implementation hides the event card on shorter desktop viewports; this feature must not inherit that behavior without a replacement. If vertical space is constrained, use a compact one-rail mode, expose the mobile subtab strip on short desktop, or move the story rail into the visible comparison stack. The user should never need to discover another view to answer "what happened recently?"
+
 ## Visual Direction
 
 The card must match the current Chronoscope aesthetic:
@@ -74,6 +76,8 @@ The card must match the current Chronoscope aesthetic:
   - Failed: small red/pink marker, not a full-row alarm unless repeated.
   - Unknown/collecting: muted gray.
 - The card should fit in the same approximate footprint as the current event feed.
+- Short-height desktop mode may reduce row height, hide optional labels, or show a single combined story rail, but it must preserve the timeline summary and at least one path to the endpoint rows.
+- Endpoint rows should show up to four visible endpoints by default. Prioritize endpoints with recent events, then focused endpoint, then current endpoint order. If more than four endpoints have recent events, show the four most severe or most recent eventful rows and make the overflow summary explicit, such as `3 more paths also changed`. If hidden endpoints are steady, use compact text such as `2 more paths steady` or `2 more paths had no events`.
 - No new decorative background treatment.
 - No large explanatory text block.
 
@@ -97,9 +101,12 @@ interface RunStoryline {
   readonly windowEnd: number;
   readonly phases: readonly StoryPhase[];
   readonly rows: readonly EndpointTimelineRow[];
+  readonly overflow: EndpointTimelineOverflow | null;
   readonly markers: readonly StoryMarker[];
   readonly summary: string;
   readonly confidence: 'collecting' | 'low' | 'medium' | 'high';
+  readonly sampleCount: number;
+  readonly readyEndpointCount: number;
 }
 
 interface StoryPhase {
@@ -113,20 +120,33 @@ interface EndpointTimelineRow {
   readonly endpointId: string;
   readonly label: string;
   readonly color: string;
+  readonly summary: string;
   readonly points: readonly TimelinePoint[];
+  readonly hiddenReason?: 'overflow';
 }
 
 interface TimelinePoint {
   readonly t: number;
+  readonly round: number;
+  readonly latency: number | null;
   readonly normalizedLatency: number | null;
-  readonly status: 'ok' | 'slow' | 'failed' | 'unknown';
+  readonly status: 'ok' | 'elevated' | 'slow' | 'failed' | 'unknown';
+  readonly threshold: number;
+  readonly sampleCount: number;
 }
 
 interface StoryMarker {
   readonly t: number;
+  readonly round?: number;
   readonly endpointId?: string;
-  readonly kind: 'slowdown' | 'failure' | 'recovery' | 'shared-change';
+  readonly kind: 'elevation' | 'slowdown' | 'failure' | 'recovery' | 'shared-change';
   readonly label: string;
+  readonly evidence: string;
+}
+
+interface EndpointTimelineOverflow {
+  readonly hiddenCount: number;
+  readonly summary: string;
 }
 ```
 
@@ -136,14 +156,33 @@ The exact type names can change during implementation, but the boundary should s
 
 The first version should stay conservative.
 
-- Use the current run window only.
-- Use the most recent bounded sample window, matching the product's existing short-run behavior.
-- Mark a sample as slow only when it crosses the configured threshold or a clearly established run-relative spike rule.
+- Use the current run window only; do not mix prior saved history into the storyline.
+- Use `windowEnd = latest sample timestamp` and `windowStart = max(runStart, windowEnd - 5 minutes)`.
+- Cap rendering density to the most recent 120 synchronized rounds. If more rounds are present in the five-minute window, downsample for drawing only; marker and summary derivation must still use the full five-minute window.
+- Use `collecting` until at least one ready endpoint has eight samples in the window. With only one ready endpoint, render the row but keep confidence `low` and avoid correlation language.
+- Mark an individual ok sample as `slow` only when `latency > threshold`.
+- Mark an individual ok sample as `elevated`, not `slow`, when it is below threshold but meets both of these gates:
+  - at least 75 ms above that endpoint's median ok latency over the previous eight ok samples, and
+  - at least 1.75x that previous median.
+  Elevated samples may shape the sparkline and create low-confidence `latency rose` language, but they must not create `slow` wording or a degraded-looking phase by themselves.
+  If the previous eight ok samples are not available, do not classify below-threshold samples as elevated.
 - Treat failed/error/timeout samples separately from slow samples.
-- Identify isolated slowdown when one endpoint worsens while most ready endpoints remain normal.
-- Identify shared slowdown only when multiple ready endpoints worsen in the same time region.
-- Use `collecting` until there are enough samples to avoid over-reading noise.
+- Create a slowdown marker only after at least two of the last three samples for that endpoint are `slow`.
+- Create a failure marker on any timeout/error sample, but phrase single failures as `had a failed request`, not `is failing`.
+- Create a recovery marker only after a marked slow/failure period is followed by at least three consecutive ok samples at or below threshold.
+- Identify isolated slowdown only when at least two endpoints are ready, exactly one ready endpoint has a slowdown marker in a 15-second window, and at least half of the other ready endpoints have ok samples at or below threshold in that same window.
+- Identify shared slowdown only when at least two ready endpoints have slowdown markers within the same 15-second window.
+- Use `low` confidence when the run has enough samples to render but fewer than 16 samples per ready endpoint, or when only one ready endpoint is usable.
+- Use `medium` confidence when at least two ready endpoints have 16 or more samples each.
+- Use `high` confidence when at least three ready endpoints have 24 or more samples each and the relevant pattern repeats across at least two adjacent sample windows.
 - Prefer saying `slowed`, `failed`, `recovered`, or `stayed clean` over diagnosis language such as `ISP`, `WiFi`, `DNS`, or `server issue`.
+
+Confidence must change copy:
+
+- `collecting`: do not assert a pattern; say Chronoscope is collecting.
+- `low`: use cautious language such as `possible brief rise` or `early signal`.
+- `medium`: allow `slowed`, `failed`, and `recovered` when the gates above are met.
+- `high`: allow stronger correlation wording such as `multiple paths slowed together`, still without root-cause claims.
 
 ## Interaction
 
@@ -161,12 +200,15 @@ Hover or focus may show a compact tooltip:
 
 The tooltip must be optional enhancement. The broad story should be understandable without hover.
 
+Tooltip and marker text must be generated from the proof-carrying model, not from display-only strings. Every visible marker needs enough structured evidence to explain timestamp, endpoint, status, threshold relationship, sample count, and whether other ready endpoints were normal in the same window.
+
 ## Empty And Edge States
 
 - No samples: `Start test to build the run timeline.`
 - Too few samples: `Collecting enough samples to show what changed.`
 - No events: show flat traces and summary `No meaningful changes in the current window.`
 - All endpoints disabled or unready: use existing endpoint readiness language where possible.
+- More than four monitored endpoints: show the four highest-priority rows and an overflow summary. The summary must not hide the existence of any slow/failure marker on an omitted endpoint.
 - Paused run: keep the last timeline visible and indicate that it is paused only if the surrounding UI does not already make that clear.
 
 ## Accessibility
@@ -188,6 +230,11 @@ Unit tests should cover the pure derivation utility:
 - Recovery is detected after a slowdown returns to normal.
 - Too few samples creates collecting state.
 - Unknown/missing samples create muted gaps.
+- Below-threshold elevated samples do not create `slow` wording.
+- Isolated slowdown requires at least two ready endpoints and normal samples from other ready endpoints in the same 15-second window.
+- Shared slowdown requires at least two ready endpoints in the same 15-second window.
+- Low-confidence runs use cautious copy.
+- More than four endpoints creates overflow without hiding eventful endpoints.
 
 Component tests should cover:
 
@@ -195,11 +242,13 @@ Component tests should cover:
 - Empty and collecting states are readable.
 - Clicking a row calls the drill handler with the correct endpoint.
 - The component fits the existing Status right-column footprint.
+- Short-height desktop mode still exposes the recent timeline in compact form or via the visible subtab path.
 
 Visual tests should cover:
 
 - Desktop Status view remains above the fold.
 - Small desktop height does not push the dial off-screen.
+- Short desktop height does not make recent history unreachable.
 - Mobile layout remains scroll-safe and does not hide timeline content behind fixed controls.
 
 ## Implementation Notes

--- a/docs/superpowers/specs/2026-05-13-run-storyline-design.md
+++ b/docs/superpowers/specs/2026-05-13-run-storyline-design.md
@@ -41,6 +41,7 @@ The card contains:
    - Rows share the same time axis as the story rail.
    - Each row renders a tiny waveform/sparkline, not blocky status pips.
    - Normal latency stays visually flat.
+   - Elevated below-threshold samples render as subtle amber points or rings with tooltip text such as `Elevated: higher than recent median but below the slow trigger`; they must not change phase color or use `slow` wording.
    - Spikes rise visibly.
    - Failed samples create a small failure marker.
    - Missing or unknown samples create a muted break, not a scary state.
@@ -77,7 +78,7 @@ The card must match the current Chronoscope aesthetic:
   - Unknown/collecting: muted gray.
 - The card should fit in the same approximate footprint as the current event feed.
 - Short-height desktop mode may reduce row height, hide optional labels, or show a single combined story rail, but it must preserve the timeline summary and at least one path to the endpoint rows.
-- Endpoint rows should show up to four visible endpoints by default. Prioritize endpoints with recent events, then focused endpoint, then current endpoint order. If more than four endpoints have recent events, show the four most severe or most recent eventful rows and make the overflow summary explicit, such as `3 more paths also changed`. If hidden endpoints are steady, use compact text such as `2 more paths steady` or `2 more paths had no events`.
+- Endpoint rows should show up to four visible endpoints by default. Prioritize endpoints with recent events, then focused endpoint, then current endpoint order. If more than four endpoints have recent events, keep the four-row display cap, show the four most severe or most recent eventful rows, and make the overflow summary explicit by event type, such as `1 more path failed, 2 more paths slowed`. If hidden endpoints are steady, use compact text such as `2 more paths steady` or `2 more paths had no events`.
 - No new decorative background treatment.
 - No large explanatory text block.
 
@@ -158,7 +159,7 @@ The first version should stay conservative.
 
 - Use the current run window only; do not mix prior saved history into the storyline.
 - Use `windowEnd = latest sample timestamp` and `windowStart = max(runStart, windowEnd - 5 minutes)`.
-- Cap rendering density to the most recent 120 synchronized rounds. If more rounds are present in the five-minute window, downsample for drawing only; marker and summary derivation must still use the full five-minute window.
+- Cap rendering density to the most recent 120 synchronized rounds. A synchronized round means samples sharing Chronoscope's measurement `round` sequence id; samples are raw endpoint observations, rounds are aligned batches from the browser measurement loop, and the five-minute window is the aggregation timespan. If more rounds are present in the five-minute window, downsample for drawing only; marker and summary derivation must still use the full five-minute window.
 - Use `collecting` until at least one ready endpoint has eight samples in the window. With only one ready endpoint, render the row but keep confidence `low` and avoid correlation language.
 - Mark an individual ok sample as `slow` only when `latency > threshold`.
 - Mark an individual ok sample as `elevated`, not `slow`, when it is below threshold but meets both of these gates:
@@ -170,11 +171,11 @@ The first version should stay conservative.
 - Create a slowdown marker only after at least two of the last three samples for that endpoint are `slow`.
 - Create a failure marker on any timeout/error sample, but phrase single failures as `had a failed request`, not `is failing`.
 - Create a recovery marker only after a marked slow/failure period is followed by at least three consecutive ok samples at or below threshold.
-- Identify isolated slowdown only when at least two endpoints are ready, exactly one ready endpoint has a slowdown marker in a 15-second window, and at least half of the other ready endpoints have ok samples at or below threshold in that same window.
+- Identify isolated slowdown only when at least two endpoints are ready, exactly one ready endpoint has a slowdown marker in a 15-second window, and at least `ceil(N / 2)` of the other ready endpoints have ok samples at or below threshold in that same window.
 - Identify shared slowdown only when at least two ready endpoints have slowdown markers within the same 15-second window.
 - Use `low` confidence when the run has enough samples to render but fewer than 16 samples per ready endpoint, or when only one ready endpoint is usable.
 - Use `medium` confidence when at least two ready endpoints have 16 or more samples each.
-- Use `high` confidence when at least three ready endpoints have 24 or more samples each and the relevant pattern repeats across at least two adjacent sample windows.
+- Use `high` confidence when at least three ready endpoints have 24 or more samples each and the relevant pattern repeats across at least two adjacent 15-second correlation buckets. Adjacent buckets are consecutive, non-overlapping 15-second windows derived from sample timestamps.
 - Prefer saying `slowed`, `failed`, `recovered`, or `stayed clean` over diagnosis language such as `ISP`, `WiFi`, `DNS`, or `server issue`.
 
 Confidence must change copy:
@@ -208,7 +209,7 @@ Tooltip and marker text must be generated from the proof-carrying model, not fro
 - Too few samples: `Collecting enough samples to show what changed.`
 - No events: show flat traces and summary `No meaningful changes in the current window.`
 - All endpoints disabled or unready: use existing endpoint readiness language where possible.
-- More than four monitored endpoints: show the four highest-priority rows and an overflow summary. The summary must not hide the existence of any slow/failure marker on an omitted endpoint.
+- More than four monitored endpoints: show the four highest-priority rows and an overflow summary while preserving the four-row cap. The summary must enumerate omitted slow/failure event types and counts, such as `1 more path failed, 2 more paths slowed`, so omitted endpoint problems are not hidden.
 - Paused run: keep the last timeline visible and indicate that it is paused only if the surrounding UI does not already make that clear.
 
 ## Accessibility

--- a/docs/superpowers/specs/2026-05-13-run-storyline-design.md
+++ b/docs/superpowers/specs/2026-05-13-run-storyline-design.md
@@ -1,0 +1,223 @@
+# Run Storyline Design
+
+## Purpose
+
+Chronoscope should make the recent run history immediately understandable without copying the visual language of `s80`. The new surface should answer: what changed, when did it change, which endpoints were involved, and what evidence supports that reading.
+
+The feature replaces the main Status view's `Recent events` card with a compact `What happened` card. It keeps the current Chronoscope layout, dial, comparison card, typography, density, and restrained technical aesthetic.
+
+## Product Goal
+
+The Status view should give a first-time user a fast, trustworthy read of the run:
+
+- Whether the connection currently looks clean, degraded, or poor.
+- Whether the recent issue was isolated to one endpoint or shared across paths.
+- When a slowdown, failure, or recovery happened.
+- What evidence Chronoscope has, without guessing root cause.
+
+The experience should feel like Chronoscope becoming clearer, not like a redesigned product.
+
+## Non-Goals
+
+- Do not add a new top-level History view in this phase.
+- Do not redesign the Status layout.
+- Do not claim ISP, WiFi, DNS, or server root cause from browser-only evidence.
+- Do not include private local companion history in shared/public output.
+- Do not make the page taller or reintroduce Status scrolling.
+
+## User Experience
+
+The lower-right Status card changes from `Recent events` to `What happened`.
+
+The card contains:
+
+1. A compact story rail across the top.
+   - The rail shows the recent run as phases over time.
+   - Example phases: `steady`, `AWS slow`, `failures`, `recovered`, `collecting`.
+   - Phase labels should be short and placed directly on or near the rail.
+
+2. Endpoint micro-trace rows.
+   - One row per monitored endpoint.
+   - Rows share the same time axis as the story rail.
+   - Each row renders a tiny waveform/sparkline, not blocky status pips.
+   - Normal latency stays visually flat.
+   - Spikes rise visibly.
+   - Failed samples create a small failure marker.
+   - Missing or unknown samples create a muted break, not a scary state.
+
+3. Event alignment markers.
+   - Important moments are marked with tiny vertical ticks that line up across the story rail and endpoint traces.
+   - Markers represent observable events: slowdown, failure, recovery, broad correlation, or not-enough-data transition.
+
+4. A plain-language summary line.
+   - The sentence should describe the observed pattern.
+   - Examples:
+     - `AWS slowed briefly; the other paths stayed clean.`
+     - `Multiple paths slowed together, then recovered.`
+     - `Fastly had failed requests; the other paths stayed reachable.`
+     - `Still collecting enough samples to show a reliable timeline.`
+
+5. A compact drill affordance.
+   - Example: `Click a moment -> Diagnose`.
+   - Clicking a row or marker focuses the endpoint and routes to Diagnose or Live with existing store/navigation behavior.
+
+## Visual Direction
+
+The card must match the current Chronoscope aesthetic:
+
+- Same glass-card treatment, border, radius, spacing, and restrained color use as `RacingStrip` and `EventFeed`.
+- Mono labels and tabular numbers where useful.
+- Existing endpoint colors should carry identity.
+- Status colors must be limited and evidence-based:
+  - Clean/normal: muted green or endpoint color at low intensity.
+  - Slow/degraded: amber or pink depending on existing severity conventions.
+  - Failed: small red/pink marker, not a full-row alarm unless repeated.
+  - Unknown/collecting: muted gray.
+- The card should fit in the same approximate footprint as the current event feed.
+- No new decorative background treatment.
+- No large explanatory text block.
+
+## Data Model
+
+The implementation should derive the card from existing browser samples:
+
+- `samplesByEndpoint`
+- endpoint metadata
+- threshold
+- current diagnostic narrative where appropriate
+- current run timing
+
+Introduce a pure utility that converts endpoint samples into a compact timeline model.
+
+Suggested model:
+
+```ts
+interface RunStoryline {
+  readonly windowStart: number;
+  readonly windowEnd: number;
+  readonly phases: readonly StoryPhase[];
+  readonly rows: readonly EndpointTimelineRow[];
+  readonly markers: readonly StoryMarker[];
+  readonly summary: string;
+  readonly confidence: 'collecting' | 'low' | 'medium' | 'high';
+}
+
+interface StoryPhase {
+  readonly start: number;
+  readonly end: number;
+  readonly label: string;
+  readonly kind: 'collecting' | 'steady' | 'isolated-slow' | 'shared-slow' | 'failure' | 'recovered';
+}
+
+interface EndpointTimelineRow {
+  readonly endpointId: string;
+  readonly label: string;
+  readonly color: string;
+  readonly points: readonly TimelinePoint[];
+}
+
+interface TimelinePoint {
+  readonly t: number;
+  readonly normalizedLatency: number | null;
+  readonly status: 'ok' | 'slow' | 'failed' | 'unknown';
+}
+
+interface StoryMarker {
+  readonly t: number;
+  readonly endpointId?: string;
+  readonly kind: 'slowdown' | 'failure' | 'recovery' | 'shared-change';
+  readonly label: string;
+}
+```
+
+The exact type names can change during implementation, but the boundary should stay pure and testable.
+
+## Derivation Rules
+
+The first version should stay conservative.
+
+- Use the current run window only.
+- Use the most recent bounded sample window, matching the product's existing short-run behavior.
+- Mark a sample as slow only when it crosses the configured threshold or a clearly established run-relative spike rule.
+- Treat failed/error/timeout samples separately from slow samples.
+- Identify isolated slowdown when one endpoint worsens while most ready endpoints remain normal.
+- Identify shared slowdown only when multiple ready endpoints worsen in the same time region.
+- Use `collecting` until there are enough samples to avoid over-reading noise.
+- Prefer saying `slowed`, `failed`, `recovered`, or `stayed clean` over diagnosis language such as `ISP`, `WiFi`, `DNS`, or `server issue`.
+
+## Interaction
+
+Clicking an endpoint row should focus that endpoint and route to Live or Diagnose using the existing interaction pattern.
+
+Clicking a marker should:
+
+- Focus the related endpoint when there is one.
+- Route to Diagnose when deeper evidence is useful.
+- Preserve current keyboard accessibility expectations.
+
+Hover or focus may show a compact tooltip:
+
+`3:42 PM · AWS slow · 4 samples · others normal`
+
+The tooltip must be optional enhancement. The broad story should be understandable without hover.
+
+## Empty And Edge States
+
+- No samples: `Start test to build the run timeline.`
+- Too few samples: `Collecting enough samples to show what changed.`
+- No events: show flat traces and summary `No meaningful changes in the current window.`
+- All endpoints disabled or unready: use existing endpoint readiness language where possible.
+- Paused run: keep the last timeline visible and indicate that it is paused only if the surrounding UI does not already make that clear.
+
+## Accessibility
+
+- The card needs an accessible label such as `Recent run timeline`.
+- Rows should expose endpoint name and short status summary.
+- Markers should be keyboard-focusable only if they perform an action.
+- SVG traces should be `aria-hidden` when equivalent text is provided.
+- Color cannot be the only signal: marker shape, row labels, and summary text must carry meaning.
+
+## Testing
+
+Unit tests should cover the pure derivation utility:
+
+- Flat clean run creates a steady phase and clean summary.
+- One endpoint spike creates isolated slowdown language.
+- Multiple endpoint spikes in the same window create shared slowdown language.
+- Failed samples create failure markers without being treated as latency spikes.
+- Recovery is detected after a slowdown returns to normal.
+- Too few samples creates collecting state.
+- Unknown/missing samples create muted gaps.
+
+Component tests should cover:
+
+- The card renders endpoint rows and story rail.
+- Empty and collecting states are readable.
+- Clicking a row calls the drill handler with the correct endpoint.
+- The component fits the existing Status right-column footprint.
+
+Visual tests should cover:
+
+- Desktop Status view remains above the fold.
+- Small desktop height does not push the dial off-screen.
+- Mobile layout remains scroll-safe and does not hide timeline content behind fixed controls.
+
+## Implementation Notes
+
+Likely files:
+
+- `src/lib/utils/run-storyline.ts`
+- `src/lib/components/RunStorylineCard.svelte`
+- `src/lib/components/OverviewView.svelte`
+- `tests/unit/run-storyline.test.ts`
+- Status visual tests in `tests/visual/`
+
+The new card can initially replace `EventFeed` in `OverviewView`. Existing event derivation may be reused or folded into the new pure utility if doing so reduces duplication.
+
+## Success Criteria
+
+- A first-time user can glance at Status and understand what happened over the last few minutes.
+- The feature is visibly Chronoscope-native and does not feel like a new design system.
+- The feature explains correlation better than `s80` without copying its visual form.
+- All claims are evidence-bound and avoid unsupported root-cause diagnosis.
+- The main page remains stable, compact, and non-scrolling on target desktop layouts.

--- a/docs/superpowers/specs/2026-05-13-run-storyline-design.md
+++ b/docs/superpowers/specs/2026-05-13-run-storyline-design.md
@@ -259,7 +259,7 @@ Likely files:
 - `src/lib/utils/run-storyline.ts`
 - `src/lib/components/RunStorylineCard.svelte`
 - `src/lib/components/OverviewView.svelte`
-- `tests/unit/run-storyline.test.ts`
+- `tests/unit/utils/run-storyline.test.ts`
 - Status visual tests in `tests/visual/`
 
 The new card can initially replace `EventFeed` in `OverviewView`. Existing event derivation may be reused or folded into the new pure utility if doing so reduces duplication.

--- a/src/lib/components/OverviewSubtabStrip.svelte
+++ b/src/lib/components/OverviewSubtabStrip.svelte
@@ -1,6 +1,6 @@
 <!-- src/lib/components/OverviewSubtabStrip.svelte -->
 <!-- Two-button segmented control that selects between the racing-strip and   -->
-<!-- event-feed cards in OverviewView's right column. Rendered on narrow      -->
+<!-- timeline cards in OverviewView's right column. Rendered on narrow        -->
 <!-- viewports only (≤1023 px) where both cards don't fit above the fold;     -->
 <!-- the parent hides this strip via CSS at desktop widths.                   -->
 <script lang="ts">
@@ -20,7 +20,7 @@
   // proper WAI-ARIA tabs relationship.
   const TABS: readonly { readonly id: Subtab; readonly label: string; readonly tabId: string; readonly panelId: string }[] = [
     { id: 'racing', label: 'Per-endpoint', tabId: 'overview-subtab-racing', panelId: 'overview-panel-racing' },
-    { id: 'events', label: 'Events', tabId: 'overview-subtab-events', panelId: 'overview-panel-events' },
+    { id: 'events', label: 'Timeline', tabId: 'overview-subtab-events', panelId: 'overview-panel-events' },
   ];
 
   function onKeydown(e: KeyboardEvent, idx: number): void {

--- a/src/lib/components/OverviewView.svelte
+++ b/src/lib/components/OverviewView.svelte
@@ -1,7 +1,7 @@
 <!-- src/lib/components/OverviewView.svelte -->
 <!-- Overview — verdict-first Status layout. Composes the CausalVerdictStrip, -->
-<!-- chronograph dial, RacingStrip, and EventFeed. Score-history /             -->
-<!-- baseline / events are derived locally here; the underlying stats + samples -->
+<!-- chronograph dial, RacingStrip, and RunStorylineCard. Score-history /      -->
+<!-- baseline / storyline are derived locally here; the underlying stats + samples -->
 <!-- flow through the monitoredEndpointsStore invariant.                        -->
 <!-- The classic Overview mode was retired in v8; pre-v10 payloads that         -->
 <!-- carried overviewMode are reset to defaults on load via persistence.ts.     -->
@@ -17,15 +17,15 @@
   import { diagnosticAlignedScore } from '$lib/utils/classify';
   import { buildScoreExplanation } from '$lib/utils/score-explanation';
   import { buildHistoryBaselineInsight, type HistoryBaselineInsight } from '$lib/utils/history-baseline';
+  import { buildRunStoryline, type RunStoryline } from '$lib/utils/run-storyline';
   import type { VerdictRow } from '$lib/utils/verdict';
   import { tokens } from '$lib/tokens';
   import ChronographDial from './ChronographDial.svelte';
   import CausalVerdictStrip from './CausalVerdictStrip.svelte';
   import RacingStrip from './RacingStrip.svelte';
-  import EventFeed from './EventFeed.svelte';
+  import RunStorylineCard from './RunStorylineCard.svelte';
   import OverviewSubtabStrip from './OverviewSubtabStrip.svelte';
   import type { Endpoint, MeasurementSample } from '$lib/types';
-  import type { FeedEvent } from './EventFeed.svelte';
 
   let { onStart }: { onStart?: () => void } = $props();
 
@@ -113,57 +113,26 @@
     return out;
   });
 
+  const storylineSamplesByEndpoint = $derived.by<Record<string, readonly MeasurementSample[]>>(() => {
+    const out: Record<string, readonly MeasurementSample[]> = {};
+    for (const ep of monitored) {
+      const m = measurements.endpoints[ep.id];
+      out[ep.id] = m ? m.samples.toArray() : [];
+    }
+    return out;
+  });
+
   const HISTORY_MAX = 60;
   let scoreHistory = $state<number[]>([]);
   let lastSeenRound = -1;
 
-  // Event ring buffer — threshold crossings + p95 shifts. Per-endpoint
-  // prev-state map tracks the comparison baseline across ticks.
-  const EVENT_MAX = 12;
-  const SHIFT_FRACTION = 0.35;
-  interface PrevState { readonly over: boolean; readonly p95: number; }
-  let prevByEp: Record<string, PrevState> = {};
-  let events = $state<FeedEvent[]>([]);
-  let lastSeenEventRound = -1;
-  $effect(() => {
-    const round = measurements.roundCounter;
-    if (round === lastSeenEventRound) return;
-    const prevRound = lastSeenEventRound;
-    lastSeenEventRound = round;
-
-    const now = Date.now();
-    const nextPrev: Record<string, PrevState> = {};
-    const newEvents: FeedEvent[] = [];
-
-    for (const ep of monitored) {
-      const lat = measurements.endpoints[ep.id]?.lastLatency ?? null;
-      const s = stats[ep.id];
-      const p95 = s?.p95 ?? 0;
-      const over = lat != null && lat > threshold;
-      const prev = prevByEp[ep.id];
-
-      if (prev !== undefined) {
-        if (over && !prev.over) {
-          newEvents.push({ t: now, epId: ep.id, kind: 'cross-up', value: lat ?? undefined, threshold });
-        } else if (!over && prev.over) {
-          newEvents.push({ t: now, epId: ep.id, kind: 'cross-down', value: lat ?? undefined, threshold });
-        }
-        // Shift event: only check every 8th round to avoid chatter.
-        if (prevRound >= 0 && round % 8 === 0 && prev.p95 > 0) {
-          const delta = Math.abs(p95 - prev.p95) / prev.p95;
-          if (delta > SHIFT_FRACTION) {
-            newEvents.push({ t: now, epId: ep.id, kind: 'shift', from: prev.p95, to: p95 });
-          }
-        }
-      }
-      nextPrev[ep.id] = { over, p95 };
-    }
-
-    prevByEp = nextPrev;
-    if (newEvents.length > 0) {
-      events = [...newEvents.reverse(), ...events].slice(0, EVENT_MAX);
-    }
-  });
+  const runStoryline: RunStoryline = $derived(buildRunStoryline({
+    endpoints: monitored,
+    samplesByEndpoint: storylineSamplesByEndpoint,
+    threshold,
+    runStart: measurements.startedAt,
+    focusedEndpointId: $uiStore.focusedEndpointId,
+  }));
 
   // Baseline — p25/median/p75 over last 120s of samples × monitored endpoints.
   // Recomputes every 5s on a setInterval, not every tick — stable band avoids
@@ -287,31 +256,10 @@
     uiStore.setActiveView('diagnose');
   }
 
-  function handleEventDrill(epId: string): void {
+  function handleStorylineDrill(epId: string): void {
     uiStore.setFocusedEndpoint(epId);
-    uiStore.setActiveView('live');
+    uiStore.setActiveView('diagnose');
   }
-
-  // Rerender clock for the event feed's relative-time labels. Ticks every
-  // second so labels age monotonically regardless of measurement cadence —
-  // a round-counter-driven clock would freeze "N s ago" between rounds or
-  // after lifecycle stops. Torn down on component destroy.
-  let nowTick = $state(Date.now());
-  let nowTimer: ReturnType<typeof setInterval> | null = null;
-  $effect(() => {
-    nowTick = Date.now();
-    if (nowTimer !== null) clearInterval(nowTimer);
-    nowTimer = setInterval(() => { nowTick = Date.now(); }, 1000);
-  });
-  onDestroy(() => {
-    if (nowTimer !== null) clearInterval(nowTimer);
-  });
-  // Include the round counter as a secondary trigger so the feed also updates
-  // on the measurement edge (not just on the 1s tick).
-  const now = $derived.by(() => {
-    void measurements.roundCounter;
-    return nowTick;
-  });
 </script>
 
 <section class="overview status-view" aria-label="Status">
@@ -347,7 +295,7 @@
       </div>
       <div
         class="overview-right"
-        data-has-events={events.length > 0 ? 'true' : 'false'}
+        data-has-events={runStoryline.markers.length > 0 ? 'true' : 'false'}
         data-subtab={$uiStore.overviewSubtab}
       >
         <div class="overview-subtab-strip">
@@ -378,11 +326,9 @@
           role="tabpanel"
           aria-labelledby="overview-subtab-events"
         >
-          <EventFeed
-            {events}
-            endpoints={monitored}
-            {now}
-            onDrill={handleEventDrill}
+          <RunStorylineCard
+            storyline={runStoryline}
+            onDrill={handleStorylineDrill}
           />
         </div>
       </div>
@@ -500,7 +446,9 @@
     .overview { --status-shell-gap: 10px; }
     .overview { padding-block: 10px; }
     .overview-grid { gap: 16px; }
-    .overview-right .card-slot--events { display: none; }
+    .overview-subtab-strip { display: block; }
+    .overview-right[data-subtab="racing"] .card-slot--events { display: none; }
+    .overview-right[data-subtab="events"] .card-slot--racing { display: none; }
   }
 
   @media (max-width: 767px) and (max-height: 860px) {

--- a/src/lib/components/OverviewView.svelte
+++ b/src/lib/components/OverviewView.svelte
@@ -98,7 +98,7 @@
     return worstEp;
   });
 
-  // ── Derived data for the dial / strip / feed cards ───────────────────────
+  // ── Derived data for the dial / strip / storyline cards ──────────────────
   // Samples slice per endpoint, materialized once per render for the racing
   // strip sparkline. 40-sample tail is enough for the spec. Using toArray()
   // copies out of the ring buffer — acceptable at N<=20 endpoints.
@@ -113,11 +113,12 @@
     return out;
   });
 
+  const STORYLINE_SOURCE_SAMPLE_CAP = 5_000;
   const storylineSamplesByEndpoint = $derived.by<Record<string, readonly MeasurementSample[]>>(() => {
     const out: Record<string, readonly MeasurementSample[]> = {};
     for (const ep of monitored) {
       const m = measurements.endpoints[ep.id];
-      out[ep.id] = m ? m.samples.toArray() : [];
+      out[ep.id] = m ? m.samples.slice(-STORYLINE_SOURCE_SAMPLE_CAP) : [];
     }
     return out;
   });

--- a/src/lib/components/RunStorylineCard.svelte
+++ b/src/lib/components/RunStorylineCard.svelte
@@ -7,6 +7,7 @@
     RunStoryline,
     StoryPhase,
     TimelinePoint,
+    StoryMarker,
   } from '$lib/utils/run-storyline';
 
   interface Props {
@@ -46,6 +47,18 @@
   function failurePoints(row: EndpointTimelineRow): readonly TimelinePoint[] {
     return row.points.filter((point) => point.status === 'failed');
   }
+
+  function elevatedPoints(row: EndpointTimelineRow): readonly TimelinePoint[] {
+    return row.points.filter((point) => point.status === 'elevated');
+  }
+
+  function markerLabel(marker: StoryMarker): string {
+    return `${marker.label}, ${marker.evidence}`;
+  }
+
+  function drillMarker(marker: StoryMarker): void {
+    if (marker.endpointId) onDrill(marker.endpointId);
+  }
 </script>
 
 <section class="storyline" aria-label="Recent run timeline" data-confidence={storyline.confidence}>
@@ -57,8 +70,8 @@
     <p class="storyline-hint">Click a moment -&gt; Diagnose</p>
   </header>
 
-  <div class="story-rail" aria-hidden="true">
-    <div class="story-phases">
+  <div class="story-rail">
+    <div class="story-phases" aria-hidden="true">
       {#each storyline.phases as phase (`${phase.kind}-${phase.start}-${phase.end}`)}
         <span
           class="story-phase"
@@ -70,12 +83,24 @@
       {/each}
     </div>
     {#each storyline.markers as marker (`${marker.kind}-${marker.endpointId ?? 'all'}-${marker.t}`)}
-      <span
-        class="story-marker"
-        data-kind={marker.kind}
-        style:left="{pct(marker.t)}%"
-        title={marker.evidence}
-      ></span>
+      {#if marker.endpointId}
+        <button
+          type="button"
+          class="story-marker"
+          data-kind={marker.kind}
+          style:left="{pct(marker.t)}%"
+          title={marker.evidence}
+          aria-label={markerLabel(marker)}
+          onclick={() => drillMarker(marker)}
+        ></button>
+      {:else}
+        <span
+          class="story-marker"
+          data-kind={marker.kind}
+          style:left="{pct(marker.t)}%"
+          title={marker.evidence}
+        ></span>
+      {/if}
     {/each}
   </div>
 
@@ -99,6 +124,15 @@
           </svg>
           {#each failurePoints(row) as point (`${row.endpointId}-${point.round}-${point.t}`)}
             <span class="story-failure" style:left="{pct(point.t)}%" aria-hidden="true">!</span>
+          {/each}
+          {#each elevatedPoints(row) as point (`${row.endpointId}-elevated-${point.round}-${point.t}`)}
+            <span
+              class="story-elevated"
+              style:left="{pct(point.t)}%"
+              style:top="{22 - Math.min(20, (point.normalizedLatency ?? 0) * 20)}px"
+              title="Elevated: higher than recent median but below the slow trigger"
+              aria-hidden="true"
+            ></span>
           {/each}
         </span>
       </button>
@@ -205,14 +239,32 @@
     position: absolute;
     top: 1px;
     bottom: -3px;
-    width: 1px;
-    background: rgba(255,255,255,.55);
-    transform: translateX(-.5px);
+    width: 10px;
+    padding: 0;
+    border: none;
+    background: transparent;
+    transform: translateX(-50%);
+    cursor: pointer;
   }
-  .story-marker[data-kind="failure"] { background: var(--accent-pink); }
-  .story-marker[data-kind="slowdown"],
-  .story-marker[data-kind="shared-change"] { background: var(--accent-amber); }
-  .story-marker[data-kind="recovery"] { background: var(--accent-green); }
+  .story-marker::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    width: 1px;
+    transform: translateX(-.5px);
+    background: rgba(255,255,255,.55);
+  }
+  .story-marker:focus-visible {
+    outline: 1.5px solid var(--accent-cyan);
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+  .story-marker[data-kind="failure"]::before { background: var(--accent-pink); }
+  .story-marker[data-kind="slowdown"]::before,
+  .story-marker[data-kind="shared-change"]::before { background: var(--accent-amber); }
+  .story-marker[data-kind="recovery"]::before { background: var(--accent-green); }
 
   .story-rows {
     display: flex;
@@ -307,6 +359,16 @@
     font-size: 10px;
     font-weight: 700;
     line-height: 1;
+  }
+  .story-elevated {
+    position: absolute;
+    width: 7px;
+    height: 7px;
+    transform: translate(-50%, -50%);
+    border-radius: 50%;
+    border: 1px solid var(--accent-amber);
+    background: rgba(251, 191, 36, .12);
+    box-shadow: 0 0 5px rgba(251, 191, 36, .28);
   }
 
   .story-footer {

--- a/src/lib/components/RunStorylineCard.svelte
+++ b/src/lib/components/RunStorylineCard.svelte
@@ -1,0 +1,364 @@
+<!-- src/lib/components/RunStorylineCard.svelte -->
+<!-- Compact recent-run storyline. Pure render: evidence derivation lives in -->
+<!-- utils/run-storyline so this component cannot invent unsupported claims. -->
+<script lang="ts">
+  import type {
+    EndpointTimelineRow,
+    RunStoryline,
+    StoryPhase,
+    TimelinePoint,
+  } from '$lib/utils/run-storyline';
+
+  interface Props {
+    storyline: RunStoryline;
+    onDrill: (endpointId: string) => void;
+  }
+
+  let { storyline, onDrill }: Props = $props();
+
+  function pct(t: number): number {
+    const span = Math.max(1, storyline.windowEnd - storyline.windowStart);
+    return Math.max(0, Math.min(100, ((t - storyline.windowStart) / span) * 100));
+  }
+
+  function phaseBasis(phase: StoryPhase): number {
+    const span = Math.max(1, storyline.windowEnd - storyline.windowStart);
+    return Math.max(4, ((phase.end - phase.start) / span) * 100);
+  }
+
+  function pathFor(row: EndpointTimelineRow): string {
+    if (row.points.length === 0) return '';
+    let d = '';
+    let prevWasGap = true;
+    for (const point of row.points) {
+      if (point.status === 'failed' || point.normalizedLatency == null) {
+        prevWasGap = true;
+        continue;
+      }
+      const x = pct(point.t);
+      const y = 22 - Math.min(20, point.normalizedLatency * 20);
+      d += `${prevWasGap ? 'M' : 'L'} ${x.toFixed(1)} ${y.toFixed(1)} `;
+      prevWasGap = false;
+    }
+    return d.trim();
+  }
+
+  function failurePoints(row: EndpointTimelineRow): readonly TimelinePoint[] {
+    return row.points.filter((point) => point.status === 'failed');
+  }
+</script>
+
+<section class="storyline" aria-label="Recent run timeline" data-confidence={storyline.confidence}>
+  <header class="storyline-header">
+    <div>
+      <h3 class="storyline-title">What happened</h3>
+      <p class="storyline-sub">Recent run timeline</p>
+    </div>
+    <p class="storyline-hint">Click a moment -&gt; Diagnose</p>
+  </header>
+
+  <div class="story-rail" aria-hidden="true">
+    <div class="story-phases">
+      {#each storyline.phases as phase (`${phase.kind}-${phase.start}-${phase.end}`)}
+        <span
+          class="story-phase"
+          data-kind={phase.kind}
+          style:flex-basis="{phaseBasis(phase)}%"
+        >
+          <span>{phase.label}</span>
+        </span>
+      {/each}
+    </div>
+    {#each storyline.markers as marker (`${marker.kind}-${marker.endpointId ?? 'all'}-${marker.t}`)}
+      <span
+        class="story-marker"
+        data-kind={marker.kind}
+        style:left="{pct(marker.t)}%"
+        title={marker.evidence}
+      ></span>
+    {/each}
+  </div>
+
+  <div class="story-rows">
+    {#each storyline.rows as row (row.endpointId)}
+      <button
+        type="button"
+        class="story-row"
+        style:--ep-color={row.color}
+        data-endpoint-id={row.endpointId}
+        aria-label="{row.label}, {row.summary}"
+        onclick={() => onDrill(row.endpointId)}
+      >
+        <span class="story-label">
+          <span class="story-dot" aria-hidden="true"></span>
+          <span class="story-name">{row.label}</span>
+        </span>
+        <span class="story-track">
+          <svg class="story-spark" viewBox="0 0 100 24" preserveAspectRatio="none" aria-hidden="true">
+            <path d={pathFor(row)} fill="none" stroke="var(--ep-color)" stroke-width="1.3" stroke-linejoin="round" stroke-linecap="round" />
+          </svg>
+          {#each failurePoints(row) as point (`${row.endpointId}-${point.round}-${point.t}`)}
+            <span class="story-failure" style:left="{pct(point.t)}%" aria-hidden="true">!</span>
+          {/each}
+        </span>
+      </button>
+    {/each}
+  </div>
+
+  <footer class="story-footer">
+    <p class="story-summary">{storyline.summary}</p>
+    {#if storyline.overflow}
+      <p class="story-overflow">{storyline.overflow.summary}</p>
+    {/if}
+  </footer>
+</section>
+
+<style>
+  .storyline {
+    background: var(--glass-bg-rail-hover);
+    border: 1px solid var(--border-mid);
+    border-radius: 14px;
+    padding: 14px 16px;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 9px;
+  }
+
+  .storyline-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    gap: 12px;
+  }
+  .storyline-title {
+    margin: 0;
+    font-size: var(--ts-lg);
+    font-weight: 500;
+    color: var(--t1);
+    letter-spacing: var(--tr-tight);
+  }
+  .storyline-sub {
+    margin: 2px 0 0;
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-kicker);
+    color: var(--t3);
+    text-transform: uppercase;
+  }
+  .storyline-hint {
+    margin: 0;
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    color: var(--t2);
+    white-space: nowrap;
+  }
+
+  .story-rail {
+    position: relative;
+    min-width: 0;
+    padding-top: 3px;
+  }
+  .story-phases {
+    display: flex;
+    height: 22px;
+    overflow: hidden;
+    border-radius: 5px;
+    background: rgba(255,255,255,.035);
+    border: 1px solid var(--border-mid);
+  }
+  .story-phase {
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    padding: 0 7px;
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    color: var(--t2);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    border-right: 1px solid rgba(255,255,255,.07);
+  }
+  .story-phase:last-child { border-right: none; }
+  .story-phase[data-kind="steady"],
+  .story-phase[data-kind="recovered"] {
+    background: rgba(74, 222, 128, .08);
+    color: var(--t2);
+  }
+  .story-phase[data-kind="isolated-slow"] {
+    background: rgba(251, 191, 36, .13);
+    color: var(--accent-amber);
+  }
+  .story-phase[data-kind="shared-slow"],
+  .story-phase[data-kind="failure"] {
+    background: rgba(249, 168, 212, .13);
+    color: var(--accent-pink);
+  }
+  .story-phase[data-kind="collecting"] {
+    background: rgba(148, 163, 184, .08);
+    color: var(--t3);
+  }
+  .story-marker {
+    position: absolute;
+    top: 1px;
+    bottom: -3px;
+    width: 1px;
+    background: rgba(255,255,255,.55);
+    transform: translateX(-.5px);
+  }
+  .story-marker[data-kind="failure"] { background: var(--accent-pink); }
+  .story-marker[data-kind="slowdown"],
+  .story-marker[data-kind="shared-change"] { background: var(--accent-amber); }
+  .story-marker[data-kind="recovery"] { background: var(--accent-green); }
+
+  .story-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+  .story-row {
+    display: grid;
+    grid-template-columns: 118px minmax(0, 1fr);
+    align-items: center;
+    gap: 10px;
+    height: 24px;
+    padding: 0 6px;
+    border: 1px solid transparent;
+    border-radius: 7px;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+  }
+  .story-row:hover {
+    background: rgba(255,255,255,.035);
+    border-color: var(--border-mid);
+  }
+  .story-row:focus-visible {
+    outline: 1.5px solid var(--accent-cyan);
+    outline-offset: 2px;
+  }
+  .story-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+  .story-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--ep-color);
+    box-shadow: 0 0 6px var(--ep-color);
+    flex: 0 0 auto;
+  }
+  .story-name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: var(--mono);
+    font-size: var(--ts-sm);
+    color: var(--t1);
+    letter-spacing: var(--tr-body);
+  }
+  .story-track {
+    position: relative;
+    height: 24px;
+    min-width: 0;
+    border-radius: 4px;
+    background:
+      linear-gradient(90deg, rgba(255,255,255,.06) 1px, transparent 1px) 0 0 / 25% 100%,
+      linear-gradient(180deg, rgba(255,255,255,.025), rgba(255,255,255,.045));
+    overflow: hidden;
+  }
+  .story-track::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 7px;
+    height: 1px;
+    background: rgba(255,255,255,.08);
+  }
+  .story-spark {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    opacity: .9;
+  }
+  .story-failure {
+    position: absolute;
+    top: 3px;
+    width: 11px;
+    height: 16px;
+    transform: translateX(-50%);
+    display: grid;
+    place-items: center;
+    border-radius: 3px;
+    background: rgba(249, 168, 212, .16);
+    color: var(--accent-pink);
+    font-family: var(--mono);
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 1;
+  }
+
+  .story-footer {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    align-items: baseline;
+    min-width: 0;
+  }
+  .story-summary,
+  .story-overflow {
+    margin: 0;
+    min-width: 0;
+    font-family: var(--mono);
+    font-size: var(--ts-sm);
+    color: var(--t2);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .story-summary { color: var(--t1); }
+  .story-overflow {
+    flex: 0 0 auto;
+    color: var(--t3);
+  }
+
+  @media (max-width: 1023px) {
+    .storyline {
+      gap: 6px;
+      padding: 10px 12px;
+    }
+    .storyline-hint { display: none; }
+    .story-phases { height: 18px; }
+    .story-row {
+      grid-template-columns: 96px minmax(0, 1fr);
+      height: 20px;
+    }
+    .story-track { height: 20px; }
+    .story-footer { display: block; }
+    .story-overflow { margin-top: 2px; }
+  }
+
+  @media (max-width: 767px) and (max-height: 760px) {
+    .storyline {
+      padding: 8px 10px;
+      gap: 5px;
+    }
+    .storyline-title { font-size: var(--ts-base); }
+    .storyline-sub { display: none; }
+    .story-phases { height: 16px; }
+    .story-phase { padding-inline: 5px; }
+    .story-row { height: 18px; }
+    .story-track { height: 18px; }
+  }
+</style>

--- a/src/lib/utils/run-storyline.ts
+++ b/src/lib/utils/run-storyline.ts
@@ -80,6 +80,7 @@ export interface EndpointTimelineOverflow {
 
 interface FullEndpointRow extends EndpointTimelineRow {
   readonly allPoints: readonly TimelinePoint[];
+  readonly markers: readonly StoryMarker[];
   readonly eventScore: number;
   readonly lastEventAt: number;
 }
@@ -110,7 +111,7 @@ export function buildRunStoryline(input: BuildRunStorylineInput): RunStoryline {
   const sampleCount = fullRows.reduce((sum, row) => sum + row.allPoints.length, 0);
   const readyRows = fullRows.filter((row) => row.allPoints.length >= MIN_RENDER_SAMPLES);
   const readyEndpointCount = readyRows.length;
-  const allMarkers = fullRows.flatMap((row) => markersForRow(row, input.threshold));
+  const allMarkers = fullRows.flatMap((row) => row.markers);
   const markers = allMarkers.sort((a, b) => a.t - b.t);
   const confidence = confidenceFor(readyRows, markers);
   const pattern = selectPattern({ rows: fullRows, markers, confidence });
@@ -168,6 +169,7 @@ function buildEndpointRow(input: {
     summary,
     points: normalizedPoints,
     allPoints,
+    markers: rowMarkers,
     eventScore,
     lastEventAt,
   };
@@ -229,10 +231,6 @@ function isElevated(latency: number, previousOkLatencies: readonly number[]): bo
   const baseline = median(previousEight);
   if (baseline <= 0) return false;
   return latency - baseline >= ELEVATED_MIN_DELTA_MS && latency >= baseline * ELEVATED_FACTOR;
-}
-
-function markersForRow(row: FullEndpointRow, threshold: number): StoryMarker[] {
-  return markersForPoints(row.label, row.endpointId, row.allPoints, threshold);
 }
 
 function markersForPoints(label: string, endpointId: string, points: readonly TimelinePoint[], threshold: number): StoryMarker[] {
@@ -452,8 +450,16 @@ function visibleRows(input: {
 
   const hiddenEventful = hidden.filter((row) => row.eventScore >= 2).length;
   const hiddenCount = hidden.length;
-  const summary = hiddenEventful > 0
-    ? `${hiddenEventful} more ${pathWord(hiddenEventful)} also changed.`
+  const hiddenFailureCount = hidden.filter((row) => row.markers.some((marker) => marker.kind === 'failure')).length;
+  const hiddenSlowCount = hidden.filter((row) => row.markers.some((marker) => marker.kind === 'slowdown')).length;
+  const hiddenElevatedCount = hidden.filter((row) => (
+    !row.markers.some((marker) => marker.kind === 'failure' || marker.kind === 'slowdown') &&
+    row.allPoints.some((point) => point.status === 'elevated')
+  )).length;
+  const summary = hiddenFailureCount > 0 || hiddenSlowCount > 0 || hiddenElevatedCount > 0
+    ? overflowEventSummary({ failed: hiddenFailureCount, slowed: hiddenSlowCount, elevated: hiddenElevatedCount })
+    : hiddenEventful > 0
+      ? `${hiddenEventful} more ${pathWord(hiddenEventful)} also changed.`
     : `${hiddenCount} more ${pathWord(hiddenCount)} steady.`;
 
   return {
@@ -474,7 +480,6 @@ function stripInternalRow(row: FullEndpointRow): EndpointTimelineRow {
 
 function confidenceFor(rows: readonly FullEndpointRow[], markers: readonly StoryMarker[]): RunStorylineConfidence {
   if (rows.length === 0) return 'collecting';
-  if (rows.some((row) => row.allPoints.length < MIN_RENDER_SAMPLES)) return 'collecting';
   if (rows.length < 2 || rows.some((row) => row.allPoints.length < MEDIUM_CONFIDENCE_SAMPLES)) return 'low';
   if (
     rows.length >= 3 &&
@@ -544,7 +549,14 @@ function hasRepeatedSharedPattern(markers: readonly StoryMarker[]): boolean {
     set.add(marker.endpointId);
     buckets.set(bucket, set);
   }
-  return [...buckets.values()].filter((set) => set.size >= 2).length >= 2;
+  const sharedBuckets = [...buckets.entries()]
+    .filter(([, set]) => set.size >= 2)
+    .map(([bucket]) => bucket)
+    .sort((a, b) => a - b);
+  for (let i = 1; i < sharedBuckets.length; i++) {
+    if (sharedBuckets[i] === sharedBuckets[i - 1] + 1) return true;
+  }
+  return false;
 }
 
 function rowSummary(label: string, points: readonly TimelinePoint[], markers: readonly StoryMarker[]): string {
@@ -595,4 +607,12 @@ function clampTime(value: number, min: number, max: number): number {
 
 function pathWord(count: number): string {
   return count === 1 ? 'path' : 'paths';
+}
+
+function overflowEventSummary(counts: { readonly failed: number; readonly slowed: number; readonly elevated: number }): string {
+  const parts: string[] = [];
+  if (counts.failed > 0) parts.push(`${counts.failed} more ${pathWord(counts.failed)} failed`);
+  if (counts.slowed > 0) parts.push(`${counts.slowed} more ${pathWord(counts.slowed)} slowed`);
+  if (counts.elevated > 0) parts.push(`${counts.elevated} more ${pathWord(counts.elevated)} rose below trigger`);
+  return `${parts.join(', ')}.`;
 }

--- a/src/lib/utils/run-storyline.ts
+++ b/src/lib/utils/run-storyline.ts
@@ -1,0 +1,598 @@
+import type { Endpoint, MeasurementSample } from '../types';
+
+const WINDOW_MS = 5 * 60 * 1000;
+const CORRELATION_WINDOW_MS = 15_000;
+const CORRELATION_HALF_WINDOW_MS = CORRELATION_WINDOW_MS / 2;
+const MAX_RENDER_ROUNDS = 120;
+const DEFAULT_MAX_ROWS = 4;
+const MIN_RENDER_SAMPLES = 8;
+const MEDIUM_CONFIDENCE_SAMPLES = 16;
+const HIGH_CONFIDENCE_SAMPLES = 24;
+const ELEVATED_MIN_DELTA_MS = 75;
+const ELEVATED_FACTOR = 1.75;
+
+export type RunStorylineConfidence = 'collecting' | 'low' | 'medium' | 'high';
+export type StoryPhaseKind = 'collecting' | 'steady' | 'isolated-slow' | 'shared-slow' | 'failure' | 'recovered';
+export type TimelinePointStatus = 'ok' | 'elevated' | 'slow' | 'failed' | 'unknown';
+export type StoryMarkerKind = 'elevation' | 'slowdown' | 'failure' | 'recovery' | 'shared-change';
+
+export interface BuildRunStorylineInput {
+  readonly endpoints: readonly Endpoint[];
+  readonly samplesByEndpoint: Readonly<Record<string, readonly MeasurementSample[]>>;
+  readonly threshold: number;
+  readonly runStart?: number | null;
+  readonly now?: number;
+  readonly focusedEndpointId?: string | null;
+  readonly maxVisibleRows?: number;
+}
+
+export interface RunStoryline {
+  readonly windowStart: number;
+  readonly windowEnd: number;
+  readonly phases: readonly StoryPhase[];
+  readonly rows: readonly EndpointTimelineRow[];
+  readonly overflow: EndpointTimelineOverflow | null;
+  readonly markers: readonly StoryMarker[];
+  readonly summary: string;
+  readonly confidence: RunStorylineConfidence;
+  readonly sampleCount: number;
+  readonly readyEndpointCount: number;
+}
+
+export interface StoryPhase {
+  readonly start: number;
+  readonly end: number;
+  readonly label: string;
+  readonly kind: StoryPhaseKind;
+}
+
+export interface EndpointTimelineRow {
+  readonly endpointId: string;
+  readonly label: string;
+  readonly color: string;
+  readonly summary: string;
+  readonly points: readonly TimelinePoint[];
+}
+
+export interface TimelinePoint {
+  readonly t: number;
+  readonly round: number;
+  readonly latency: number | null;
+  readonly normalizedLatency: number | null;
+  readonly status: TimelinePointStatus;
+  readonly threshold: number;
+  readonly sampleCount: number;
+}
+
+export interface StoryMarker {
+  readonly t: number;
+  readonly round?: number;
+  readonly endpointId?: string;
+  readonly kind: StoryMarkerKind;
+  readonly label: string;
+  readonly evidence: string;
+}
+
+export interface EndpointTimelineOverflow {
+  readonly hiddenCount: number;
+  readonly summary: string;
+}
+
+interface FullEndpointRow extends EndpointTimelineRow {
+  readonly allPoints: readonly TimelinePoint[];
+  readonly eventScore: number;
+  readonly lastEventAt: number;
+}
+
+interface PatternSelection {
+  readonly kind: 'collecting' | 'steady' | 'isolated' | 'shared' | 'failure' | 'elevated';
+  readonly primaryEndpointId?: string;
+  readonly primaryLabel?: string;
+  readonly eventAt?: number;
+  readonly recoveryAt?: number;
+}
+
+export function buildRunStoryline(input: BuildRunStorylineInput): RunStoryline {
+  const now = input.now ?? Date.now();
+  const latestSampleAt = latestTimestamp(input.samplesByEndpoint);
+  const windowEnd = latestSampleAt ?? now;
+  const windowStart = Math.max(input.runStart ?? Number.NEGATIVE_INFINITY, windowEnd - WINDOW_MS);
+  const maxVisibleRows = Math.max(1, input.maxVisibleRows ?? DEFAULT_MAX_ROWS);
+
+  const fullRows = input.endpoints.map((endpoint) => buildEndpointRow({
+    endpoint,
+    samples: input.samplesByEndpoint[endpoint.id] ?? [],
+    threshold: input.threshold,
+    windowStart,
+    windowEnd,
+  }));
+
+  const sampleCount = fullRows.reduce((sum, row) => sum + row.allPoints.length, 0);
+  const readyRows = fullRows.filter((row) => row.allPoints.length >= MIN_RENDER_SAMPLES);
+  const readyEndpointCount = readyRows.length;
+  const allMarkers = fullRows.flatMap((row) => markersForRow(row, input.threshold));
+  const markers = allMarkers.sort((a, b) => a.t - b.t);
+  const confidence = confidenceFor(readyRows, markers);
+  const pattern = selectPattern({ rows: fullRows, markers, confidence });
+  const summary = summaryFor({ pattern, rows: fullRows, markers, confidence });
+  const phases = phasesFor({
+    pattern,
+    windowStart,
+    windowEnd,
+    markers,
+  });
+  const { rows, overflow } = visibleRows({
+    rows: fullRows,
+    markers,
+    focusedEndpointId: input.focusedEndpointId ?? null,
+    maxVisibleRows,
+  });
+
+  return {
+    windowStart,
+    windowEnd,
+    phases,
+    rows,
+    overflow,
+    markers,
+    summary,
+    confidence,
+    sampleCount,
+    readyEndpointCount,
+  };
+}
+
+function buildEndpointRow(input: {
+  readonly endpoint: Endpoint;
+  readonly samples: readonly MeasurementSample[];
+  readonly threshold: number;
+  readonly windowStart: number;
+  readonly windowEnd: number;
+}): FullEndpointRow {
+  const windowSamples = input.samples
+    .filter((sample) => sample.timestamp >= input.windowStart && sample.timestamp <= input.windowEnd)
+    .sort((a, b) => a.timestamp - b.timestamp || a.round - b.round);
+  const renderRounds = newestRounds(windowSamples, MAX_RENDER_ROUNDS);
+  const allPoints = classifySamples(windowSamples, input.threshold);
+  const renderPoints = allPoints.filter((point) => renderRounds.has(point.round));
+  const normalizedPoints = normalizePoints(renderPoints, input.threshold);
+  const rowMarkers = markersForPoints(input.endpoint.label, input.endpoint.id, allPoints, input.threshold);
+  const summary = rowSummary(input.endpoint.label, normalizedPoints, rowMarkers);
+  const eventScore = eventScoreFor(normalizedPoints, rowMarkers);
+  const lastEventAt = rowMarkers.reduce((latest, marker) => Math.max(latest, marker.t), 0);
+
+  return {
+    endpointId: input.endpoint.id,
+    label: input.endpoint.label,
+    color: input.endpoint.color,
+    summary,
+    points: normalizedPoints,
+    allPoints,
+    eventScore,
+    lastEventAt,
+  };
+}
+
+function classifySamples(samples: readonly MeasurementSample[], threshold: number): TimelinePoint[] {
+  const previousOkLatencies: number[] = [];
+  const points: TimelinePoint[] = [];
+
+  for (const sample of samples) {
+    let latency: number | null = null;
+    let status: TimelinePointStatus = 'unknown';
+
+    if (sample.status === 'ok' && Number.isFinite(sample.latency)) {
+      latency = sample.latency;
+      if (sample.latency > threshold) {
+        status = 'slow';
+      } else if (previousOkLatencies.length >= 8 && isElevated(sample.latency, previousOkLatencies)) {
+        status = 'elevated';
+      } else {
+        status = 'ok';
+      }
+      previousOkLatencies.push(sample.latency);
+    } else {
+      status = 'failed';
+    }
+
+    points.push({
+      t: sample.timestamp,
+      round: sample.round,
+      latency,
+      normalizedLatency: null,
+      status,
+      threshold,
+      sampleCount: points.length + 1,
+    });
+  }
+
+  return points;
+}
+
+function normalizePoints(points: readonly TimelinePoint[], threshold: number): TimelinePoint[] {
+  const maxLatency = Math.max(
+    threshold,
+    ...points
+      .map((point) => point.latency ?? 0)
+      .filter((latency) => Number.isFinite(latency)),
+  );
+  const ceiling = Math.max(1, maxLatency * 1.1);
+  return points.map((point) => ({
+    ...point,
+    normalizedLatency: point.latency == null ? null : Math.max(0, Math.min(1, point.latency / ceiling)),
+  }));
+}
+
+function isElevated(latency: number, previousOkLatencies: readonly number[]): boolean {
+  const previousEight = previousOkLatencies.slice(-8);
+  if (previousEight.length < 8) return false;
+  const baseline = median(previousEight);
+  if (baseline <= 0) return false;
+  return latency - baseline >= ELEVATED_MIN_DELTA_MS && latency >= baseline * ELEVATED_FACTOR;
+}
+
+function markersForRow(row: FullEndpointRow, threshold: number): StoryMarker[] {
+  return markersForPoints(row.label, row.endpointId, row.allPoints, threshold);
+}
+
+function markersForPoints(label: string, endpointId: string, points: readonly TimelinePoint[], threshold: number): StoryMarker[] {
+  const markers: StoryMarker[] = [];
+  let inProblem = false;
+  let normalAfterProblem = 0;
+
+  for (let i = 0; i < points.length; i++) {
+    const point = points[i];
+    const recent = points.slice(Math.max(0, i - 2), i + 1);
+    const slowCount = recent.filter((candidate) => candidate.status === 'slow').length;
+
+    if (point.status === 'failed') {
+      markers.push({
+        t: point.t,
+        round: point.round,
+        endpointId,
+        kind: 'failure',
+        label: `${label} failed`,
+        evidence: `${label} returned a timeout or error sample.`,
+      });
+      inProblem = true;
+      normalAfterProblem = 0;
+      continue;
+    }
+
+    if (slowCount >= 2 && !inProblem) {
+      markers.push({
+        t: point.t,
+        round: point.round,
+        endpointId,
+        kind: 'slowdown',
+        label: `${label} slow`,
+        evidence: `${label} had ${slowCount} of the last ${recent.length} samples above ${Math.round(threshold)} ms.`,
+      });
+      inProblem = true;
+      normalAfterProblem = 0;
+      continue;
+    }
+
+    if (point.status === 'slow') {
+      normalAfterProblem = 0;
+      continue;
+    }
+
+    if (point.status === 'ok' || point.status === 'elevated') {
+      if (inProblem) {
+        normalAfterProblem++;
+        if (normalAfterProblem >= 3) {
+          markers.push({
+            t: point.t,
+            round: point.round,
+            endpointId,
+            kind: 'recovery',
+            label: `${label} recovered`,
+            evidence: `${label} had three consecutive samples back at or below ${Math.round(threshold)} ms.`,
+          });
+          inProblem = false;
+          normalAfterProblem = 0;
+        }
+      }
+    } else {
+      normalAfterProblem = 0;
+    }
+  }
+
+  return markers;
+}
+
+function selectPattern(input: {
+  readonly rows: readonly FullEndpointRow[];
+  readonly markers: readonly StoryMarker[];
+  readonly confidence: RunStorylineConfidence;
+}): PatternSelection {
+  if (input.confidence === 'collecting') return { kind: 'collecting' };
+
+  const slowdownMarkers = input.markers.filter((marker) => marker.kind === 'slowdown');
+  const shared = sharedSlowdown(slowdownMarkers);
+  if (shared) {
+    return {
+      kind: 'shared',
+      eventAt: shared.t,
+      recoveryAt: recoveryAfter(input.markers, shared.t),
+    };
+  }
+
+  const isolated = isolatedSlowdown(input.rows, slowdownMarkers);
+  if (isolated) {
+    const row = input.rows.find((candidate) => candidate.endpointId === isolated.endpointId);
+    return {
+      kind: 'isolated',
+      primaryEndpointId: isolated.endpointId,
+      primaryLabel: row?.label ?? isolated.endpointId,
+      eventAt: isolated.t,
+      recoveryAt: recoveryAfter(input.markers, isolated.t, isolated.endpointId),
+    };
+  }
+
+  const failure = input.markers.find((marker) => marker.kind === 'failure');
+  if (failure) {
+    const row = input.rows.find((candidate) => candidate.endpointId === failure.endpointId);
+    return {
+      kind: 'failure',
+      primaryEndpointId: failure.endpointId,
+      primaryLabel: row?.label ?? failure.endpointId,
+      eventAt: failure.t,
+      recoveryAt: recoveryAfter(input.markers, failure.t, failure.endpointId),
+    };
+  }
+
+  const elevatedRow = input.rows.find((row) => row.allPoints.some((point) => point.status === 'elevated'));
+  if (elevatedRow) {
+    return {
+      kind: 'elevated',
+      primaryEndpointId: elevatedRow.endpointId,
+      primaryLabel: elevatedRow.label,
+      eventAt: elevatedRow.allPoints.find((point) => point.status === 'elevated')?.t,
+    };
+  }
+
+  return { kind: 'steady' };
+}
+
+function summaryFor(input: {
+  readonly pattern: PatternSelection;
+  readonly rows: readonly FullEndpointRow[];
+  readonly markers: readonly StoryMarker[];
+  readonly confidence: RunStorylineConfidence;
+}): string {
+  if (input.pattern.kind === 'collecting') return 'Collecting enough samples to show what changed.';
+  if (input.pattern.kind === 'steady') return 'No meaningful changes in the current window.';
+
+  const label = input.pattern.primaryLabel ?? 'One path';
+
+  if (input.pattern.kind === 'elevated') {
+    return `${label} had a possible brief rise below the trigger; more samples will improve confidence.`;
+  }
+
+  if (input.pattern.kind === 'failure') {
+    return `${label} had a failed request; the other paths stayed reachable.`;
+  }
+
+  if (input.pattern.kind === 'shared') {
+    if (input.pattern.recoveryAt != null) return 'Multiple paths slowed together, then recovered.';
+    return 'Multiple paths slowed together, then stayed above the trigger.';
+  }
+
+  if (input.pattern.kind === 'isolated') {
+    if (input.confidence === 'low') {
+      return `${label} had an early signal above the trigger; more samples will improve confidence.`;
+    }
+    if (input.pattern.recoveryAt != null) return `${label} slowed briefly, then recovered.`;
+    return `${label} slowed briefly; the other paths stayed clean.`;
+  }
+
+  return 'No meaningful changes in the current window.';
+}
+
+function phasesFor(input: {
+  readonly pattern: PatternSelection;
+  readonly windowStart: number;
+  readonly windowEnd: number;
+  readonly markers: readonly StoryMarker[];
+}): StoryPhase[] {
+  if (input.pattern.kind === 'collecting') {
+    return [{ start: input.windowStart, end: input.windowEnd, label: 'collecting', kind: 'collecting' }];
+  }
+  if (input.pattern.kind === 'steady' || input.pattern.kind === 'elevated') {
+    return [{ start: input.windowStart, end: input.windowEnd, label: 'steady', kind: 'steady' }];
+  }
+
+  const eventAt = clampTime(input.pattern.eventAt ?? input.windowStart, input.windowStart, input.windowEnd);
+  const recoveryAt = input.pattern.recoveryAt == null
+    ? null
+    : clampTime(input.pattern.recoveryAt, input.windowStart, input.windowEnd);
+  const recoveryStart = recoveryAt == null
+    ? null
+    : recoveryAt >= input.windowEnd
+      ? Math.max(eventAt, input.windowEnd - 1_000)
+      : recoveryAt;
+  const problemEnd = recoveryStart ?? input.windowEnd;
+  const phases: StoryPhase[] = [];
+
+  addPhase(phases, input.windowStart, eventAt, 'steady', 'steady');
+  if (input.pattern.kind === 'shared') {
+    addPhase(phases, eventAt, problemEnd, 'paths slow', 'shared-slow');
+  } else if (input.pattern.kind === 'isolated') {
+    addPhase(phases, eventAt, problemEnd, `${input.pattern.primaryLabel ?? 'path'} slow`, 'isolated-slow');
+  } else if (input.pattern.kind === 'failure') {
+    addPhase(phases, eventAt, problemEnd, `${input.pattern.primaryLabel ?? 'path'} failed`, 'failure');
+  }
+  if (recoveryStart != null) addPhase(phases, recoveryStart, input.windowEnd, 'recovered', 'recovered');
+
+  return phases.length > 0 ? phases : [{ start: input.windowStart, end: input.windowEnd, label: 'steady', kind: 'steady' }];
+}
+
+function visibleRows(input: {
+  readonly rows: readonly FullEndpointRow[];
+  readonly markers: readonly StoryMarker[];
+  readonly focusedEndpointId: string | null;
+  readonly maxVisibleRows: number;
+}): { readonly rows: readonly EndpointTimelineRow[]; readonly overflow: EndpointTimelineOverflow | null } {
+  const order = new Map(input.rows.map((row, index) => [row.endpointId, index]));
+  const sorted = [...input.rows].sort((a, b) => {
+    if (b.eventScore !== a.eventScore) return b.eventScore - a.eventScore;
+    if (b.lastEventAt !== a.lastEventAt) return b.lastEventAt - a.lastEventAt;
+    if (input.focusedEndpointId != null) {
+      if (a.endpointId === input.focusedEndpointId) return -1;
+      if (b.endpointId === input.focusedEndpointId) return 1;
+    }
+    return (order.get(a.endpointId) ?? 0) - (order.get(b.endpointId) ?? 0);
+  });
+  const visible = sorted.slice(0, input.maxVisibleRows);
+  const hidden = sorted.slice(input.maxVisibleRows);
+  const visibleRowsOnly = visible.map(stripInternalRow);
+  if (hidden.length === 0) return { rows: visibleRowsOnly, overflow: null };
+
+  const hiddenEventful = hidden.filter((row) => row.eventScore >= 2).length;
+  const hiddenCount = hidden.length;
+  const summary = hiddenEventful > 0
+    ? `${hiddenEventful} more ${pathWord(hiddenEventful)} also changed.`
+    : `${hiddenCount} more ${pathWord(hiddenCount)} steady.`;
+
+  return {
+    rows: visibleRowsOnly,
+    overflow: { hiddenCount, summary },
+  };
+}
+
+function stripInternalRow(row: FullEndpointRow): EndpointTimelineRow {
+  return {
+    endpointId: row.endpointId,
+    label: row.label,
+    color: row.color,
+    summary: row.summary,
+    points: row.points,
+  };
+}
+
+function confidenceFor(rows: readonly FullEndpointRow[], markers: readonly StoryMarker[]): RunStorylineConfidence {
+  if (rows.length === 0) return 'collecting';
+  if (rows.some((row) => row.allPoints.length < MIN_RENDER_SAMPLES)) return 'collecting';
+  if (rows.length < 2 || rows.some((row) => row.allPoints.length < MEDIUM_CONFIDENCE_SAMPLES)) return 'low';
+  if (
+    rows.length >= 3 &&
+    rows.every((row) => row.allPoints.length >= HIGH_CONFIDENCE_SAMPLES) &&
+    hasRepeatedSharedPattern(markers)
+  ) {
+    return 'high';
+  }
+  return 'medium';
+}
+
+function sharedSlowdown(markers: readonly StoryMarker[]): StoryMarker | null {
+  for (const marker of markers) {
+    const endpointIds = new Set(
+      markers
+        .filter((candidate) => Math.abs(candidate.t - marker.t) <= CORRELATION_WINDOW_MS)
+        .map((candidate) => candidate.endpointId)
+        .filter((endpointId): endpointId is string => endpointId != null),
+    );
+    if (endpointIds.size >= 2) return marker;
+  }
+  return null;
+}
+
+function isolatedSlowdown(
+  rows: readonly FullEndpointRow[],
+  markers: readonly StoryMarker[],
+): StoryMarker | null {
+  const readyRows = rows.filter((row) => row.allPoints.length >= MIN_RENDER_SAMPLES);
+  if (readyRows.length < 2) return null;
+
+  for (const marker of markers) {
+    const nearby = markers.filter((candidate) => Math.abs(candidate.t - marker.t) <= CORRELATION_WINDOW_MS);
+    const nearbyEndpointIds = new Set(nearby.map((candidate) => candidate.endpointId));
+    if (nearbyEndpointIds.size !== 1) continue;
+    const otherRows = readyRows.filter((row) => row.endpointId !== marker.endpointId);
+    const normalRows = otherRows.filter((row) => hasNormalSampleNear(row, marker.t));
+    if (normalRows.length >= Math.ceil(otherRows.length / 2)) return marker;
+  }
+  return null;
+}
+
+function hasNormalSampleNear(row: FullEndpointRow, t: number): boolean {
+  return row.allPoints.some((point) => (
+    Math.abs(point.t - t) <= CORRELATION_HALF_WINDOW_MS &&
+    (point.status === 'ok' || point.status === 'elevated') &&
+    point.latency != null &&
+    point.latency <= point.threshold
+  ));
+}
+
+function recoveryAfter(markers: readonly StoryMarker[], t: number, endpointId?: string): number | undefined {
+  return markers.find((marker) => (
+    marker.kind === 'recovery' &&
+    marker.t > t &&
+    (endpointId == null || marker.endpointId === endpointId)
+  ))?.t;
+}
+
+function hasRepeatedSharedPattern(markers: readonly StoryMarker[]): boolean {
+  const slowdownMarkers = markers.filter((marker) => marker.kind === 'slowdown');
+  const buckets = new Map<number, Set<string>>();
+  for (const marker of slowdownMarkers) {
+    if (marker.endpointId == null) continue;
+    const bucket = Math.floor(marker.t / CORRELATION_WINDOW_MS);
+    const set = buckets.get(bucket) ?? new Set<string>();
+    set.add(marker.endpointId);
+    buckets.set(bucket, set);
+  }
+  return [...buckets.values()].filter((set) => set.size >= 2).length >= 2;
+}
+
+function rowSummary(label: string, points: readonly TimelinePoint[], markers: readonly StoryMarker[]): string {
+  if (markers.some((marker) => marker.kind === 'failure')) return `${label} had a failed request.`;
+  if (markers.some((marker) => marker.kind === 'slowdown')) return `${label} crossed the trigger.`;
+  if (points.some((point) => point.status === 'elevated')) return `${label} rose below the trigger.`;
+  if (points.length === 0) return `${label} has no recent samples.`;
+  return `${label} stayed clean.`;
+}
+
+function eventScoreFor(points: readonly TimelinePoint[], markers: readonly StoryMarker[]): number {
+  if (markers.some((marker) => marker.kind === 'failure')) return 4;
+  if (markers.some((marker) => marker.kind === 'slowdown')) return 3;
+  if (markers.some((marker) => marker.kind === 'recovery')) return 2;
+  if (points.some((point) => point.status === 'elevated')) return 1;
+  return 0;
+}
+
+function newestRounds(samples: readonly MeasurementSample[], maxRounds: number): Set<number> {
+  const rounds = [...new Set(samples.map((sample) => sample.round))].sort((a, b) => a - b);
+  return new Set(rounds.slice(-maxRounds));
+}
+
+function latestTimestamp(samplesByEndpoint: Readonly<Record<string, readonly MeasurementSample[]>>): number | null {
+  let latest: number | null = null;
+  for (const samples of Object.values(samplesByEndpoint)) {
+    for (const sample of samples) {
+      if (latest === null || sample.timestamp > latest) latest = sample.timestamp;
+    }
+  }
+  return latest;
+}
+
+function median(values: readonly number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = sorted.length >> 1;
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function addPhase(phases: StoryPhase[], start: number, end: number, label: string, kind: StoryPhaseKind): void {
+  if (end <= start) return;
+  phases.push({ start, end, label, kind });
+}
+
+function clampTime(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function pathWord(count: number): string {
+  return count === 1 ? 'path' : 'paths';
+}

--- a/tests/unit/components/RunStorylineCard.test.ts
+++ b/tests/unit/components/RunStorylineCard.test.ts
@@ -112,4 +112,18 @@ describe('RunStorylineCard', () => {
 
     expect(onDrill).toHaveBeenCalledWith('aws');
   });
+
+  it('drills into the clicked event marker', async () => {
+    const onDrill = vi.fn();
+    const { getByRole } = render(RunStorylineCard, {
+      props: {
+        storyline: storyline(),
+        onDrill,
+      },
+    });
+
+    await fireEvent.click(getByRole('button', { name: /AWS slow, AWS had 2 of the last 3 samples/i }));
+
+    expect(onDrill).toHaveBeenCalledWith('aws');
+  });
 });

--- a/tests/unit/components/RunStorylineCard.test.ts
+++ b/tests/unit/components/RunStorylineCard.test.ts
@@ -1,0 +1,115 @@
+import { fireEvent, render } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import RunStorylineCard from '../../../src/lib/components/RunStorylineCard.svelte';
+import type { RunStoryline } from '../../../src/lib/utils/run-storyline';
+
+const BASE = 1_765_000_000_000;
+
+function storyline(over: Partial<RunStoryline> = {}): RunStoryline {
+  return {
+    windowStart: BASE,
+    windowEnd: BASE + 60_000,
+    confidence: 'medium',
+    sampleCount: 40,
+    readyEndpointCount: 2,
+    summary: 'AWS slowed briefly; the other paths stayed clean.',
+    phases: [
+      { start: BASE, end: BASE + 30_000, label: 'steady', kind: 'steady' },
+      { start: BASE + 30_000, end: BASE + 45_000, label: 'AWS slow', kind: 'isolated-slow' },
+      { start: BASE + 45_000, end: BASE + 60_000, label: 'recovered', kind: 'recovered' },
+    ],
+    rows: [
+      {
+        endpointId: 'google',
+        label: 'Google',
+        color: '#67e8f9',
+        summary: 'Google stayed clean.',
+        points: [
+          { t: BASE, round: 1, latency: 40, normalizedLatency: 0.2, status: 'ok', threshold: 120, sampleCount: 1 },
+          { t: BASE + 30_000, round: 2, latency: 42, normalizedLatency: 0.21, status: 'ok', threshold: 120, sampleCount: 2 },
+          { t: BASE + 60_000, round: 3, latency: 41, normalizedLatency: 0.2, status: 'ok', threshold: 120, sampleCount: 3 },
+        ],
+      },
+      {
+        endpointId: 'aws',
+        label: 'AWS',
+        color: '#fbbf24',
+        summary: 'AWS crossed the trigger.',
+        points: [
+          { t: BASE, round: 1, latency: 50, normalizedLatency: 0.2, status: 'ok', threshold: 120, sampleCount: 1 },
+          { t: BASE + 30_000, round: 2, latency: 180, normalizedLatency: 0.88, status: 'slow', threshold: 120, sampleCount: 2 },
+          { t: BASE + 60_000, round: 3, latency: 55, normalizedLatency: 0.24, status: 'ok', threshold: 120, sampleCount: 3 },
+        ],
+      },
+    ],
+    markers: [
+      {
+        t: BASE + 30_000,
+        round: 2,
+        endpointId: 'aws',
+        kind: 'slowdown',
+        label: 'AWS slow',
+        evidence: 'AWS had 2 of the last 3 samples above 120 ms.',
+      },
+    ],
+    overflow: null,
+    ...over,
+  };
+}
+
+describe('RunStorylineCard', () => {
+  it('renders the native timeline heading and summary', () => {
+    const { getByRole, getByText } = render(RunStorylineCard, {
+      props: {
+        storyline: storyline(),
+        onDrill: vi.fn(),
+      },
+    });
+
+    expect(getByRole('heading', { name: 'What happened' })).toBeTruthy();
+    expect(getByText('Recent run timeline')).toBeTruthy();
+    expect(getByText('AWS slowed briefly; the other paths stayed clean.')).toBeTruthy();
+  });
+
+  it('renders endpoint rows with accessible status labels', () => {
+    const { getByRole } = render(RunStorylineCard, {
+      props: {
+        storyline: storyline(),
+        onDrill: vi.fn(),
+      },
+    });
+
+    expect(getByRole('button', { name: /Google, Google stayed clean/i })).toBeTruthy();
+    expect(getByRole('button', { name: /AWS, AWS crossed the trigger/i })).toBeTruthy();
+  });
+
+  it('renders overflow text when extra endpoints are hidden', () => {
+    const { getByText } = render(RunStorylineCard, {
+      props: {
+        storyline: storyline({
+          overflow: {
+            hiddenCount: 2,
+            summary: '2 more paths steady.',
+          },
+        }),
+        onDrill: vi.fn(),
+      },
+    });
+
+    expect(getByText('2 more paths steady.')).toBeTruthy();
+  });
+
+  it('drills into the clicked endpoint', async () => {
+    const onDrill = vi.fn();
+    const { getByRole } = render(RunStorylineCard, {
+      props: {
+        storyline: storyline(),
+        onDrill,
+      },
+    });
+
+    await fireEvent.click(getByRole('button', { name: /AWS, AWS crossed the trigger/i }));
+
+    expect(onDrill).toHaveBeenCalledWith('aws');
+  });
+});

--- a/tests/unit/utils/run-storyline.test.ts
+++ b/tests/unit/utils/run-storyline.test.ts
@@ -26,7 +26,7 @@ function sample(round: number, latency: number, over: Partial<MeasurementSample>
 
 function series(
   latencies: readonly number[],
-  statusFor: (index: number) => SampleStatus = () => 'ok',
+  statusFor: (index: number) => SampleStatus = (_index: number) => 'ok',
 ): MeasurementSample[] {
   return latencies.map((latency, index) => sample(index + 1, latency, { status: statusFor(index) }));
 }
@@ -107,6 +107,34 @@ describe('run storyline derivation', () => {
     expect(result.summary).toBe('Multiple paths slowed together, then stayed above the trigger.');
     expect(result.markers.filter((marker) => marker.kind === 'slowdown')).toHaveLength(2);
     expect(result.phases.some((phase) => phase.kind === 'shared-slow')).toBe(true);
+  });
+
+  it('uses high confidence only when shared patterns repeat in adjacent 15-second buckets', () => {
+    const repeatedShared = [
+      ...Array.from({ length: 14 }, () => 48),
+      170,
+      172,
+      169,
+      50,
+      49,
+      48,
+      ...Array.from({ length: 8 }, () => 47),
+      171,
+      173,
+      172,
+    ];
+    const result = buildRunStoryline({
+      endpoints: [endpoint('google', 'Google'), endpoint('cloudflare', 'Cloudflare'), endpoint('aws', 'AWS')],
+      samplesByEndpoint: {
+        google: series(repeatedShared),
+        cloudflare: series(repeatedShared.map((latency) => latency + 4)),
+        aws: series(repeatedShared.map((latency) => latency + 8)),
+      },
+      threshold: 120,
+      runStart: BASE,
+    });
+
+    expect(result.confidence).toBe('high');
   });
 
   it('treats failed samples as failure evidence, not latency spikes', () => {
@@ -206,5 +234,52 @@ describe('run storyline derivation', () => {
     expect(result.rows).toHaveLength(4);
     expect(result.overflow?.hiddenCount).toBe(2);
     expect(result.overflow?.summary).toContain('more paths');
+  });
+
+  it('summarizes hidden slow and failed endpoints by event type', () => {
+    const endpoints = [
+      endpoint('a', 'A'),
+      endpoint('b', 'B'),
+      endpoint('c', 'C'),
+      endpoint('d', 'D'),
+      endpoint('e', 'E'),
+      endpoint('f', 'F'),
+    ];
+    const slow = [
+      ...Array.from({ length: 14 }, () => 40),
+      180,
+      181,
+      182,
+      183,
+    ];
+    const samplesByEndpoint = {
+      a: series(Array.from({ length: 18 }, (_, index) => (index === 14 ? 0 : 40)), (index) => (
+        index === 14 ? 'timeout' : 'ok'
+      )),
+      b: series(Array.from({ length: 18 }, (_, index) => (index === 14 ? 0 : 40)), (index) => (
+        index === 14 ? 'error' : 'ok'
+      )),
+      c: series(Array.from({ length: 18 }, (_, index) => (index === 14 ? 0 : 40)), (index) => (
+        index === 14 ? 'timeout' : 'ok'
+      )),
+      d: series(Array.from({ length: 18 }, (_, index) => (index === 14 ? 0 : 40)), (index) => (
+        index === 14 ? 'error' : 'ok'
+      )),
+      e: series(Array.from({ length: 18 }, (_, index) => (index === 14 ? 0 : 40)), (index) => (
+        index === 14 ? 'timeout' : 'ok'
+      )),
+      f: series(slow),
+    };
+
+    const result = buildRunStoryline({
+      endpoints,
+      samplesByEndpoint,
+      threshold: 120,
+      runStart: BASE,
+      maxVisibleRows: 4,
+    });
+
+    expect(result.rows).toHaveLength(4);
+    expect(result.overflow?.summary).toBe('1 more path failed, 1 more path slowed.');
   });
 });

--- a/tests/unit/utils/run-storyline.test.ts
+++ b/tests/unit/utils/run-storyline.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest';
+import { buildRunStoryline } from '../../../src/lib/utils/run-storyline';
+import type { Endpoint, MeasurementSample, SampleStatus } from '../../../src/lib/types';
+
+const BASE = 1_765_000_000_000;
+
+function endpoint(id: string, label = id): Endpoint {
+  return {
+    id,
+    label,
+    url: `https://${id}.example.com/health`,
+    enabled: true,
+    color: '#67e8f9',
+  };
+}
+
+function sample(round: number, latency: number, over: Partial<MeasurementSample> = {}): MeasurementSample {
+  return {
+    round,
+    latency,
+    status: 'ok',
+    timestamp: BASE + round * 1000,
+    ...over,
+  };
+}
+
+function series(
+  latencies: readonly number[],
+  statusFor: (index: number) => SampleStatus = () => 'ok',
+): MeasurementSample[] {
+  return latencies.map((latency, index) => sample(index + 1, latency, { status: statusFor(index) }));
+}
+
+describe('run storyline derivation', () => {
+  it('stays in collecting state until at least one endpoint has eight samples', () => {
+    const result = buildRunStoryline({
+      endpoints: [endpoint('google', 'Google')],
+      samplesByEndpoint: { google: series([40, 41, 42, 40, 41, 42, 40]) },
+      threshold: 120,
+      runStart: BASE,
+    });
+
+    expect(result.confidence).toBe('collecting');
+    expect(result.summary).toContain('Collecting enough samples');
+    expect(result.markers).toEqual([]);
+  });
+
+  it('summarizes a clean multi-endpoint run as steady', () => {
+    const result = buildRunStoryline({
+      endpoints: [endpoint('google', 'Google'), endpoint('aws', 'AWS')],
+      samplesByEndpoint: {
+        google: series(Array.from({ length: 16 }, () => 42)),
+        aws: series(Array.from({ length: 16 }, () => 55)),
+      },
+      threshold: 120,
+      runStart: BASE,
+    });
+
+    expect(result.confidence).toBe('medium');
+    expect(result.summary).toBe('No meaningful changes in the current window.');
+    expect(result.phases).toHaveLength(1);
+    expect(result.phases[0]?.kind).toBe('steady');
+    expect(result.markers).toEqual([]);
+  });
+
+  it('detects an isolated slowdown only when other ready endpoints stayed normal in the same window', () => {
+    const result = buildRunStoryline({
+      endpoints: [endpoint('google', 'Google'), endpoint('aws', 'AWS')],
+      samplesByEndpoint: {
+        google: series(Array.from({ length: 20 }, () => 45)),
+        aws: series([
+          ...Array.from({ length: 16 }, () => 50),
+          180,
+          185,
+          190,
+          188,
+        ]),
+      },
+      threshold: 120,
+      runStart: BASE,
+    });
+
+    expect(result.summary).toBe('AWS slowed briefly; the other paths stayed clean.');
+    expect(result.markers.some((marker) => marker.kind === 'slowdown' && marker.endpointId === 'aws')).toBe(true);
+    expect(result.phases.some((phase) => phase.kind === 'isolated-slow')).toBe(true);
+  });
+
+  it('detects shared slowdown when multiple endpoints cross threshold in the same 15-second window', () => {
+    const slowTail = [
+      ...Array.from({ length: 16 }, () => 48),
+      170,
+      172,
+      169,
+      171,
+    ];
+    const result = buildRunStoryline({
+      endpoints: [endpoint('google', 'Google'), endpoint('cloudflare', 'Cloudflare'), endpoint('aws', 'AWS')],
+      samplesByEndpoint: {
+        google: series(slowTail),
+        cloudflare: series(slowTail.map((latency) => latency + 8)),
+        aws: series(Array.from({ length: 20 }, () => 54)),
+      },
+      threshold: 120,
+      runStart: BASE,
+    });
+
+    expect(result.summary).toBe('Multiple paths slowed together, then stayed above the trigger.');
+    expect(result.markers.filter((marker) => marker.kind === 'slowdown')).toHaveLength(2);
+    expect(result.phases.some((phase) => phase.kind === 'shared-slow')).toBe(true);
+  });
+
+  it('treats failed samples as failure evidence, not latency spikes', () => {
+    const result = buildRunStoryline({
+      endpoints: [endpoint('fastly', 'Fastly'), endpoint('google', 'Google')],
+      samplesByEndpoint: {
+        fastly: series(Array.from({ length: 16 }, (_, index) => (index === 12 ? 0 : 45)), (index) => (
+          index === 12 ? 'timeout' : 'ok'
+        )),
+        google: series(Array.from({ length: 16 }, () => 44)),
+      },
+      threshold: 120,
+      runStart: BASE,
+    });
+
+    expect(result.summary).toBe('Fastly had a failed request; the other paths stayed reachable.');
+    expect(result.markers.some((marker) => marker.kind === 'failure' && marker.endpointId === 'fastly')).toBe(true);
+    expect(result.markers.some((marker) => marker.kind === 'slowdown')).toBe(false);
+  });
+
+  it('adds recovery after a marked problem has three normal samples', () => {
+    const result = buildRunStoryline({
+      endpoints: [endpoint('aws', 'AWS'), endpoint('google', 'Google')],
+      samplesByEndpoint: {
+        aws: series([
+          ...Array.from({ length: 12 }, () => 50),
+          180,
+          182,
+          181,
+          52,
+          51,
+          50,
+        ]),
+        google: series(Array.from({ length: 18 }, () => 44)),
+      },
+      threshold: 120,
+      runStart: BASE,
+    });
+
+    expect(result.markers.some((marker) => marker.kind === 'recovery' && marker.endpointId === 'aws')).toBe(true);
+    expect(result.phases.some((phase) => phase.kind === 'recovered')).toBe(true);
+    expect(result.summary).toBe('AWS slowed briefly, then recovered.');
+  });
+
+  it('does not promote below-threshold elevated latency to slow wording', () => {
+    const result = buildRunStoryline({
+      endpoints: [endpoint('aws', 'AWS')],
+      samplesByEndpoint: {
+        aws: series([
+          ...Array.from({ length: 8 }, () => 40),
+          120,
+          118,
+          119,
+        ]),
+      },
+      threshold: 150,
+      runStart: BASE,
+    });
+
+    expect(result.confidence).toBe('low');
+    expect(result.rows[0]?.points.some((point) => point.status === 'elevated')).toBe(true);
+    expect(result.markers.some((marker) => marker.kind === 'slowdown')).toBe(false);
+    expect(result.summary).toContain('possible brief rise');
+    expect(result.summary).not.toMatch(/slowed/i);
+  });
+
+  it('prioritizes eventful endpoints before overflow rows', () => {
+    const endpoints = [
+      endpoint('a', 'A'),
+      endpoint('b', 'B'),
+      endpoint('c', 'C'),
+      endpoint('d', 'D'),
+      endpoint('e', 'E'),
+      endpoint('f', 'F'),
+    ];
+    const samplesByEndpoint = Object.fromEntries(endpoints.map((ep) => [
+      ep.id,
+      series(Array.from({ length: 18 }, () => 40)),
+    ]));
+    samplesByEndpoint.f = series([
+      ...Array.from({ length: 14 }, () => 40),
+      180,
+      181,
+      182,
+      183,
+    ]);
+
+    const result = buildRunStoryline({
+      endpoints,
+      samplesByEndpoint,
+      threshold: 120,
+      runStart: BASE,
+      maxVisibleRows: 4,
+    });
+
+    expect(result.rows.map((row) => row.endpointId)).toContain('f');
+    expect(result.rows).toHaveLength(4);
+    expect(result.overflow?.hiddenCount).toBe(2);
+    expect(result.overflow?.summary).toContain('more paths');
+  });
+});

--- a/tests/visual/overview-no-scroll.spec.ts
+++ b/tests/visual/overview-no-scroll.spec.ts
@@ -262,11 +262,14 @@ test.describe('Status — no scroll on first visit', () => {
       `internal scrollers with hidden content: ${JSON.stringify(state.overflowingScrollers, null, 2)}`,
     ).toEqual([]);
 
-    const reachability = await page.evaluate(() => {
-      const timelineHeading = Array.from(document.querySelectorAll<HTMLElement>('h3'))
-        .find((heading) => heading.textContent?.trim() === 'What happened');
-      const timelineTab = Array.from(document.querySelectorAll<HTMLElement>('button[role="tab"]'))
-        .find((tab) => tab.textContent?.trim() === 'Timeline');
+    const reachability = await page.evaluate(async () => {
+      const findTimelineHeading = () =>
+        Array.from(document.querySelectorAll<HTMLElement>('h3')).find(
+          (heading) => heading.textContent?.trim() === 'What happened',
+        );
+      const timelineTab = Array.from(document.querySelectorAll<HTMLElement>('button[role="tab"]')).find(
+        (tab) => tab.textContent?.trim() === 'Timeline',
+      );
       const visible = (element: HTMLElement | undefined): boolean => {
         if (!element) return false;
         const rect = element.getBoundingClientRect();
@@ -281,9 +284,36 @@ test.describe('Status — no scroll on first visit', () => {
           rect.bottom <= viewportH
         );
       };
+      const intersectsViewport = (element: HTMLElement | undefined): boolean => {
+        if (!element) return false;
+        const rect = element.getBoundingClientRect();
+        const style = getComputedStyle(element);
+        const viewportH = window.innerHeight || document.documentElement.clientHeight;
+        return (
+          style.display !== 'none' &&
+          style.visibility !== 'hidden' &&
+          rect.width > 0 &&
+          rect.height > 0 &&
+          rect.bottom > 0 &&
+          rect.top < viewportH
+        );
+      };
+      let headingVisible = visible(findTimelineHeading());
+      const tabVisible = intersectsViewport(timelineTab);
+
+      if (!headingVisible && tabVisible && timelineTab) {
+        timelineTab.click();
+        const deadline = performance.now() + 800;
+        while (performance.now() < deadline) {
+          await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+          headingVisible = visible(findTimelineHeading());
+          if (headingVisible) break;
+        }
+      }
+
       return {
-        headingVisible: visible(timelineHeading),
-        tabVisible: visible(timelineTab),
+        headingVisible,
+        tabVisible,
       };
     });
 

--- a/tests/visual/overview-no-scroll.spec.ts
+++ b/tests/visual/overview-no-scroll.spec.ts
@@ -250,7 +250,7 @@ test.describe('Status — no scroll on first visit', () => {
     ).toBeLessThanOrEqual(warning.main!.bottom - 4);
   });
 
-  test('recent timeline remains reachable on short desktop viewports', async ({ page }) => {
+  test('recent timeline remains reachable on short desktop viewport (1366x768)', async ({ page }) => {
     await page.setViewportSize({ width: 1366, height: 768 });
     await page.goto('/');
     await page.waitForSelector('#chronoscope-root');
@@ -271,7 +271,15 @@ test.describe('Status — no scroll on first visit', () => {
         if (!element) return false;
         const rect = element.getBoundingClientRect();
         const style = getComputedStyle(element);
-        return style.display !== 'none' && style.visibility !== 'hidden' && rect.width > 0 && rect.height > 0;
+        const viewportH = window.innerHeight || document.documentElement.clientHeight;
+        return (
+          style.display !== 'none' &&
+          style.visibility !== 'hidden' &&
+          rect.width > 0 &&
+          rect.height > 0 &&
+          rect.top >= 0 &&
+          rect.bottom <= viewportH
+        );
       };
       return {
         headingVisible: visible(timelineHeading),

--- a/tests/visual/overview-no-scroll.spec.ts
+++ b/tests/visual/overview-no-scroll.spec.ts
@@ -250,6 +250,41 @@ test.describe('Status — no scroll on first visit', () => {
     ).toBeLessThanOrEqual(warning.main!.bottom - 4);
   });
 
+  test('recent timeline remains reachable on short desktop viewports', async ({ page }) => {
+    await page.setViewportSize({ width: 1366, height: 768 });
+    await page.goto('/');
+    await page.waitForSelector('#chronoscope-root');
+    await page.waitForTimeout(400);
+
+    const state = await scrollState(page);
+    expect(
+      state.overflowingScrollers,
+      `internal scrollers with hidden content: ${JSON.stringify(state.overflowingScrollers, null, 2)}`,
+    ).toEqual([]);
+
+    const reachability = await page.evaluate(() => {
+      const timelineHeading = Array.from(document.querySelectorAll<HTMLElement>('h3'))
+        .find((heading) => heading.textContent?.trim() === 'What happened');
+      const timelineTab = Array.from(document.querySelectorAll<HTMLElement>('button[role="tab"]'))
+        .find((tab) => tab.textContent?.trim() === 'Timeline');
+      const visible = (element: HTMLElement | undefined): boolean => {
+        if (!element) return false;
+        const rect = element.getBoundingClientRect();
+        const style = getComputedStyle(element);
+        return style.display !== 'none' && style.visibility !== 'hidden' && rect.width > 0 && rect.height > 0;
+      };
+      return {
+        headingVisible: visible(timelineHeading),
+        tabVisible: visible(timelineTab),
+      };
+    });
+
+    expect(
+      reachability.headingVisible || reachability.tabVisible,
+      `timeline should be visible or reachable via visible tab: ${JSON.stringify(reachability)}`,
+    ).toBe(true);
+  });
+
   test('lifecycle stability @ mobile-floor (no reflow after engine starts)', async ({ page }) => {
     await page.setViewportSize({ width: 360, height: 780 });
     await page.goto('/');


### PR DESCRIPTION
## Summary
- Add a pure run-storyline model that derives phases, endpoint traces, markers, confidence, and evidence-bound summary copy from current-run samples.
- Replace the Status Recent events card with a native What happened timeline card showing story rail, endpoint micro-traces, failure markers, overflow text, and Diagnose drill-through.
- Keep short desktop layouts non-scrolling by exposing the Timeline subtab instead of hiding recent history.

## Test Plan
- [x] npm test
- [x] npm run build
- [x] npm run typecheck
- [x] npm run lint
- [x] npx playwright test tests/visual/overview-no-scroll.spec.ts
- [x] Local browser smoke at 1440x920 and 1366x768

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "What happened" timeline card to Overview, displaying recent run activity with per-endpoint status rows, event markers (slowdowns, failures, recovery), and plain-language summaries for quick run insights.
  * Renamed "Events" tab to "Timeline" for improved clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xaedyn/chronoscope/pull/150)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->