### PR TITLE
[codex] Make run timeline readable

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import noRawVisualValues from './eslint-rules/no-raw-visual-values.js';
 
 export default tseslint.config(
   {
-    ignores: ['dist/**', 'node_modules/**', '*.min.js'],
+    ignores: ['dist/**', 'node_modules/**', 'tests/**', '*.min.js'],
   },
   ...tseslint.configs.strict,
   ...sveltePlugin.configs['flat/recommended'],

--- a/src/lib/components/CausalVerdictStrip.svelte
+++ b/src/lib/components/CausalVerdictStrip.svelte
@@ -574,11 +574,17 @@
 
   @media (max-width: 767px) and (max-height: 860px) {
     .verdict.hero {
-      padding: 8px 10px;
-      gap: 6px;
+      padding: 6px 10px;
+      gap: 4px;
     }
+    .verdict-main { gap: 6px; }
     .verdict.hero .verdict-headline {
       font-size: var(--ts-lg);
+    }
+    .verdict-confidence,
+    .verdict-baseline-chip {
+      padding: 1px 5px;
+      font-size: 9px;
     }
     .verdict.hero .verdict-explanation,
     .verdict.hero .verdict-context,
@@ -591,6 +597,9 @@
     }
     .verdict-metric-num {
       font-size: var(--ts-md);
+    }
+    .verdict-drill {
+      padding: 5px 8px;
     }
   }
 </style>

--- a/src/lib/components/OverviewSubtabStrip.svelte
+++ b/src/lib/components/OverviewSubtabStrip.svelte
@@ -64,6 +64,7 @@
   button[role="tab"] {
     background: transparent;
     border: none;
+    border-radius: 7px 7px 0 0;
     color: var(--t3);
     font-family: var(--sans);
     font-size: var(--ts-sm);
@@ -71,7 +72,7 @@
     padding: 8px 12px 10px;
     cursor: pointer;
     position: relative;
-    transition: color 140ms ease;
+    transition: color 120ms ease;
   }
   button[role="tab"]::after {
     content: '';
@@ -79,12 +80,15 @@
     left: 8px; right: 8px; bottom: -1px;
     height: 2px;
     background: transparent;
-    transition: background 140ms ease;
   }
