### PR TITLE
Add timeline signature beats

### DIFF
--- a/src/lib/components/CausalVerdictStrip.svelte
+++ b/src/lib/components/CausalVerdictStrip.svelte
@@ -131,30 +131,32 @@
   {/if}
 
   {#if showMetrics}
-    <dl class="verdict-facts verdict-metrics" aria-label="Measured facts">
+    <div class="verdict-facts verdict-metrics" role="group" aria-label="Measured facts">
       <div class="verdict-facts-heading" aria-hidden="true">Measured facts</div>
-      <div class="verdict-metric">
-        <dt class="verdict-metric-label">Median</dt>
-        <dd class="verdict-metric-value">
-          <span class="verdict-metric-num">{fmtInt(avgP50)}</span>
-          <span class="verdict-metric-unit">ms</span>
-        </dd>
-      </div>
-      <div class="verdict-metric">
-        <dt class="verdict-metric-label">Jitter</dt>
-        <dd class="verdict-metric-value">
-          <span class="verdict-metric-num">{fmt1(avgJitter)}</span>
-          <span class="verdict-metric-unit">ms</span>
-        </dd>
-      </div>
-      <div class="verdict-metric">
-        <dt class="verdict-metric-label">Loss</dt>
-        <dd class="verdict-metric-value">
-          <span class="verdict-metric-num">{fmt1(avgLoss)}</span>
-          <span class="verdict-metric-unit">%</span>
-        </dd>
-      </div>
-    </dl>
+      <dl class="verdict-metric-list">
+        <div class="verdict-metric">
+          <dt class="verdict-metric-label">Median</dt>
+          <dd class="verdict-metric-value">
+            <span class="verdict-metric-num">{fmtInt(avgP50)}</span>
+            <span class="verdict-metric-unit">ms</span>
+          </dd>
+        </div>
+        <div class="verdict-metric">
+          <dt class="verdict-metric-label">Jitter</dt>
+          <dd class="verdict-metric-value">
+            <span class="verdict-metric-num">{fmt1(avgJitter)}</span>
+            <span class="verdict-metric-unit">ms</span>
+          </dd>
+        </div>
+        <div class="verdict-metric">
+          <dt class="verdict-metric-label">Loss</dt>
+          <dd class="verdict-metric-value">
+            <span class="verdict-metric-num">{fmt1(avgLoss)}</span>
+            <span class="verdict-metric-unit">%</span>
+          </dd>
+        </div>
+      </dl>
+    </div>
   {/if}
 
   {#if drillEndpoint && verdict.tone === 'warn'}
@@ -467,6 +469,11 @@
     font-size: var(--ts-xs);
     letter-spacing: var(--tr-kicker);
     text-transform: uppercase;
+  }
+  .verdict-metric-list {
+    display: contents;
+    margin: 0;
+    padding: 0;
   }
   .verdict-metric {
     display: flex;

--- a/src/lib/components/EventFeed.svelte
+++ b/src/lib/components/EventFeed.svelte
@@ -58,11 +58,12 @@
 
   function relTime(ms: number): string {
     const s = Math.max(0, Math.round(ms / 1000));
-    if (s < 60) return `${s}s ago`;
+    if (s <= 1) return 'Now';
+    if (s < 60) return `-${s}s`;
     const m = Math.round(s / 60);
-    if (m < 60) return `${m}m ago`;
+    if (m < 60) return `-${m}m`;
     const h = Math.round(m / 60);
-    return `${h}h ago`;
+    return `-${h}h`;
   }
 
   function endpointFor(epId: string): Endpoint | undefined {
@@ -71,10 +72,10 @@
 
   function actionPhrase(ev: FeedEvent): { phrase: string; value: string } {
     switch (ev.kind) {
-      case 'cross-up':   return { phrase: 'crossed up',   value: ev.value != null ? `${fmt(ev.value)}ms` : '' };
-      case 'cross-down': return { phrase: 'recovered',    value: ev.value != null ? `${fmt(ev.value)}ms` : '' };
+      case 'cross-up':   return { phrase: 'crossed trigger', value: ev.value != null ? `${fmt(ev.value)}ms` : '' };
+      case 'cross-down': return { phrase: 'recovered below trigger', value: ev.value != null ? `${fmt(ev.value)}ms` : '' };
       case 'shift':      return {
-        phrase: 'p95 shift',
+        phrase: 'p95 shifted',
         value: ev.from != null && ev.to != null ? `${fmt(ev.from)}→${fmt(ev.to)}ms` : '',
       };
     }
@@ -84,11 +85,11 @@
 <section class="feed" aria-label="Recent events">
   <header class="feed-header">
     <h3 class="feed-title">Recent events</h3>
-    <p class="feed-sub">Threshold activity</p>
+    <p class="feed-sub">Run-relative activity</p>
   </header>
 
   {#if rows.length === 0}
-    <p class="feed-empty">No crossings in window. Network steady.</p>
+    <p class="feed-empty">No threshold events in this window.</p>
   {:else}
     <ol class="feed-rows" aria-live="polite">
       {#each rows as ev, rank (`${ev.t}-${ev.epId}-${ev.kind}`)}

--- a/src/lib/components/OverviewView.svelte
+++ b/src/lib/components/OverviewView.svelte
@@ -344,7 +344,7 @@
     --status-dial-pad-y: 16px;
     --status-mobile-dial-size: 300px;
     --status-mobile-dial-row-h: calc(var(--status-mobile-dial-size) + var(--status-dial-pad-y));
-    --status-mobile-detail-row-h: 167px;
+    --status-mobile-detail-row-h: 186px;
     flex: 1;
     height: 100%;
     display: flex;
@@ -463,7 +463,7 @@
   @media (max-width: 767px) and (max-height: 860px) {
     .overview {
       --status-mobile-dial-size: 300px;
-      --status-mobile-detail-row-h: 167px;
+      --status-mobile-detail-row-h: 186px;
     }
     .overview { padding-block: 6px; }
     .status-shell,
@@ -481,14 +481,14 @@
   @media (max-width: 767px) and (max-height: 760px) {
     .overview {
       --status-dial-pad-y: 4px;
-      --status-mobile-dial-size: 270px;
-      --status-mobile-detail-row-h: 144px;
+      --status-mobile-dial-size: 262px;
+      --status-mobile-detail-row-h: 152px;
     }
   }
 
   @media (max-width: 375px) and (max-height: 760px) {
     .overview {
-      --status-mobile-dial-size: 252px;
+      --status-mobile-dial-size: 244px;
     }
   }
 </style>

--- a/src/lib/components/RunStorylineCard.svelte
+++ b/src/lib/components/RunStorylineCard.svelte
@@ -9,6 +9,7 @@
     TimelinePoint,
     StoryMarker,
     StoryMarkerKind,
+    StoryBeat,
   } from '$lib/utils/run-storyline';
 
   interface Props {
@@ -30,6 +31,8 @@
 
   let windowLabel = $derived(`Last ${durationLabel(windowSpan())} · Now on right`);
   let axisTicks = $derived(buildAxisTicks(storyline.windowStart, storyline.windowEnd));
+  let visibleBeats = $derived(storyline.beats.slice(-4));
+  let mobileBeats = $derived(storyline.beats.slice(-2));
 
   function windowSpan(): number {
     return Math.max(1, storyline.windowEnd - storyline.windowStart);
@@ -113,8 +116,17 @@
   }
 
   function markerTimeLabel(marker: StoryMarker): string {
-    const age = storyline.windowEnd - marker.t;
+    return timeAgoLabel(marker.t);
+  }
+
+  function timeAgoLabel(t: number): string {
+    const age = storyline.windowEnd - t;
     return age <= 999 ? 'now' : `${durationLabel(age)} ago`;
+  }
+
+  function runRelativeLabel(t: number): string {
+    const age = storyline.windowEnd - t;
+    return age <= 999 ? 'Now' : `-${durationLabel(age)}`;
   }
 
   function markerKindLabel(kind: StoryMarkerKind): string {
@@ -146,12 +158,20 @@
     return `Steady for ${durationLabel(windowSpan())}`;
   }
 
-  function markerLabel(marker: StoryMarker): string {
-    return `${marker.label}, ${markerTimeLabel(marker)}, ${marker.evidence}`;
+  function beatLabel(beat: StoryBeat): string {
+    return `Timeline event: ${beat.label}, ${timeAgoLabel(beat.t)}, ${beat.evidence}`;
   }
 
-  function drillMarker(marker: StoryMarker): void {
-    if (marker.endpointId) onDrill(marker.endpointId);
+  function beatEdge(beat: StoryBeat): 'start' | 'middle' | 'end' {
+    const position = pct(beat.t);
+    if (position <= 12) return 'start';
+    if (position >= 88) return 'end';
+    return 'middle';
+  }
+
+  function drillBeat(beat: StoryBeat): void {
+    const endpointId = beat.endpointIds[0];
+    if (endpointId) onDrill(endpointId);
   }
 </script>
 
@@ -163,6 +183,24 @@
     </div>
     <p class="storyline-hint">Click a marker -&gt; Diagnose</p>
   </header>
+
+  {#if mobileBeats.length > 0}
+    <div class="story-mobile-beats" aria-label="Recent timeline events">
+      {#each mobileBeats as beat (beat.id)}
+        <button
+          type="button"
+          class="story-mobile-beat"
+          data-kind={beat.kind}
+          data-severity={beat.severity}
+          aria-label={beatLabel(beat)}
+          onclick={() => drillBeat(beat)}
+        >
+          <span>{beat.shortLabel}</span>
+          <span>{runRelativeLabel(beat.t)}</span>
+        </button>
+      {/each}
+    </div>
+  {/if}
 
   <div class="story-time-header">
     <ul class="story-legend" aria-label="Timeline status legend">
@@ -198,24 +236,40 @@
           </span>
         {/each}
       </div>
-      {#each storyline.markers as marker (`${marker.kind}-${marker.endpointId ?? 'all'}-${marker.t}`)}
-        {#if marker.endpointId}
+      {#each visibleBeats as beat (beat.id)}
+        {#if beat.endpointIds.length > 0}
           <button
             type="button"
-            class="story-marker"
-            data-kind={marker.kind}
-            style:left="{pct(marker.t)}%"
-            title="{markerTimeLabel(marker)} - {marker.evidence}"
-            aria-label={markerLabel(marker)}
-            onclick={() => drillMarker(marker)}
-          ></button>
+            class="story-beat"
+            data-kind={beat.kind}
+            data-severity={beat.severity}
+            data-edge={beatEdge(beat)}
+            style:left="{pct(beat.t)}%"
+            title="{timeAgoLabel(beat.t)} - {beat.evidence}"
+            aria-label={beatLabel(beat)}
+            onclick={() => drillBeat(beat)}
+          >
+            <span class="story-beat-pin" aria-hidden="true"></span>
+            <span class="story-beat-copy">
+              <span class="story-beat-label">{beat.shortLabel}</span>
+              <span class="story-beat-time">{timeAgoLabel(beat.t)}</span>
+            </span>
+          </button>
         {:else}
           <span
-            class="story-marker"
-            data-kind={marker.kind}
-            style:left="{pct(marker.t)}%"
-            title="{markerTimeLabel(marker)} - {marker.evidence}"
-          ></span>
+            class="story-beat"
+            data-kind={beat.kind}
+            data-severity={beat.severity}
+            data-edge={beatEdge(beat)}
+            style:left="{pct(beat.t)}%"
+            title="{timeAgoLabel(beat.t)} - {beat.evidence}"
+          >
+            <span class="story-beat-pin" aria-hidden="true"></span>
+            <span class="story-beat-copy">
+              <span class="story-beat-label">{beat.shortLabel}</span>
+              <span class="story-beat-time">{timeAgoLabel(beat.t)}</span>
+            </span>
+          </span>
         {/if}
       {/each}
     </div>
@@ -323,6 +377,9 @@
     font-size: var(--ts-xs);
     color: var(--t2);
     white-space: nowrap;
+  }
+  .story-mobile-beats {
+    display: none;
   }
 
   .story-time-header {
@@ -459,55 +516,89 @@
     background: rgba(148, 163, 184, .1);
     color: var(--t3);
   }
-  .story-marker {
+  .story-beat {
     position: absolute;
-    top: -2px;
-    bottom: -4px;
-    width: 18px;
-    padding: 0;
-    border: none;
-    background: transparent;
+    top: 3px;
+    z-index: 2;
+    min-width: 96px;
+    max-width: 156px;
+    height: 24px;
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    padding: 0 9px 0 7px;
+    border: 1px solid rgba(255,255,255,.14);
+    border-radius: 999px;
+    background: rgba(15, 23, 42, .82);
+    color: var(--t1);
+    font: inherit;
+    font-family: var(--mono);
+    text-align: left;
+    box-shadow: 0 8px 24px rgba(0,0,0,.26);
     transform: translateX(-50%);
     cursor: pointer;
   }
-  .story-marker::before {
-    content: '';
-    position: absolute;
-    top: 1px;
-    bottom: 1px;
-    left: 50%;
-    width: 2px;
-    transform: translateX(-1px);
-    background: rgba(255,255,255,.6);
+  .story-beat[data-edge="start"] { transform: translateX(0); }
+  .story-beat[data-edge="end"] { transform: translateX(-100%); }
+  .story-beat[data-severity="bad"] {
+    border-color: rgba(251, 191, 36, .34);
+    background: rgba(49, 36, 20, .9);
   }
-  .story-marker::after {
-    content: '';
-    position: absolute;
-    top: 10px;
-    left: 50%;
+  .story-beat[data-severity="good"] {
+    border-color: rgba(134, 239, 172, .28);
+    background: rgba(20, 46, 31, .88);
+  }
+  .story-beat[data-severity="watch"] {
+    border-color: rgba(103, 232, 249, .26);
+    background: rgba(18, 42, 52, .88);
+  }
+  .story-beat:focus-visible {
+    outline: 1.5px solid var(--accent-cyan);
+    outline-offset: 2px;
+  }
+  .story-beat-pin {
     width: 10px;
     height: 10px;
     border-radius: 50%;
-    transform: translate(-50%, -50%);
-    background: rgba(255,255,255,.8);
-    box-shadow: 0 0 12px rgba(255,255,255,.28);
+    flex: 0 0 auto;
+    background: var(--accent-cyan);
+    box-shadow: 0 0 10px rgba(103,232,249,.45);
   }
-  .story-marker:focus-visible {
-    outline: 1.5px solid var(--accent-cyan);
-    outline-offset: 2px;
-    border-radius: 5px;
+  .story-beat[data-severity="bad"] .story-beat-pin {
+    background: var(--accent-amber);
+    box-shadow: 0 0 10px rgba(251,191,36,.42);
   }
-  .story-marker[data-kind="failure"]::before,
-  .story-marker[data-kind="failure"]::after { background: var(--accent-pink); }
-  .story-marker[data-kind="slowdown"]::before,
-  .story-marker[data-kind="slowdown"]::after,
-  .story-marker[data-kind="shared-change"]::before,
-  .story-marker[data-kind="shared-change"]::after { background: var(--accent-amber); }
-  .story-marker[data-kind="recovery"]::before,
-  .story-marker[data-kind="recovery"]::after { background: var(--accent-green); }
-  .story-marker[data-kind="elevation"]::before,
-  .story-marker[data-kind="elevation"]::after { background: var(--accent-amber); }
-
+  .story-beat[data-severity="good"] .story-beat-pin {
+    background: var(--accent-green);
+    box-shadow: 0 0 10px rgba(134,239,172,.38);
+  }
+  .story-beat-copy {
+    min-width: 0;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 6px;
+    align-items: baseline;
+    width: 100%;
+  }
+  .story-beat-label,
+  .story-beat-time {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .story-beat-label {
+    font-size: 10px;
+    color: var(--t1);
+    letter-spacing: var(--tr-kicker);
+    text-transform: uppercase;
+  }
+  .story-beat-time {
+    font-size: 9px;
+    color: var(--t3);
+    letter-spacing: var(--tr-kicker);
+    text-transform: uppercase;
+  }
   .story-rows {
     display: flex;
     flex-direction: column;
@@ -518,7 +609,9 @@
     grid-template-columns: var(--story-label-w) minmax(0, 1fr);
     align-items: center;
     gap: 10px;
+    flex: 0 0 42px;
     height: 42px;
+    min-height: 42px;
     padding: 0;
     border: 1px solid transparent;
     border-radius: 8px;
@@ -675,6 +768,10 @@
     }
     .story-phases { height: 22px; }
     .story-row { height: 30px; }
+    .story-row {
+      flex-basis: 30px;
+      min-height: 30px;
+    }
     .story-track { height: 28px; }
     .story-footer { display: block; }
     .story-overflow { margin-top: 2px; }
@@ -724,6 +821,59 @@
       display: none;
     }
 
+    .story-mobile-beats {
+      display: flex;
+      gap: 4px;
+      flex: 0 0 22px;
+      height: 22px;
+      min-height: 22px;
+      min-width: 0;
+      overflow: hidden;
+    }
+
+    .story-mobile-beat {
+      flex: 1 1 0;
+      min-width: 0;
+      height: 22px;
+      padding: 0 7px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 6px;
+      border-radius: 6px;
+      border: 1px solid rgba(255,255,255,.12);
+      background: rgba(255,255,255,.045);
+      color: var(--t2);
+      font-family: var(--mono);
+      font-size: 9px;
+      letter-spacing: var(--tr-kicker);
+      text-transform: uppercase;
+    }
+
+    .story-mobile-beat[data-severity="bad"] {
+      color: var(--accent-amber);
+      border-color: rgba(251, 191, 36, .24);
+      background: rgba(251, 191, 36, .06);
+    }
+
+    .story-mobile-beat[data-severity="good"] {
+      color: var(--accent-green);
+      border-color: rgba(134, 239, 172, .22);
+      background: rgba(134, 239, 172, .055);
+    }
+
+    .story-mobile-beat span {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .story-mobile-beat span:last-child {
+      flex: 0 0 auto;
+      color: var(--t3);
+    }
+
     .story-rows {
       gap: 1px;
       min-height: 0;
@@ -731,7 +881,9 @@
 
     .story-row {
       --row-h: 24px;
+      flex-basis: var(--row-h);
       height: var(--row-h);
+      min-height: var(--row-h);
       grid-template-columns: var(--story-label-w) minmax(0, 1fr);
       gap: 6px;
       border-radius: 5px;
@@ -800,6 +952,10 @@
 
     .story-rows {
       gap: 0;
+    }
+
+    .story-mobile-beats {
+      display: none;
     }
 
     .story-row {

--- a/src/lib/utils/run-storyline.ts
+++ b/src/lib/utils/run-storyline.ts
@@ -15,6 +15,8 @@ export type RunStorylineConfidence = 'collecting' | 'low' | 'medium' | 'high';
 export type StoryPhaseKind = 'collecting' | 'steady' | 'isolated-slow' | 'shared-slow' | 'failure' | 'recovered';
 export type TimelinePointStatus = 'ok' | 'elevated' | 'slow' | 'failed' | 'unknown';
 export type StoryMarkerKind = 'elevation' | 'slowdown' | 'failure' | 'recovery' | 'shared-change';
+export type StoryBeatKind = StoryMarkerKind | 'shared-slowdown';
+export type StoryBeatSeverity = 'info' | 'watch' | 'bad' | 'good';
 
 export interface BuildRunStorylineInput {
   readonly endpoints: readonly Endpoint[];
@@ -33,6 +35,7 @@ export interface RunStoryline {
   readonly rows: readonly EndpointTimelineRow[];
   readonly overflow: EndpointTimelineOverflow | null;
   readonly markers: readonly StoryMarker[];
+  readonly beats: readonly StoryBeat[];
   readonly summary: string;
   readonly confidence: RunStorylineConfidence;
   readonly sampleCount: number;
@@ -71,6 +74,18 @@ export interface StoryMarker {
   readonly kind: StoryMarkerKind;
   readonly label: string;
   readonly evidence: string;
+}
+
+export interface StoryBeat {
+  readonly id: string;
+  readonly t: number;
+  readonly kind: StoryBeatKind;
+  readonly severity: StoryBeatSeverity;
+  readonly label: string;
+  readonly shortLabel: string;
+  readonly endpointIds: readonly string[];
+  readonly evidence: string;
+  readonly markerCount: number;
 }
 
 export interface EndpointTimelineOverflow {
@@ -113,6 +128,7 @@ export function buildRunStoryline(input: BuildRunStorylineInput): RunStoryline {
   const readyEndpointCount = readyRows.length;
   const allMarkers = fullRows.flatMap((row) => row.markers);
   const markers = allMarkers.sort((a, b) => a.t - b.t);
+  const beats = beatsFor(markers, fullRows);
   const confidence = confidenceFor(readyRows, markers);
   const pattern = selectPattern({ rows: fullRows, markers, confidence });
   const summary = summaryFor({ pattern, rows: fullRows, markers, confidence });
@@ -136,6 +152,7 @@ export function buildRunStoryline(input: BuildRunStorylineInput): RunStoryline {
     rows,
     overflow,
     markers,
+    beats,
     summary,
     confidence,
     sampleCount,
@@ -537,6 +554,153 @@ function recoveryAfter(markers: readonly StoryMarker[], t: number, endpointId?: 
     marker.t > t &&
     (endpointId == null || marker.endpointId === endpointId)
   ))?.t;
+}
+
+function beatsFor(markers: readonly StoryMarker[], rows: readonly FullEndpointRow[]): StoryBeat[] {
+  const sorted = [...markers].sort((a, b) => a.t - b.t);
+  const clusters: StoryMarker[][] = [];
+
+  for (const marker of sorted) {
+    if (marker.kind === 'recovery') {
+      clusters.push([marker]);
+      continue;
+    }
+
+    const last = clusters[clusters.length - 1];
+    const canJoinLast = last !== undefined &&
+      last.every((candidate) => candidate.kind !== 'recovery') &&
+      marker.t - last[0].t <= CORRELATION_WINDOW_MS;
+    if (canJoinLast) {
+      last.push(marker);
+    } else {
+      clusters.push([marker]);
+    }
+  }
+
+  return clusters.map((cluster) => beatForCluster(cluster, rows));
+}
+
+function beatForCluster(cluster: readonly StoryMarker[], rows: readonly FullEndpointRow[]): StoryBeat {
+  const endpointIds = uniqueEndpointIds(cluster);
+  const endpointLabel = labelForEndpoint(endpointIds[0], rows);
+  const failureMarkers = cluster.filter((marker) => marker.kind === 'failure');
+  const slowdownMarkers = cluster.filter((marker) => marker.kind === 'slowdown');
+  const recoveryMarkers = cluster.filter((marker) => marker.kind === 'recovery');
+  const elevationMarkers = cluster.filter((marker) => marker.kind === 'elevation');
+  const sharedChangeMarkers = cluster.filter((marker) => marker.kind === 'shared-change');
+  const t = cluster[0]?.t ?? 0;
+
+  if (failureMarkers.length > 0) {
+    const count = endpointIds.length;
+    const label = count > 1 ? `${count} paths failed` : `${endpointLabel} failed`;
+    return {
+      id: beatId('failure', endpointIds, t),
+      t,
+      kind: 'failure',
+      severity: 'bad',
+      label,
+      shortLabel: label,
+      endpointIds,
+      evidence: count > 1
+        ? `${count} endpoints returned timeout or error samples within 15 seconds.`
+        : failureMarkers[0]?.evidence ?? 'A path returned a timeout or error sample.',
+      markerCount: cluster.length,
+    };
+  }
+
+  if (slowdownMarkers.length > 1 && endpointIds.length > 1) {
+    const count = endpointIds.length;
+    return {
+      id: beatId('shared-slowdown', endpointIds, t),
+      t,
+      kind: 'shared-slowdown',
+      severity: 'bad',
+      label: `${count} paths slowed together`,
+      shortLabel: `${count} paths slow`,
+      endpointIds,
+      evidence: `${count} endpoints crossed the trigger within 15 seconds.`,
+      markerCount: cluster.length,
+    };
+  }
+
+  if (slowdownMarkers.length > 0) {
+    const label = `${endpointLabel} slow`;
+    return {
+      id: beatId('slowdown', endpointIds, t),
+      t,
+      kind: 'slowdown',
+      severity: 'bad',
+      label,
+      shortLabel: label,
+      endpointIds,
+      evidence: slowdownMarkers[0]?.evidence ?? `${endpointLabel} crossed the trigger.`,
+      markerCount: cluster.length,
+    };
+  }
+
+  if (recoveryMarkers.length > 0) {
+    const count = endpointIds.length;
+    const label = count > 1 ? `${count} paths recovered` : `${endpointLabel} recovered`;
+    return {
+      id: beatId('recovery', endpointIds, t),
+      t,
+      kind: 'recovery',
+      severity: 'good',
+      label,
+      shortLabel: label,
+      endpointIds,
+      evidence: count > 1
+        ? `${count} endpoints returned to the configured threshold.`
+        : recoveryMarkers[0]?.evidence ?? `${endpointLabel} returned to the configured threshold.`,
+      markerCount: cluster.length,
+    };
+  }
+
+  if (elevationMarkers.length > 0) {
+    const label = `${endpointLabel} rose`;
+    return {
+      id: beatId('elevation', endpointIds, t),
+      t,
+      kind: 'elevation',
+      severity: 'watch',
+      label,
+      shortLabel: label,
+      endpointIds,
+      evidence: elevationMarkers[0]?.evidence ?? `${endpointLabel} rose below the trigger.`,
+      markerCount: cluster.length,
+    };
+  }
+
+  const label = endpointIds.length > 1 ? `${endpointIds.length} paths changed` : `${endpointLabel} changed`;
+  return {
+    id: beatId('shared-change', endpointIds, t),
+    t,
+    kind: sharedChangeMarkers[0]?.kind ?? 'shared-change',
+    severity: 'info',
+    label,
+    shortLabel: label,
+    endpointIds,
+    evidence: sharedChangeMarkers[0]?.evidence ?? 'A browser-visible event changed in the current window.',
+    markerCount: cluster.length,
+  };
+}
+
+function beatId(kind: StoryBeatKind, endpointIds: readonly string[], t: number): string {
+  return `${kind}-${endpointIds.length > 0 ? endpointIds.join('-') : 'all'}-${t}`;
+}
+
+function uniqueEndpointIds(markers: readonly StoryMarker[]): string[] {
+  const out: string[] = [];
+  for (const marker of markers) {
+    if (marker.endpointId == null || out.includes(marker.endpointId)) continue;
+    out.push(marker.endpointId);
+  }
+  return out;
+}
+
+function labelForEndpoint(endpointId: string | undefined, rows: readonly FullEndpointRow[]): string {
+  if (endpointId === undefined) return 'One path';
+  return rows.find((row) => row.endpointId === endpointId)?.label ?? endpointId;
 }
 
 function hasRepeatedSharedPattern(markers: readonly StoryMarker[]): boolean {

--- a/tests/unit/components/EventFeed.test.ts
+++ b/tests/unit/components/EventFeed.test.ts
@@ -1,0 +1,62 @@
+import { fireEvent, render } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import EventFeed, { type FeedEvent } from '../../../src/lib/components/EventFeed.svelte';
+import type { Endpoint } from '../../../src/lib/types';
+
+const NOW = 1_765_000_060_000;
+
+const endpoints: Endpoint[] = [
+  {
+    id: 'edge',
+    url: 'https://chronoscope.dev/probe',
+    label: 'Edge',
+    enabled: true,
+    color: '#f9a8d4',
+  },
+];
+
+function renderFeed(events: readonly FeedEvent[]) {
+  return render(EventFeed, {
+    props: {
+      events,
+      endpoints,
+      now: NOW,
+      onDrill: vi.fn(),
+    },
+  });
+}
+
+describe('EventFeed', () => {
+  it('uses run-relative time labels and plain threshold language', async () => {
+    const onDrill = vi.fn();
+    const event: FeedEvent = {
+      t: NOW - 30_000,
+      epId: 'edge',
+      kind: 'cross-up',
+      value: 181,
+      threshold: 120,
+    };
+    const { getByRole, getByText, queryByText } = render(EventFeed, {
+      props: {
+        events: [event],
+        endpoints,
+        now: NOW,
+        onDrill,
+      },
+    });
+
+    expect(getByText('-30s')).toBeTruthy();
+    expect(queryByText('30s ago')).toBeNull();
+    expect(getByText(/crossed trigger/i)).toBeTruthy();
+
+    await fireEvent.click(getByRole('button', { name: /-30s Edge crossed trigger 181ms/i }));
+
+    expect(onDrill).toHaveBeenCalledWith('edge');
+  });
+
+  it('keeps the empty state compact and time-neutral', () => {
+    const { getByText } = renderFeed([]);
+
+    expect(getByText('No threshold events in this window.')).toBeTruthy();
+  });
+});

--- a/tests/unit/components/RunStorylineCard.test.ts
+++ b/tests/unit/components/RunStorylineCard.test.ts
@@ -52,6 +52,19 @@ function storyline(over: Partial<RunStoryline> = {}): RunStoryline {
         evidence: 'AWS had 2 of the last 3 samples above 120 ms.',
       },
     ],
+    beats: [
+      {
+        id: 'slowdown-aws-1765000030000',
+        t: BASE + 30_000,
+        kind: 'slowdown',
+        severity: 'bad',
+        label: 'AWS slow',
+        shortLabel: 'AWS slow',
+        endpointIds: ['aws'],
+        evidence: 'AWS had 2 of the last 3 samples above 120 ms.',
+        markerCount: 1,
+      },
+    ],
     overflow: null,
     ...over,
   };
@@ -72,7 +85,7 @@ describe('RunStorylineCard', () => {
   });
 
   it('renders readable time labels and a status legend', () => {
-    const { container, getByRole, getByText } = render(RunStorylineCard, {
+    const { container, getByRole, getByText, getAllByText } = render(RunStorylineCard, {
       props: {
         storyline: storyline(),
         onDrill: vi.fn(),
@@ -81,7 +94,7 @@ describe('RunStorylineCard', () => {
 
     expect(getByText('-60s')).toBeTruthy();
     expect(getByText('-45s')).toBeTruthy();
-    expect(getByText('-30s')).toBeTruthy();
+    expect(getAllByText('-30s').length).toBeGreaterThanOrEqual(1);
     expect(getByText('-15s')).toBeTruthy();
     expect(getByText('Now')).toBeTruthy();
     const legend = within(getByRole('list', { name: 'Timeline status legend' }));
@@ -90,6 +103,24 @@ describe('RunStorylineCard', () => {
     expect(legend.getByText('slow')).toBeTruthy();
     expect(legend.getByText('failed')).toBeTruthy();
     expect(container.querySelector('.story-time-header')).not.toBeNull();
+  });
+
+  it('renders large signature event marks with time, endpoint, and evidence', () => {
+    const { container } = render(RunStorylineCard, {
+      props: {
+        storyline: storyline(),
+        onDrill: vi.fn(),
+      },
+    });
+
+    const beat = container.querySelector<HTMLElement>('.story-beat');
+
+    expect(beat).not.toBeNull();
+    expect(beat?.textContent).toContain('AWS slow');
+    expect(beat?.textContent).toContain('30s ago');
+    expect(beat?.getAttribute('aria-label')).toMatch(
+      /Timeline event: AWS slow, 30s ago, AWS had 2 of the last 3 samples/i,
+    );
   });
 
   it('positions alert markers with proportional track coordinates', () => {
@@ -133,6 +164,7 @@ describe('RunStorylineCard', () => {
           windowEnd: BASE + 7_000,
           phases: [{ start: BASE, end: BASE + 7_000, label: 'collecting', kind: 'collecting' }],
           markers: [],
+          beats: [],
         }),
         onDrill: vi.fn(),
       },
@@ -153,6 +185,7 @@ describe('RunStorylineCard', () => {
           windowEnd: BASE + 800,
           phases: [{ start: BASE, end: BASE + 800, label: 'collecting', kind: 'collecting' }],
           markers: [],
+          beats: [],
         }),
         onDrill: vi.fn(),
       },
@@ -220,14 +253,19 @@ describe('RunStorylineCard', () => {
 
   it('drills into the clicked event marker', async () => {
     const onDrill = vi.fn();
-    const { getByRole } = render(RunStorylineCard, {
+    const { container } = render(RunStorylineCard, {
       props: {
         storyline: storyline(),
         onDrill,
       },
     });
 
-    await fireEvent.click(getByRole('button', { name: /AWS slow, 30s ago, AWS had 2 of the last 3 samples/i }));
+    const rail = container.querySelector<HTMLElement>('.story-rail');
+
+    expect(rail).not.toBeNull();
+    await fireEvent.click(within(rail as HTMLElement).getByRole('button', {
+      name: /Timeline event: AWS slow, 30s ago, AWS had 2 of the last 3 samples/i,
+    }));
 
     expect(onDrill).toHaveBeenCalledWith('aws');
   });

--- a/tests/unit/utils/run-storyline.test.ts
+++ b/tests/unit/utils/run-storyline.test.ts
@@ -107,6 +107,16 @@ describe('run storyline derivation', () => {
     expect(result.summary).toBe('Multiple paths slowed together, then stayed above the trigger.');
     expect(result.markers.filter((marker) => marker.kind === 'slowdown')).toHaveLength(2);
     expect(result.phases.some((phase) => phase.kind === 'shared-slow')).toBe(true);
+    expect(result.beats).toEqual([
+      expect.objectContaining({
+        kind: 'shared-slowdown',
+        severity: 'bad',
+        label: '2 paths slowed together',
+        shortLabel: '2 paths slow',
+        endpointIds: ['google', 'cloudflare'],
+        markerCount: 2,
+      }),
+    ]);
   });
 
   it('uses high confidence only when shared patterns repeat in adjacent 15-second buckets', () => {
@@ -153,6 +163,14 @@ describe('run storyline derivation', () => {
     expect(result.summary).toBe('Fastly had a failed request; the other paths stayed reachable.');
     expect(result.markers.some((marker) => marker.kind === 'failure' && marker.endpointId === 'fastly')).toBe(true);
     expect(result.markers.some((marker) => marker.kind === 'slowdown')).toBe(false);
+    expect(result.beats[0]).toEqual(expect.objectContaining({
+      kind: 'failure',
+      severity: 'bad',
+      label: 'Fastly failed',
+      shortLabel: 'Fastly failed',
+      endpointIds: ['fastly'],
+      evidence: 'Fastly returned a timeout or error sample.',
+    }));
   });
 
   it('adds recovery after a marked problem has three normal samples', () => {
@@ -177,6 +195,7 @@ describe('run storyline derivation', () => {
     expect(result.markers.some((marker) => marker.kind === 'recovery' && marker.endpointId === 'aws')).toBe(true);
     expect(result.phases.some((phase) => phase.kind === 'recovered')).toBe(true);
     expect(result.summary).toBe('AWS slowed briefly, then recovered.');
+    expect(result.beats.map((beat) => beat.shortLabel)).toEqual(['AWS slow', 'AWS recovered']);
   });
 
   it('does not promote below-threshold elevated latency to slow wording', () => {

--- a/tests/visual/ac-verification.spec.ts
+++ b/tests/visual/ac-verification.spec.ts
@@ -212,14 +212,14 @@ test.describe('Acceptance criteria verification', () => {
     expect(await endpointButtons.count()).toBeGreaterThan(0);
   });
 
-  test('cold Status renders dial, racing comparison, and event feed', async ({ page }) => {
+  test('cold Status renders dial, racing comparison, and timeline', async ({ page }) => {
     await page.goto('/');
     await page.waitForSelector('#chronoscope-root');
 
     await expect(page.locator('section[aria-label="Status"]')).toBeVisible();
     await expect(page.locator('svg.dial')).toBeVisible();
     await expect(page.locator('section[aria-label="Per-endpoint comparison"]')).toBeVisible();
-    await expect(page.locator('section[aria-label="Recent events"]')).toBeAttached();
+    await expect(page.locator('section[aria-label^="Recent run timeline"]')).toBeAttached();
   });
 
   test('Status first paint shows verdict before the dial on desktop', async ({ page }) => {

--- a/tests/visual/accessibility.spec.ts
+++ b/tests/visual/accessibility.spec.ts
@@ -122,14 +122,16 @@ test.describe('Accessibility', () => {
     await expectNoAxeViolations(page);
   });
 
-  test('no axe violations when recent threshold events are visible', async ({ page }) => {
-    test.skip((page.viewportSize()?.width ?? 0) < 700, 'Event feed contrast is covered in the desktop Status layout.');
+  test('no axe violations when recent timeline events are visible', async ({ page }) => {
+    test.skip((page.viewportSize()?.width ?? 0) < 700, 'Timeline event contrast is covered in the desktop Status layout.');
     await page.goto('/');
     await page.waitForSelector('#chronoscope-root');
     await seedThresholdCrossingSamples(page);
+    const timelineTab = page.getByRole('tab', { name: 'Timeline' });
+    if (await timelineTab.isVisible()) await timelineTab.click();
 
-    await expect(page.locator('.feed-row').first()).toBeVisible();
-    const opacities = await page.locator('.feed-row').evaluateAll((rows) => (
+    await expect(page.locator('.story-beat').first()).toBeVisible();
+    const opacities = await page.locator('.story-beat').evaluateAll((rows) => (
       rows.map((row) => Number(getComputedStyle(row).opacity))
     ));
     for (const opacity of opacities) {


### PR DESCRIPTION
## Summary
- add clustered timeline `beats` to the run-storyline model so related marker evidence becomes readable, time-aware events
- replace tiny timeline markers with larger desktop event pills and compact mobile event chips
- preserve mobile no-scroll/touch-target constraints and update event/timeline accessibility coverage
- clean up verdict metric semantics so axe no longer flags the measured-facts group

## Verification
- `npm run typecheck`
- `npm run lint`
- `npm test` (97 files, 1133 tests)
- `npm run build`
- `npm run test:visual -- tests/visual/overview-no-scroll.spec.ts --project=chromium` (15 passed)
- `npm run test:visual -- tests/visual/accessibility.spec.ts --project=chromium` (7 passed)
- `npm run test:visual -- tests/visual/ac-verification.spec.ts --project=chromium --grep "cold Status renders"` (1 passed)
- Browser smoke at 390x844: Timeline rows rendered with 24px minimum row height; viewport reset and local dev server stopped