-  button[role="tab"].active {
+  button[role="tab"].active,
+  button[role="tab"][aria-selected="true"] {
+    background: rgba(103, 232, 249, 0.08);
+    box-shadow: inset 0 0 0 1px rgba(103, 232, 249, 0.18);
     color: var(--t1);
   }
-  button[role="tab"].active::after {
+  button[role="tab"].active::after,
+  button[role="tab"][aria-selected="true"]::after {
     background: var(--accent-cyan);
   }
   button[role="tab"]:focus-visible {

--- a/src/lib/components/OverviewView.svelte
+++ b/src/lib/components/OverviewView.svelte
@@ -405,6 +405,10 @@
     min-width: 0;
     min-height: 0;
   }
+  .card-slot {
+    min-width: 0;
+    min-height: 0;
+  }
   /* Desktop: both racing and events live side-by-side in the right column
      (the 2-col grid above stacks them vertically). The subtab strip is
      hidden — it only exists as a mobile affordance. */
@@ -422,6 +426,10 @@
     }
     .overview-right {
       height: var(--status-mobile-detail-row-h);
+      overflow: hidden;
+    }
+    .card-slot {
+      flex: 1 1 0;
       overflow: hidden;
     }
     /* Narrow viewports: expose the subtab strip and render only the active

--- a/src/lib/components/RunStorylineCard.svelte
+++ b/src/lib/components/RunStorylineCard.svelte
@@ -59,9 +59,15 @@
     }
     return positions.map((position) => {
       const age = span * (1 - position);
-      const label = position === 1 ? 'now' : position === 0 ? `${durationLabel(age)} ago` : durationLabel(age);
+      const label = axisTickLabel(position, age);
       return { pct: position * 100, label };
     });
+  }
+
+  function axisTickLabel(position: number, age: number): string {
+    if (position === 1) return 'now';
+    if (position === 0) return `${durationLabel(age)} ago`;
+    return durationLabel(age);
   }
 
   function pct(t: number): number {
@@ -74,8 +80,12 @@
     return Math.max(4, ((phase.end - phase.start) / span) * 100);
   }
 
-  function sparkY(point: Pick<TimelinePoint, 'normalizedLatency'>): number {
+  function sparkSvgY(point: Pick<TimelinePoint, 'normalizedLatency'>): number {
     return SPARK_BASELINE_Y - Math.min(SPARK_RANGE_Y, (point.normalizedLatency ?? 0) * SPARK_RANGE_Y);
+  }
+
+  function sparkY(point: Pick<TimelinePoint, 'normalizedLatency'>): number {
+    return (sparkSvgY(point) / SPARK_VIEWBOX_HEIGHT) * 100;
   }
 
   function pathFor(row: EndpointTimelineRow): string {
@@ -88,7 +98,7 @@
         continue;
       }
       const x = pct(point.t);
-      const y = sparkY(point);
+      const y = sparkSvgY(point);
       d += `${prevWasGap ? 'M' : 'L'} ${x.toFixed(1)} ${y.toFixed(1)} `;
       prevWasGap = false;
     }
@@ -245,13 +255,13 @@
             />
           </svg>
           {#each failurePoints(row) as point (`${row.endpointId}-${point.round}-${point.t}`)}
-            <span class="story-failure" style:left="{pct(point.t)}%" style:top="{sparkY(point)}px" aria-hidden="true">!</span>
+            <span class="story-failure" style:left="{pct(point.t)}%" style:top="{sparkY(point)}%" aria-hidden="true">!</span>
           {/each}
           {#each elevatedPoints(row) as point (`${row.endpointId}-elevated-${point.round}-${point.t}`)}
             <span
               class="story-elevated"
               style:left="{pct(point.t)}%"
-              style:top="{sparkY(point)}px"
+              style:top="{sparkY(point)}%"
               title="Elevated: higher than recent median but below the slow trigger"
               aria-hidden="true"
             ></span>

--- a/src/lib/components/RunStorylineCard.svelte
+++ b/src/lib/components/RunStorylineCard.svelte
@@ -1,5 +1,5 @@
 <!-- src/lib/components/RunStorylineCard.svelte -->
-<!-- Compact recent-run storyline. Pure render: evidence derivation lives in -->
+<!-- Recent-run storyline. Pure render: evidence derivation lives in -->
 <!-- utils/run-storyline so this component cannot invent unsupported claims. -->
 <script lang="ts">
   import type {
@@ -8,6 +8,7 @@
     StoryPhase,
     TimelinePoint,
     StoryMarker,
+    StoryMarkerKind,
   } from '$lib/utils/run-storyline';
 
   interface Props {
@@ -15,16 +16,66 @@
     onDrill: (endpointId: string) => void;
   }
 
+  const SPARK_VIEWBOX_HEIGHT = 40;
+  const SPARK_BASELINE_Y = 34;
+  const SPARK_RANGE_Y = 28;
+  const LEGEND_ITEMS: readonly { readonly kind: TimelinePoint['status']; readonly label: string }[] = [
+    { kind: 'ok', label: 'steady' },
+    { kind: 'elevated', label: 'elevated' },
+    { kind: 'slow', label: 'slow' },
+    { kind: 'failed', label: 'failed' },
+  ];
+
   let { storyline, onDrill }: Props = $props();
 
+  let windowLabel = $derived(`Last ${durationLabel(windowSpan())} · newest on right`);
+  let axisTicks = $derived(buildAxisTicks(storyline.windowStart, storyline.windowEnd));
+
+  function windowSpan(): number {
+    return Math.max(1, storyline.windowEnd - storyline.windowStart);
+  }
+
+  function durationLabel(ms: number): string {
+    const seconds = Math.max(0, Math.round(ms / 1000));
+    if (seconds < 90) return `${seconds}s`;
+    const minutes = Math.round(seconds / 60);
+    if (minutes < 60) return `${minutes}m`;
+    const hours = Math.round(minutes / 60);
+    return `${hours}h`;
+  }
+
+  function buildAxisTicks(start: number, end: number): readonly { readonly pct: number; readonly label: string }[] {
+    const span = Math.max(1, end - start);
+    const seconds = span / 1000;
+    let positions: readonly number[];
+    if (seconds < 3) {
+      positions = [0, 1];
+    } else if (seconds < 20) {
+      positions = [0, 0.5, 1];
+    } else if (seconds < 45) {
+      positions = [0, 1 / 3, 2 / 3, 1];
+    } else {
+      positions = [0, 0.25, 0.5, 0.75, 1];
+    }
+    return positions.map((position) => {
+      const age = span * (1 - position);
+      const label = position === 1 ? 'now' : position === 0 ? `${durationLabel(age)} ago` : durationLabel(age);
+      return { pct: position * 100, label };
+    });
+  }
+
   function pct(t: number): number {
-    const span = Math.max(1, storyline.windowEnd - storyline.windowStart);
+    const span = windowSpan();
     return Math.max(0, Math.min(100, ((t - storyline.windowStart) / span) * 100));
   }
 
   function phaseBasis(phase: StoryPhase): number {
-    const span = Math.max(1, storyline.windowEnd - storyline.windowStart);
+    const span = windowSpan();
     return Math.max(4, ((phase.end - phase.start) / span) * 100);
+  }
+
+  function sparkY(point: Pick<TimelinePoint, 'normalizedLatency'>): number {
+    return SPARK_BASELINE_Y - Math.min(SPARK_RANGE_Y, (point.normalizedLatency ?? 0) * SPARK_RANGE_Y);
   }
 
   function pathFor(row: EndpointTimelineRow): string {
@@ -37,7 +88,7 @@
         continue;
       }
       const x = pct(point.t);
-      const y = 22 - Math.min(20, point.normalizedLatency * 20);
+      const y = sparkY(point);
       d += `${prevWasGap ? 'M' : 'L'} ${x.toFixed(1)} ${y.toFixed(1)} `;
       prevWasGap = false;
     }
@@ -52,8 +103,42 @@
     return row.points.filter((point) => point.status === 'elevated');
   }
 
+  function markerTimeLabel(marker: StoryMarker): string {
+    const age = storyline.windowEnd - marker.t;
+    return age <= 999 ? 'now' : `${durationLabel(age)} ago`;
+  }
+
+  function markerKindLabel(kind: StoryMarkerKind): string {
+    switch (kind) {
+      case 'elevation':
+        return 'Elevated';
+      case 'slowdown':
+        return 'Slow';
+      case 'failure':
+        return 'Failed';
+      case 'recovery':
+        return 'Recovered';
+      case 'shared-change':
+        return 'Shared change';
+    }
+  }
+
+  function latestMarkerFor(row: EndpointTimelineRow): StoryMarker | undefined {
+    return storyline.markers
+      .filter((marker) => marker.endpointId === row.endpointId)
+      .sort((a, b) => b.t - a.t)[0];
+  }
+
+  function rowTimeSummary(row: EndpointTimelineRow): string {
+    const marker = latestMarkerFor(row);
+    if (marker) return `${markerKindLabel(marker.kind)} ${markerTimeLabel(marker)}`;
+    if (storyline.confidence === 'collecting') return 'Collecting samples';
+    if (row.points.length === 0) return 'No recent samples';
+    return `Steady for ${durationLabel(windowSpan())}`;
+  }
+
   function markerLabel(marker: StoryMarker): string {
-    return `${marker.label}, ${marker.evidence}`;
+    return `${marker.label}, ${markerTimeLabel(marker)}, ${marker.evidence}`;
   }
 
   function drillMarker(marker: StoryMarker): void {
@@ -61,75 +146,112 @@
   }
 </script>
 
-<section class="storyline" aria-label="Recent run timeline" data-confidence={storyline.confidence}>
+<section class="storyline" aria-label="Recent run timeline. {windowLabel}" data-confidence={storyline.confidence}>
   <header class="storyline-header">
     <div>
       <h3 class="storyline-title">What happened</h3>
-      <p class="storyline-sub">Recent run timeline</p>
+      <p class="storyline-sub">{windowLabel}</p>
     </div>
-    <p class="storyline-hint">Click a moment -&gt; Diagnose</p>
+    <p class="storyline-hint">Click a marker -&gt; Diagnose</p>
   </header>
 
-  <div class="story-rail">
-    <div class="story-phases" aria-hidden="true">
-      {#each storyline.phases as phase (`${phase.kind}-${phase.start}-${phase.end}`)}
-        <span
-          class="story-phase"
-          data-kind={phase.kind}
-          style:flex-basis="{phaseBasis(phase)}%"
-        >
-          <span>{phase.label}</span>
-        </span>
+  <ul class="story-legend" aria-label="Timeline status legend">
+    {#each LEGEND_ITEMS as item (item.kind)}
+      <li data-kind={item.kind}>
+        <span aria-hidden="true"></span>
+        {item.label}
+      </li>
+    {/each}
+  </ul>
+
+  <div class="story-axis" aria-hidden="true">
+    <span class="story-axis-title">time</span>
+    <div class="story-axis-track">
+      {#each axisTicks as tick (tick.pct)}
+        <span class="story-axis-tick" style:left="{tick.pct}%">{tick.label}</span>
       {/each}
     </div>
-    {#each storyline.markers as marker (`${marker.kind}-${marker.endpointId ?? 'all'}-${marker.t}`)}
-      {#if marker.endpointId}
-        <button
-          type="button"
-          class="story-marker"
-          data-kind={marker.kind}
-          style:left="{pct(marker.t)}%"
-          title={marker.evidence}
-          aria-label={markerLabel(marker)}
-          onclick={() => drillMarker(marker)}
-        ></button>
-      {:else}
-        <span
-          class="story-marker"
-          data-kind={marker.kind}
-          style:left="{pct(marker.t)}%"
-          title={marker.evidence}
-        ></span>
-      {/if}
-    {/each}
+  </div>
+
+  <div class="story-rail">
+    <span class="story-rail-label">events</span>
+    <div class="story-rail-track">
+      <div class="story-phases" aria-hidden="true">
+        {#each storyline.phases as phase (`${phase.kind}-${phase.start}-${phase.end}`)}
+          <span
+            class="story-phase"
+            data-kind={phase.kind}
+            style:flex-basis="{phaseBasis(phase)}%"
+          >
+            <span>{phase.label}</span>
+          </span>
+        {/each}
+      </div>
+      {#each storyline.markers as marker (`${marker.kind}-${marker.endpointId ?? 'all'}-${marker.t}`)}
+        {#if marker.endpointId}
+          <button
+            type="button"
+            class="story-marker"
+            data-kind={marker.kind}
+            style:left="{pct(marker.t)}%"
+            title="{markerTimeLabel(marker)} - {marker.evidence}"
+            aria-label={markerLabel(marker)}
+            onclick={() => drillMarker(marker)}
+          ></button>
+        {:else}
+          <span
+            class="story-marker"
+            data-kind={marker.kind}
+            style:left="{pct(marker.t)}%"
+            title="{markerTimeLabel(marker)} - {marker.evidence}"
+          ></span>
+        {/if}
+      {/each}
+    </div>
   </div>
 
   <div class="story-rows">
     {#each storyline.rows as row (row.endpointId)}
+      {@const timeSummary = rowTimeSummary(row)}
       <button
         type="button"
         class="story-row"
         style:--ep-color={row.color}
         data-endpoint-id={row.endpointId}
-        aria-label="{row.label}, {row.summary}"
+        aria-label="{row.label}, {timeSummary}, {row.summary}"
         onclick={() => onDrill(row.endpointId)}
       >
         <span class="story-label">
           <span class="story-dot" aria-hidden="true"></span>
-          <span class="story-name">{row.label}</span>
+          <span class="story-label-copy">
+            <span class="story-name">{row.label}</span>
+            <span class="story-row-time">{timeSummary}</span>
+          </span>
         </span>
         <span class="story-track">
-          <svg class="story-spark" viewBox="0 0 100 24" preserveAspectRatio="none" aria-hidden="true">
-            <path d={pathFor(row)} fill="none" stroke="var(--ep-color)" stroke-width="1.3" stroke-linejoin="round" stroke-linecap="round" />
+          <svg
+            class="story-spark"
+            viewBox="0 0 100 {SPARK_VIEWBOX_HEIGHT}"
+            preserveAspectRatio="none"
+            aria-hidden="true"
+          >
+            <path
+              d={pathFor(row)}
+              fill="none"
+              stroke="var(--ep-color)"
+              stroke-width="2.35"
+              stroke-linejoin="round"
+              stroke-linecap="round"
+            />
           </svg>
           {#each failurePoints(row) as point (`${row.endpointId}-${point.round}-${point.t}`)}
-            <span class="story-failure" style:left="{pct(point.t)}%" aria-hidden="true">!</span>
+            <span class="story-failure" style:left="{pct(point.t)}%" style:top="{sparkY(point)}px" aria-hidden="true">!</span>
           {/each}
           {#each elevatedPoints(row) as point (`${row.endpointId}-elevated-${point.round}-${point.t}`)}
             <span
               class="story-elevated"
               style:left="{pct(point.t)}%"
-              style:top="{22 - Math.min(20, (point.normalizedLatency ?? 0) * 20)}px"
+              style:top="{sparkY(point)}px"
               title="Elevated: higher than recent median but below the slow trigger"
               aria-hidden="true"
             ></span>
@@ -149,13 +271,15 @@
 
 <style>
   .storyline {
+    --story-label-w: 156px;
     background: var(--glass-bg-rail-hover);
     border: 1px solid var(--border-mid);
     border-radius: 14px;
-    padding: 14px 16px;
+    padding: 14px 16px 13px;
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
     min-width: 0;
+    box-sizing: border-box;
     display: flex;
     flex-direction: column;
     gap: 9px;
@@ -179,7 +303,7 @@
     font-family: var(--mono);
     font-size: var(--ts-xs);
     letter-spacing: var(--tr-kicker);
-    color: var(--t3);
+    color: var(--t2);
     text-transform: uppercase;
   }
   .storyline-hint {
@@ -190,16 +314,95 @@
     white-space: nowrap;
   }
 
+  .story-legend {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 10px;
+    min-width: 0;
+  }
+  .story-legend li {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: var(--tr-kicker);
+    color: var(--t3);
+    text-transform: uppercase;
+  }
+  .story-legend span {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--t3);
+    box-shadow: 0 0 8px rgba(255,255,255,.12);
+  }
+  .story-legend li[data-kind="ok"] span { background: var(--accent-green); }
+  .story-legend li[data-kind="elevated"] span { background: var(--accent-amber); }
+  .story-legend li[data-kind="slow"] span { background: var(--accent-pink); }
+  .story-legend li[data-kind="failed"] span { background: var(--accent-pink); }
+
+  .story-axis,
   .story-rail {
+    display: grid;
+    grid-template-columns: var(--story-label-w) minmax(0, 1fr);
+    gap: 10px;
+    align-items: center;
+    min-width: 0;
+  }
+  .story-axis {
+    height: 14px;
+  }
+  .story-axis-title,
+  .story-rail-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: var(--tr-kicker);
+    color: var(--t4);
+    text-transform: uppercase;
+  }
+  .story-axis-track {
+    position: relative;
+    height: 14px;
+    min-width: 0;
+  }
+  .story-axis-track::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 6px;
+    height: 1px;
+    background: rgba(255,255,255,.08);
+  }
+  .story-axis-tick {
+    position: absolute;
+    top: 0;
+    transform: translateX(-50%);
+    font-family: var(--mono);
+    font-size: 10px;
+    color: var(--t3);
+    white-space: nowrap;
+  }
+  .story-axis-tick:first-child { transform: translateX(0); }
+  .story-axis-tick:last-child { transform: translateX(-100%); color: var(--t1); }
+
+  .story-rail-track {
     position: relative;
     min-width: 0;
-    padding-top: 3px;
   }
   .story-phases {
     display: flex;
-    height: 22px;
+    height: 30px;
     overflow: hidden;
-    border-radius: 5px;
+    border-radius: 6px;
     background: rgba(255,255,255,.035);
     border: 1px solid var(--border-mid);
   }
@@ -207,7 +410,7 @@
     min-width: 0;
     display: flex;
     align-items: center;
-    padding: 0 7px;
+    padding: 0 8px;
     font-family: var(--mono);
     font-size: var(--ts-xs);
     color: var(--t2);
@@ -219,27 +422,27 @@
   .story-phase:last-child { border-right: none; }
   .story-phase[data-kind="steady"],
   .story-phase[data-kind="recovered"] {
-    background: rgba(74, 222, 128, .08);
+    background: rgba(74, 222, 128, .1);
     color: var(--t2);
   }
   .story-phase[data-kind="isolated-slow"] {
-    background: rgba(251, 191, 36, .13);
+    background: rgba(251, 191, 36, .16);
     color: var(--accent-amber);
   }
   .story-phase[data-kind="shared-slow"],
   .story-phase[data-kind="failure"] {
-    background: rgba(249, 168, 212, .13);
+    background: rgba(249, 168, 212, .16);
     color: var(--accent-pink);
   }
   .story-phase[data-kind="collecting"] {
-    background: rgba(148, 163, 184, .08);
+    background: rgba(148, 163, 184, .1);
     color: var(--t3);
   }
   .story-marker {
     position: absolute;
-    top: 1px;
-    bottom: -3px;
-    width: 10px;
+    top: -2px;
+    bottom: -4px;
+    width: 18px;
     padding: 0;
     border: none;
     background: transparent;
@@ -249,37 +452,55 @@
   .story-marker::before {
     content: '';
     position: absolute;
-    top: 0;
-    bottom: 0;
+    top: 1px;
+    bottom: 1px;
     left: 50%;
-    width: 1px;
-    transform: translateX(-.5px);
-    background: rgba(255,255,255,.55);
+    width: 2px;
+    transform: translateX(-1px);
+    background: rgba(255,255,255,.6);
+  }
+  .story-marker::after {
+    content: '';
+    position: absolute;
+    top: 10px;
+    left: 50%;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    transform: translate(-50%, -50%);
+    background: rgba(255,255,255,.8);
+    box-shadow: 0 0 12px rgba(255,255,255,.28);
   }
   .story-marker:focus-visible {
     outline: 1.5px solid var(--accent-cyan);
     outline-offset: 2px;
-    border-radius: 4px;
+    border-radius: 5px;
   }
-  .story-marker[data-kind="failure"]::before { background: var(--accent-pink); }
+  .story-marker[data-kind="failure"]::before,
+  .story-marker[data-kind="failure"]::after { background: var(--accent-pink); }
   .story-marker[data-kind="slowdown"]::before,
-  .story-marker[data-kind="shared-change"]::before { background: var(--accent-amber); }
-  .story-marker[data-kind="recovery"]::before { background: var(--accent-green); }
+  .story-marker[data-kind="slowdown"]::after,
+  .story-marker[data-kind="shared-change"]::before,
+  .story-marker[data-kind="shared-change"]::after { background: var(--accent-amber); }
+  .story-marker[data-kind="recovery"]::before,
+  .story-marker[data-kind="recovery"]::after { background: var(--accent-green); }
+  .story-marker[data-kind="elevation"]::before,
+  .story-marker[data-kind="elevation"]::after { background: var(--accent-amber); }
 
   .story-rows {
     display: flex;
     flex-direction: column;
-    gap: 3px;
+    gap: 6px;
   }
   .story-row {
     display: grid;
-    grid-template-columns: 118px minmax(0, 1fr);
+    grid-template-columns: var(--story-label-w) minmax(0, 1fr);
     align-items: center;
     gap: 10px;
-    height: 24px;
-    padding: 0 6px;
+    height: 42px;
+    padding: 0;
     border: 1px solid transparent;
-    border-radius: 7px;
+    border-radius: 8px;
     background: transparent;
     color: inherit;
     font: inherit;
@@ -299,33 +520,50 @@
     align-items: center;
     gap: 8px;
     min-width: 0;
+    padding-left: 6px;
   }
   .story-dot {
-    width: 7px;
-    height: 7px;
+    width: 9px;
+    height: 9px;
     border-radius: 50%;
     background: var(--ep-color);
-    box-shadow: 0 0 6px var(--ep-color);
+    box-shadow: 0 0 8px var(--ep-color);
     flex: 0 0 auto;
   }
-  .story-name {
+  .story-label-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+  .story-name,
+  .story-row-time {
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
     font-family: var(--mono);
+  }
+  .story-name {
     font-size: var(--ts-sm);
     color: var(--t1);
     letter-spacing: var(--tr-body);
   }
+  .story-row-time {
+    font-size: 10px;
+    color: var(--t3);
+    letter-spacing: var(--tr-kicker);
+    text-transform: uppercase;
+  }
   .story-track {
     position: relative;
-    height: 24px;
+    height: 38px;
     min-width: 0;
-    border-radius: 4px;
+    border-radius: 6px;
+    border: 1px solid rgba(255,255,255,.06);
     background:
-      linear-gradient(90deg, rgba(255,255,255,.06) 1px, transparent 1px) 0 0 / 25% 100%,
-      linear-gradient(180deg, rgba(255,255,255,.025), rgba(255,255,255,.045));
+      linear-gradient(90deg, rgba(255,255,255,.08) 1px, transparent 1px) 0 0 / 25% 100%,
+      linear-gradient(180deg, rgba(255,255,255,.035), rgba(255,255,255,.06));
     overflow: hidden;
   }
   .story-track::after {
@@ -335,40 +573,41 @@
     right: 0;
     bottom: 7px;
     height: 1px;
-    background: rgba(255,255,255,.08);
+    background: rgba(255,255,255,.1);
   }
   .story-spark {
     position: absolute;
     inset: 0;
     width: 100%;
     height: 100%;
-    opacity: .9;
+    opacity: 1;
+    filter: drop-shadow(0 0 4px color-mix(in srgb, var(--ep-color), transparent 55%));
   }
   .story-failure {
     position: absolute;
-    top: 3px;
-    width: 11px;
-    height: 16px;
-    transform: translateX(-50%);
+    width: 16px;
+    height: 18px;
+    transform: translate(-50%, -50%);
     display: grid;
     place-items: center;
-    border-radius: 3px;
-    background: rgba(249, 168, 212, .16);
+    border-radius: 5px;
+    background: rgba(248, 113, 113, .18);
     color: var(--accent-pink);
     font-family: var(--mono);
-    font-size: 10px;
+    font-size: 11px;
     font-weight: 700;
     line-height: 1;
+    box-shadow: 0 0 10px rgba(248, 113, 113, .26);
   }
   .story-elevated {
     position: absolute;
-    width: 7px;
-    height: 7px;
+    width: 10px;
+    height: 10px;
     transform: translate(-50%, -50%);
     border-radius: 50%;
-    border: 1px solid var(--accent-amber);
-    background: rgba(251, 191, 36, .12);
-    box-shadow: 0 0 5px rgba(251, 191, 36, .28);
+    border: 1.5px solid var(--accent-amber);
+    background: rgba(251, 191, 36, .16);
+    box-shadow: 0 0 9px rgba(251, 191, 36, .34);
   }
 
   .story-footer {
@@ -397,30 +636,178 @@
 
   @media (max-width: 1023px) {
     .storyline {
+      --story-label-w: 108px;
       gap: 6px;
       padding: 10px 12px;
     }
     .storyline-hint { display: none; }
-    .story-phases { height: 18px; }
+    .story-legend { gap: 4px 8px; }
+    .story-axis { height: 12px; }
+    .story-axis-title,
+    .story-rail-label { display: none; }
+    .story-axis,
+    .story-rail,
     .story-row {
-      grid-template-columns: 96px minmax(0, 1fr);
-      height: 20px;
+      grid-template-columns: var(--story-label-w) minmax(0, 1fr);
+      gap: 8px;
     }
-    .story-track { height: 20px; }
+    .story-phases { height: 22px; }
+    .story-row { height: 30px; }
+    .story-track { height: 28px; }
     .story-footer { display: block; }
     .story-overflow { margin-top: 2px; }
   }
 
+  @media (max-width: 767px) {
+    .storyline {
+      --story-label-w: 88px;
+      height: 100%;
+      padding: 5px 8px;
+      gap: 3px;
+      border-radius: 10px;
+    }
+
+    .storyline-header {
+      align-items: baseline;
+      min-height: 0;
+    }
+
+    .storyline-header > div {
+      min-width: 0;
+      display: flex;
+      align-items: baseline;
+      gap: 7px;
+    }
+
+    .storyline-title {
+      flex: 0 0 auto;
+      font-size: var(--ts-sm);
+      white-space: nowrap;
+    }
+
+    .storyline-sub {
+      min-width: 0;
+      margin: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      font-size: 8px;
+      letter-spacing: .12em;
+    }
+
+    .storyline-hint,
+    .story-legend,
+    .story-rail,
+    .story-footer {
+      display: none;
+    }
+
+    .story-axis {
+      display: block;
+      height: 10px;
+    }
+
+    .story-axis-title {
+      display: none;
+    }
+
+    .story-axis-track {
+      height: 10px;
+    }
+
+    .story-axis-track::before {
+      top: 5px;
+    }
+
+    .story-axis-tick {
+      font-size: 8px;
+    }
+
+    .story-rows {
+      gap: 1px;
+      min-height: 0;
+    }
+
+    .story-row {
+      --row-h: 20px;
+      height: var(--row-h);
+      grid-template-columns: var(--story-label-w) minmax(0, 1fr);
+      gap: 6px;
+      border-radius: 5px;
+    }
+
+    .story-label {
+      gap: 5px;
+      padding-left: 0;
+    }
+
+    .story-dot {
+      width: 7px;
+      height: 7px;
+    }
+
+    .story-name {
+      font-size: 10px;
+    }
+
+    .story-row-time {
+      display: none;
+    }
+
+    .story-track {
+      height: 18px;
+      border-radius: 5px;
+    }
+
+    .story-track::after {
+      bottom: 4px;
+    }
+
+    .story-failure {
+      width: 13px;
+      height: 14px;
+      border-radius: 4px;
+      font-size: 9px;
+    }
+
+    .story-elevated {
+      width: 8px;
+      height: 8px;
+    }
+  }
+
   @media (max-width: 767px) and (max-height: 760px) {
     .storyline {
-      padding: 8px 10px;
+      --story-label-w: 82px;
+      padding: 4px 7px;
+      gap: 2px;
+    }
+
+    .storyline-title {
+      font-size: 11px;
+    }
+
+    .storyline-sub,
+    .story-axis-tick {
+      font-size: 7px;
+    }
+
+    .story-axis,
+    .story-axis-track {
+      height: 9px;
+    }
+
+    .story-axis-track::before {
+      top: 4px;
+    }
+
+    .story-row {
+      --row-h: 17px;
       gap: 5px;
     }
-    .storyline-title { font-size: var(--ts-base); }
-    .storyline-sub { display: none; }
-    .story-phases { height: 16px; }
-    .story-phase { padding-inline: 5px; }
-    .story-row { height: 18px; }
-    .story-track { height: 18px; }
+
+    .story-track {
+      height: 15px;
+    }
   }
 </style>

--- a/src/lib/components/RunStorylineCard.svelte
+++ b/src/lib/components/RunStorylineCard.svelte
@@ -703,24 +703,7 @@
     }
 
     .story-axis {
-      display: block;
-      height: 10px;
-    }
-
-    .story-axis-title {
       display: none;
-    }
-
-    .story-axis-track {
-      height: 10px;
-    }
-
-    .story-axis-track::before {
-      top: 5px;
-    }
-
-    .story-axis-tick {
-      font-size: 8px;
     }
 
     .story-rows {
@@ -729,7 +712,7 @@
     }
 
     .story-row {
-      --row-h: 20px;
+      --row-h: 24px;
       height: var(--row-h);
       grid-template-columns: var(--story-label-w) minmax(0, 1fr);
       gap: 6px;
@@ -779,30 +762,30 @@
   @media (max-width: 767px) and (max-height: 760px) {
     .storyline {
       --story-label-w: 82px;
-      padding: 4px 7px;
-      gap: 2px;
+      padding: 1px 7px;
+      gap: 1px;
+    }
+
+    .storyline-header {
+      line-height: 1;
     }
 
     .storyline-title {
-      font-size: 11px;
+      font-size: 10px;
+      line-height: 1;
     }
 
-    .storyline-sub,
-    .story-axis-tick {
+    .storyline-sub {
       font-size: 7px;
+      line-height: 1;
     }
 
-    .story-axis,
-    .story-axis-track {
-      height: 9px;
-    }
-
-    .story-axis-track::before {
-      top: 4px;
+    .story-rows {
+      gap: 0;
     }
 
     .story-row {
-      --row-h: 17px;
+      --row-h: 24px;
       gap: 5px;
     }
 

--- a/tests/unit/components/RunStorylineCard.test.ts
+++ b/tests/unit/components/RunStorylineCard.test.ts
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/svelte';
+import { fireEvent, render, within } from '@testing-library/svelte';
 import { describe, expect, it, vi } from 'vitest';
 import RunStorylineCard from '../../../src/lib/components/RunStorylineCard.svelte';
 import type { RunStoryline } from '../../../src/lib/utils/run-storyline';
@@ -72,7 +72,7 @@ describe('RunStorylineCard', () => {
   });
 
   it('renders readable time labels and a status legend', () => {
-    const { getAllByText, getByText } = render(RunStorylineCard, {
+    const { getByRole, getByText } = render(RunStorylineCard, {
       props: {
         storyline: storyline(),
         onDrill: vi.fn(),
@@ -84,10 +84,45 @@ describe('RunStorylineCard', () => {
     expect(getByText('30s')).toBeTruthy();
     expect(getByText('15s')).toBeTruthy();
     expect(getByText('now')).toBeTruthy();
-    expect(getAllByText('steady').length).toBeGreaterThan(0);
-    expect(getByText('elevated')).toBeTruthy();
-    expect(getByText('slow')).toBeTruthy();
-    expect(getByText('failed')).toBeTruthy();
+    const legend = within(getByRole('list', { name: 'Timeline status legend' }));
+    expect(legend.getByText('steady')).toBeTruthy();
+    expect(legend.getByText('elevated')).toBeTruthy();
+    expect(legend.getByText('slow')).toBeTruthy();
+    expect(legend.getByText('failed')).toBeTruthy();
+  });
+
+  it('positions alert markers with proportional track coordinates', () => {
+    const { container } = render(RunStorylineCard, {
+      props: {
+        storyline: storyline({
+          rows: [
+            {
+              endpointId: 'aws',
+              label: 'AWS',
+              color: '#fbbf24',
+              summary: 'AWS changed state.',
+              points: [
+                { t: BASE, round: 1, latency: 50, normalizedLatency: 0, status: 'ok', threshold: 120, sampleCount: 1 },
+                { t: BASE + 30_000, round: 2, latency: 105, normalizedLatency: 0.5, status: 'elevated', threshold: 120, sampleCount: 2 },
+                { t: BASE + 45_000, round: 3, latency: 0, normalizedLatency: 1, status: 'failed', threshold: 120, sampleCount: 3 },
+              ],
+            },
+          ],
+          markers: [],
+        }),
+        onDrill: vi.fn(),
+      },
+    });
+
+    const elevated = container.querySelector<HTMLElement>('.story-elevated');
+    const failure = container.querySelector<HTMLElement>('.story-failure');
+    expect(elevated?.style.top).toMatch(/%$/);
+    expect(failure?.style.top).toMatch(/%$/);
+
+    const path = container.querySelector<SVGPathElement>('.story-spark path');
+    const yValues = Array.from(path?.getAttribute('d')?.matchAll(/[ML] [\d.]+ ([\d.]+)/g) ?? [])
+      .map((match) => Number(match[1]));
+    expect(yValues.every((y) => y >= 0 && y <= 40)).toBe(true);
   });
 
   it('uses fewer axis ticks for very short runs so time remains readable', () => {

--- a/tests/unit/components/RunStorylineCard.test.ts
+++ b/tests/unit/components/RunStorylineCard.test.ts
@@ -67,8 +67,77 @@ describe('RunStorylineCard', () => {
     });
 
     expect(getByRole('heading', { name: 'What happened' })).toBeTruthy();
-    expect(getByText('Recent run timeline')).toBeTruthy();
+    expect(getByText('Last 60s · newest on right')).toBeTruthy();
     expect(getByText('AWS slowed briefly; the other paths stayed clean.')).toBeTruthy();
+  });
+
+  it('renders readable time labels and a status legend', () => {
+    const { getAllByText, getByText } = render(RunStorylineCard, {
+      props: {
+        storyline: storyline(),
+        onDrill: vi.fn(),
+      },
+    });
+
+    expect(getByText('60s ago')).toBeTruthy();
+    expect(getByText('45s')).toBeTruthy();
+    expect(getByText('30s')).toBeTruthy();
+    expect(getByText('15s')).toBeTruthy();
+    expect(getByText('now')).toBeTruthy();
+    expect(getAllByText('steady').length).toBeGreaterThan(0);
+    expect(getByText('elevated')).toBeTruthy();
+    expect(getByText('slow')).toBeTruthy();
+    expect(getByText('failed')).toBeTruthy();
+  });
+
+  it('uses fewer axis ticks for very short runs so time remains readable', () => {
+    const { getByText, queryByText } = render(RunStorylineCard, {
+      props: {
+        storyline: storyline({
+          windowEnd: BASE + 7_000,
+          phases: [{ start: BASE, end: BASE + 7_000, label: 'collecting', kind: 'collecting' }],
+          markers: [],
+        }),
+        onDrill: vi.fn(),
+      },
+    });
+
+    expect(getByText('Last 7s · newest on right')).toBeTruthy();
+    expect(getByText('7s ago')).toBeTruthy();
+    expect(getByText('4s')).toBeTruthy();
+    expect(getByText('now')).toBeTruthy();
+    expect(queryByText('5s')).toBeNull();
+    expect(queryByText('2s')).toBeNull();
+  });
+
+  it('does not render a confusing 0s interior tick while a run is just starting', () => {
+    const { getByText, queryByText } = render(RunStorylineCard, {
+      props: {
+        storyline: storyline({
+          windowEnd: BASE + 800,
+          phases: [{ start: BASE, end: BASE + 800, label: 'collecting', kind: 'collecting' }],
+          markers: [],
+        }),
+        onDrill: vi.fn(),
+      },
+    });
+
+    expect(getByText('1s ago')).toBeTruthy();
+    expect(getByText('now')).toBeTruthy();
+    expect(queryByText('0s')).toBeNull();
+  });
+
+  it('renders per-row time summaries so each trace has temporal meaning', () => {
+    const { getByText, getByRole } = render(RunStorylineCard, {
+      props: {
+        storyline: storyline(),
+        onDrill: vi.fn(),
+      },
+    });
+
+    expect(getByText('Steady for 60s')).toBeTruthy();
+    expect(getByText('Slow 30s ago')).toBeTruthy();
+    expect(getByRole('button', { name: /AWS, Slow 30s ago, AWS crossed the trigger/i })).toBeTruthy();
   });
 
   it('renders endpoint rows with accessible status labels', () => {
@@ -79,8 +148,8 @@ describe('RunStorylineCard', () => {
       },
     });
 
-    expect(getByRole('button', { name: /Google, Google stayed clean/i })).toBeTruthy();
-    expect(getByRole('button', { name: /AWS, AWS crossed the trigger/i })).toBeTruthy();
+    expect(getByRole('button', { name: /Google, Steady for 60s, Google stayed clean/i })).toBeTruthy();
+    expect(getByRole('button', { name: /AWS, Slow 30s ago, AWS crossed the trigger/i })).toBeTruthy();
   });
 
   it('renders overflow text when extra endpoints are hidden', () => {
@@ -108,7 +177,7 @@ describe('RunStorylineCard', () => {
       },
     });
 
-    await fireEvent.click(getByRole('button', { name: /AWS, AWS crossed the trigger/i }));
+    await fireEvent.click(getByRole('button', { name: /AWS, Slow 30s ago, AWS crossed the trigger/i }));
 
     expect(onDrill).toHaveBeenCalledWith('aws');
   });
@@ -122,7 +191,7 @@ describe('RunStorylineCard', () => {
       },
     });
 
-    await fireEvent.click(getByRole('button', { name: /AWS slow, AWS had 2 of the last 3 samples/i }));
+    await fireEvent.click(getByRole('button', { name: /AWS slow, 30s ago, AWS had 2 of the last 3 samples/i }));
 
     expect(onDrill).toHaveBeenCalledWith('aws');
   });

--- a/tests/visual/overview-no-scroll.spec.ts
+++ b/tests/visual/overview-no-scroll.spec.ts
@@ -20,6 +20,7 @@ const VIEWPORTS = [
   { name: 'desktop-2560',  width: 2560, height: 1440 },
 ] as const;
 
+const MIN_TOUCH_TARGET_PX = 24;
 const RUNNING_OR_STARTING_CONTROL = /^(?:Starting\.\.\.|Stop)$/i;
 
 interface VisibleEndpointTarget {
@@ -466,7 +467,10 @@ test.describe('Status — no scroll on first visit', () => {
     expect(activeTabVisual.perEndpointBackground, 'Per-endpoint tab should remain visually inactive').toBe('rgba(0, 0, 0, 0)');
 
     const minTimelineRowHeight = await measureMinTimelineRowHeight(page);
-    expect(minTimelineRowHeight, 'Timeline endpoint rows should preserve the 24px touch-target floor').toBeGreaterThanOrEqual(24);
+    expect(
+      minTimelineRowHeight,
+      `Timeline endpoint rows should preserve the ${MIN_TOUCH_TARGET_PX}px touch-target floor`,
+    ).toBeGreaterThanOrEqual(MIN_TOUCH_TARGET_PX);
 
     const warning = await measureStatusLayout(page);
     expect(warning.detail).not.toBeNull();
@@ -495,7 +499,10 @@ test.describe('Status — no scroll on first visit', () => {
     await expect(page.getByRole('heading', { name: 'What happened' })).toBeVisible();
 
     const minTimelineRowHeight = await measureMinTimelineRowHeight(page);
-    expect(minTimelineRowHeight, 'Timeline endpoint rows should preserve the 24px touch-target floor').toBeGreaterThanOrEqual(24);
+    expect(
+      minTimelineRowHeight,
+      `Timeline endpoint rows should preserve the ${MIN_TOUCH_TARGET_PX}px touch-target floor`,
+    ).toBeGreaterThanOrEqual(MIN_TOUCH_TARGET_PX);
 
     const warning = await measureStatusLayout(page);
     expect(warning.detail).not.toBeNull();

--- a/tests/visual/overview-no-scroll.spec.ts
+++ b/tests/visual/overview-no-scroll.spec.ts
@@ -39,6 +39,8 @@ interface StatusLayoutMeasurement {
   readonly grid: LayoutBox | null;
   readonly dial: LayoutBox | null;
   readonly racing: LayoutBox | null;
+  readonly timeline: LayoutBox | null;
+  readonly detail: LayoutBox | null;
 }
 
 interface ScrollerReport {
@@ -160,6 +162,8 @@ const measureStatusLayout = async (page: Page): Promise<StatusLayoutMeasurement>
       grid: box('.overview-grid'),
       dial: box('svg.dial'),
       racing: box('#overview-panel-racing'),
+      timeline: box('#overview-panel-events'),
+      detail: box('.overview-right'),
     };
   });
 };
@@ -419,5 +423,50 @@ test.describe('Status — no scroll on first visit', () => {
       warning.racing!.bottom,
       `evidence bottom (${warning.racing!.bottom}) should stay within viewport (${page.viewportSize()?.height})`,
     ).toBeLessThanOrEqual(page.viewportSize()!.height);
+  });
+
+  test('warning timeline fits the mobile Status detail slot', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/');
+    await page.waitForSelector('#chronoscope-root');
+    await page.waitForTimeout(400);
+
+    await injectWarningSamples(page);
+    await page.getByRole('tab', { name: 'Timeline' }).click();
+    await expect(page.getByRole('heading', { name: 'What happened' })).toBeVisible();
+
+    const activeTabVisual = await page.evaluate(() => {
+      const tabs = Array.from(document.querySelectorAll<HTMLButtonElement>('button[role="tab"]'));
+      const timeline = tabs.find((tab) => tab.textContent?.trim() === 'Timeline');
+      const perEndpoint = tabs.find((tab) => tab.textContent?.trim() === 'Per-endpoint');
+      const bg = (tab: HTMLButtonElement | undefined): string | null => (
+        tab ? getComputedStyle(tab).backgroundColor : null
+      );
+      return {
+        timelineSelected: timeline?.getAttribute('aria-selected') === 'true',
+        perEndpointSelected: perEndpoint?.getAttribute('aria-selected') === 'true',
+        timelineBackground: bg(timeline),
+        perEndpointBackground: bg(perEndpoint),
+      };
+    });
+    expect(activeTabVisual.timelineSelected, 'Timeline tab should own the visible timeline panel').toBe(true);
+    expect(activeTabVisual.perEndpointSelected, 'Per-endpoint tab should not be selected while Timeline is visible').toBe(false);
+    expect(activeTabVisual.timelineBackground, 'Timeline tab should have a visible selected background').not.toBe('rgba(0, 0, 0, 0)');
+    expect(activeTabVisual.perEndpointBackground, 'Per-endpoint tab should remain visually inactive').toBe('rgba(0, 0, 0, 0)');
+
+    const warning = await measureStatusLayout(page);
+    expect(warning.detail).not.toBeNull();
+    expect(warning.timeline).not.toBeNull();
+
+    expect(
+      warning.timeline!.bottom,
+      `timeline bottom (${warning.timeline!.bottom}) should stay inside detail slot (${warning.detail!.bottom})`,
+    ).toBeLessThanOrEqual(warning.detail!.bottom);
+
+    const state = await scrollState(page);
+    expect(
+      state.overflowingScrollers,
+      `internal scrollers with hidden content: ${JSON.stringify(state.overflowingScrollers, null, 2)}`,
+    ).toEqual([]);
   });
 });

--- a/tests/visual/overview-no-scroll.spec.ts
+++ b/tests/visual/overview-no-scroll.spec.ts
@@ -454,10 +454,45 @@ test.describe('Status — no scroll on first visit', () => {
     expect(activeTabVisual.timelineBackground, 'Timeline tab should have a visible selected background').not.toBe('rgba(0, 0, 0, 0)');
     expect(activeTabVisual.perEndpointBackground, 'Per-endpoint tab should remain visually inactive').toBe('rgba(0, 0, 0, 0)');
 
+    const minTimelineRowHeight = await page.locator('#overview-panel-events .story-row').evaluateAll((rows) => (
+      Math.min(...rows.map((row) => row.getBoundingClientRect().height))
+    ));
+    expect(minTimelineRowHeight, 'Timeline endpoint rows should preserve the 24px touch-target floor').toBeGreaterThanOrEqual(24);
+
     const warning = await measureStatusLayout(page);
     expect(warning.detail).not.toBeNull();
     expect(warning.timeline).not.toBeNull();
 
+    expect(
+      warning.timeline!.bottom,
+      `timeline bottom (${warning.timeline!.bottom}) should stay inside detail slot (${warning.detail!.bottom})`,
+    ).toBeLessThanOrEqual(warning.detail!.bottom);
+
+    const state = await scrollState(page);
+    expect(
+      state.overflowingScrollers,
+      `internal scrollers with hidden content: ${JSON.stringify(state.overflowingScrollers, null, 2)}`,
+    ).toEqual([]);
+  });
+
+  test('warning timeline preserves touch targets on iPhone SE', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto('/');
+    await page.waitForSelector('#chronoscope-root');
+    await page.waitForTimeout(400);
+
+    await injectWarningSamples(page);
+    await page.getByRole('tab', { name: 'Timeline' }).click();
+    await expect(page.getByRole('heading', { name: 'What happened' })).toBeVisible();
+
+    const minTimelineRowHeight = await page.locator('#overview-panel-events .story-row').evaluateAll((rows) => (
+      Math.min(...rows.map((row) => row.getBoundingClientRect().height))
+    ));
+    expect(minTimelineRowHeight, 'Timeline endpoint rows should preserve the 24px touch-target floor').toBeGreaterThanOrEqual(24);
+
+    const warning = await measureStatusLayout(page);
+    expect(warning.detail).not.toBeNull();
+    expect(warning.timeline).not.toBeNull();
     expect(
       warning.timeline!.bottom,
       `timeline bottom (${warning.timeline!.bottom}) should stay inside detail slot (${warning.detail!.bottom})`,

--- a/tests/visual/overview-no-scroll.spec.ts
+++ b/tests/visual/overview-no-scroll.spec.ts
@@ -168,6 +168,17 @@ const measureStatusLayout = async (page: Page): Promise<StatusLayoutMeasurement>
   });
 };
 
+const measureMinTimelineRowHeight = async (page: Page): Promise<number> => {
+  const timelineRows = page.locator('#overview-panel-events .story-row');
+  await expect(
+    timelineRows,
+    'Timeline should render endpoint rows before checking touch targets',
+  ).not.toHaveCount(0);
+  return await timelineRows.evaluateAll((rows) => (
+    Math.min(...rows.map((row) => row.getBoundingClientRect().height))
+  ));
+};
+
 test.describe('Status — no scroll on first visit', () => {
   for (const vp of VIEWPORTS) {
     test(`cold state @ ${vp.name} (${vp.width}×${vp.height})`, async ({ page }) => {
@@ -454,9 +465,7 @@ test.describe('Status — no scroll on first visit', () => {
     expect(activeTabVisual.timelineBackground, 'Timeline tab should have a visible selected background').not.toBe('rgba(0, 0, 0, 0)');
     expect(activeTabVisual.perEndpointBackground, 'Per-endpoint tab should remain visually inactive').toBe('rgba(0, 0, 0, 0)');
 
-    const minTimelineRowHeight = await page.locator('#overview-panel-events .story-row').evaluateAll((rows) => (
-      Math.min(...rows.map((row) => row.getBoundingClientRect().height))
-    ));
+    const minTimelineRowHeight = await measureMinTimelineRowHeight(page);
     expect(minTimelineRowHeight, 'Timeline endpoint rows should preserve the 24px touch-target floor').toBeGreaterThanOrEqual(24);
 
     const warning = await measureStatusLayout(page);
@@ -485,9 +494,7 @@ test.describe('Status — no scroll on first visit', () => {
     await page.getByRole('tab', { name: 'Timeline' }).click();
     await expect(page.getByRole('heading', { name: 'What happened' })).toBeVisible();
 
-    const minTimelineRowHeight = await page.locator('#overview-panel-events .story-row').evaluateAll((rows) => (
-      Math.min(...rows.map((row) => row.getBoundingClientRect().height))
-    ));
+    const minTimelineRowHeight = await measureMinTimelineRowHeight(page);
     expect(minTimelineRowHeight, 'Timeline endpoint rows should preserve the 24px touch-target floor').toBeGreaterThanOrEqual(24);
 
     const warning = await measureStatusLayout(page);


### PR DESCRIPTION
## Summary

- Adds an explicit, adaptive time axis to the Status Timeline so short runs do not render confusing labels like `0s`.
- Enlarges desktop storyline traces, adds status legend and per-row timing summaries, and keeps mobile Timeline compact enough to fit the fixed Status viewport.
- Makes the Timeline subtab visually unambiguous when selected, with regression coverage for tab state and selected styling.

## Why

The Timeline panel showed useful event data, but it did not communicate time clearly enough. On mobile it could also exceed the reserved Status detail area, and the selected Timeline tab was too subtle, making it look like the Per-endpoint tab owned the visible panel.

## Validation

- `npx vitest run tests/unit/utils/run-storyline.test.ts tests/unit/components/RunStorylineCard.test.ts` — 19 passed
- `npm run typecheck` — passed
- `npm run lint` — passed
- `npm run build` — passed
- `npx playwright test tests/visual/overview-no-scroll.spec.ts` — 28 passed
- `npm test` — 1123 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned run storyline view with timeline visualization, enhanced event markers, and improved accessibility features.

* **Style**
  * Improved responsive design for small screens with optimized spacing and sizing.
  * Enhanced tab button styling with refined transitions and active states.
  * Refined card container sizing for tablet and mobile layouts.

* **Tests**
  * Added mobile and tablet layout validation tests.
  * Expanded test coverage for new timeline UI labels and accessibility features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xaedyn/chronoscope/pull/151)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->