### PR TITLE
[codex] Refine live view readability

### DIFF
--- a/src/lib/components/LiveView.svelte
+++ b/src/lib/components/LiveView.svelte
@@ -54,6 +54,16 @@
     soloEndpoint ? 'solo' : liveOptions.split ? 'split' : 'unified',
   );
   const scopeHeight = $derived(mode === 'split' ? 220 : 540);
+  const modeLabel = $derived.by(() => {
+    if (mode === 'solo') return 'Focused path';
+    if (mode === 'split') return 'Split lanes';
+    return 'Unified overlay';
+  });
+  const endpointCountLabel = $derived(
+    soloEndpoint ? `1 of ${monitored.length} endpoints` : `${monitored.length} endpoint${monitored.length === 1 ? '' : 's'}`,
+  );
+  const roundLabel = $derived(`Round ${currentRound}`);
+  const windowLabel = `Last ${tokens.lane.chartWindow} rounds`;
 
   function handleDrill(epId: string): void {
     uiStore.setFocusedEndpoint(epId);
@@ -74,25 +84,45 @@
   function handleChipClick(epId: string): void {
     uiStore.setFocusedEndpoint(focusedId === epId ? null : epId);
   }
+
+  function latencyLabel(latency: number | null): string {
+    return latency === null ? 'waiting' : `${fmt(latency)} ms`;
+  }
+
+  function hasP95Value(p95: number | undefined): p95 is number {
+    return typeof p95 === 'number' && Number.isFinite(p95);
+  }
+
+  function p95Label(ready: boolean | undefined, p95: number | undefined): string {
+    return ready && hasP95Value(p95) ? `p95 ${fmt(p95)} ms` : 'p95 collecting';
+  }
+
+  function footerChipLabel(epId: string, epLabel: string, last: number | null, ready: boolean | undefined, p95: number | undefined): string {
+    const action = focusedId === epId ? 'click to clear focus' : 'click to focus this endpoint';
+    return `${epLabel}: last ${latencyLabel(last)}, ${p95Label(ready, p95)}, ${action}`;
+  }
 </script>
 
 <section class="live-wrap" aria-label="Live latency trace">
   <header class="live-header">
     <div class="live-title-block">
-      <div class="live-kicker">Live · Trace</div>
-      <h1 class="live-title">
+      <div class="live-kicker">Live</div>
+      <h1 class="live-title">Live trace</h1>
+      <div class="live-status-strip" aria-label="Live trace summary">
+        <span>{modeLabel}</span>
         {#if soloEndpoint}
           <span class="live-title-solo">
             <span class="live-title-pip" style:background={soloEndpoint.color} aria-hidden="true"></span>
-            Tracing <span class="live-title-solo-label" style:color={soloEndpoint.color}>{soloEndpoint.label}</span>
+            {soloEndpoint.label}
           </span>
-        {:else}
-          All endpoints · {liveOptions.split ? 'split' : 'unified'} view
         {/if}
-      </h1>
+        <span>{endpointCountLabel}</span>
+        <span>{roundLabel}</span>
+        <span>{windowLabel}</span>
+      </div>
     </div>
 
-    <div class="live-controls">
+    <div class="live-controls" role="group" aria-label="Live view controls">
       {#if soloEndpoint}
         <button
           type="button" class="live-chip live-chip-back"
@@ -104,7 +134,7 @@
       {/if}
 
       <div class="live-control" role="group" aria-label="Layout mode">
-        <span class="live-control-label">Mode</span>
+        <span class="live-control-label">View</span>
         <div class="live-segment">
           <!--
             Pressed state tracks `liveOptions.split` (the user's stashed
@@ -130,8 +160,8 @@
         </div>
       </div>
 
-      <div class="live-control live-control-trig" aria-label="Health threshold, {threshold} milliseconds">
-        <span class="live-control-label">Threshold</span>
+      <div class="live-control live-control-trig" role="group" aria-label="Slow trigger, {threshold} milliseconds">
+        <span class="live-control-label">Trigger</span>
         <div class="trig-display">
           {threshold}<span>ms</span>
         </div>
@@ -181,13 +211,17 @@
         class:on={focusedId === ep.id}
         aria-pressed={focusedId === ep.id}
         data-endpoint-id={ep.id}
+        aria-label={footerChipLabel(ep.id, ep.label, last, s?.ready, s?.p95)}
         onclick={() => handleChipClick(ep.id)}
       >
         <span class="live-footer-pip" style:background={color} aria-hidden="true"></span>
         <span class="live-footer-name">{ep.label}</span>
-        <span class="live-footer-val">{fmt(last)} ms</span>
-        {#if s?.ready}
-          <span class="live-footer-p95">p95 {fmt(s.p95)}</span>
+        <span class="live-footer-val">
+          <span>last</span>
+          {latencyLabel(last)}
+        </span>
+        {#if s?.ready && hasP95Value(s.p95)}
+          <span class="live-footer-p95">p95 {fmt(s.p95)} ms</span>
         {/if}
       </button>
     {/each}
@@ -227,8 +261,31 @@
     letter-spacing: var(--tr-tight);
     color: var(--t1);
   }
+  .live-status-strip {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+    margin-top: 8px;
+    min-width: 0;
+  }
+  .live-status-strip > span {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    min-width: 0;
+    padding: 3px 7px;
+    border: 1px solid var(--border-mid);
+    border-radius: 5px;
+    background: rgba(255,255,255,.035);
+    color: var(--t2);
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    letter-spacing: var(--tr-kicker);
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
   .live-title-solo { display: inline-flex; align-items: center; gap: 10px; }
-  .live-title-solo-label { letter-spacing: inherit; }
   .live-title-pip {
     width: 10px; height: 10px; border-radius: 50%;
     box-shadow: 0 0 6px currentColor;
@@ -372,9 +429,16 @@
   }
   .live-footer-name { color: inherit; }
   .live-footer-val {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
     font-variant-numeric: tabular-nums;
     color: var(--t3);
     margin-left: 3px;
+  }
+  .live-footer-val span {
+    color: var(--t4);
+    text-transform: uppercase;
   }
   .live-footer-p95 {
     color: var(--t2);

--- a/src/lib/components/ScopeCanvas.svelte
+++ b/src/lib/components/ScopeCanvas.svelte
@@ -97,6 +97,8 @@
   const thresholdLabelY = $derived(Math.max(plotY0 + 12, thresholdY - 4));
   const normalBandY = $derived(yOf(Math.min(threshold, maxMs)));
   const normalBandHeight = $derived(plotY1 - normalBandY);
+  const scaleRangeLabel = $derived(`0-${maxMs} ms`);
+  const triggerLabel = $derived(`Trigger ${threshold} ms`);
 
   // X axis ticks — every 10 rounds within the visible window; major every 30.
   interface XTick { round: number; x: number; major: boolean; }
@@ -256,7 +258,7 @@
   });
 
   const ariaLabel = $derived(
-    `Live latency scope — ${endpoints.length} endpoint${endpoints.length === 1 ? '' : 's'}, last ${WINDOW} rounds, threshold ${threshold} ms.`
+    `Live latency scope — ${endpoints.length} endpoint${endpoints.length === 1 ? '' : 's'}, last ${WINDOW} rounds, latest on right, same scale ${scaleRangeLabel}, trigger ${threshold} ms.`
   );
 
   function handleClickTrace(epId: string): void {
@@ -283,6 +285,12 @@
 </script>
 
 <div class="scope-wrap" style:height="{height}px">
+  <div class="scope-meta" role="list" aria-label="Scope scale">
+    <span role="listitem">Latest on right</span>
+    <span role="listitem">Same scale</span>
+    <span role="listitem">{scaleRangeLabel}</span>
+  </div>
+
   <svg
     bind:this={svgEl}
     class="scope-svg"
@@ -352,7 +360,7 @@
       text-anchor="end" font-size="9" font-family={tokens.typography.mono.fontFamily}
       fill="var(--svg-threshold)" letter-spacing="0.1em"
       aria-hidden="true"
-    >TRIG {threshold}</text>
+    >{triggerLabel}</text>
 
     <!-- Traces -->
     {#each traces as trace (trace.id)}
@@ -454,6 +462,31 @@
     cursor: crosshair;
   }
 
+  .scope-meta {
+    position: absolute;
+    top: 10px;
+    right: 12px;
+    z-index: 2;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    max-width: calc(100% - 24px);
+    pointer-events: none;
+  }
+  .scope-meta span {
+    min-width: 0;
+    padding: 3px 6px;
+    border: 1px solid rgba(255,255,255,.09);
+    border-radius: 5px;
+    background: rgba(3, 5, 9, .66);
+    color: var(--t3);
+    font-family: var(--mono);
+    font-size: 9px;
+    letter-spacing: var(--tr-kicker);
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
   .scope-tooltip {
     position: absolute;
     background: var(--tooltip-bg-deep);
@@ -503,5 +536,17 @@
     padding: 0; margin: -1px; overflow: hidden;
     clip-path: inset(50%);
     white-space: nowrap; border: 0;
+  }
+
+  @media (max-width: 767px) {
+    .scope-meta {
+      top: 7px;
+      right: 8px;
+      gap: 4px;
+    }
+    .scope-meta span {
+      padding: 2px 5px;
+      font-size: 8px;
+    }
   }
 </style>

--- a/src/lib/utils/run-storyline.ts
+++ b/src/lib/utils/run-storyline.ts
@@ -577,10 +577,10 @@ function beatsFor(markers: readonly StoryMarker[], rows: readonly FullEndpointRo
     }
   }
 
-  return clusters.map((cluster) => beatForCluster(cluster, rows));
+  return clusters.map((cluster, index) => beatForCluster(cluster, rows, index));
 }
 
-function beatForCluster(cluster: readonly StoryMarker[], rows: readonly FullEndpointRow[]): StoryBeat {
+function beatForCluster(cluster: readonly StoryMarker[], rows: readonly FullEndpointRow[], sequence: number): StoryBeat {
   const endpointIds = uniqueEndpointIds(cluster);
   const endpointLabel = labelForEndpoint(endpointIds[0], rows);
   const failureMarkers = cluster.filter((marker) => marker.kind === 'failure');
@@ -594,7 +594,7 @@ function beatForCluster(cluster: readonly StoryMarker[], rows: readonly FullEndp
     const count = endpointIds.length;
     const label = count > 1 ? `${count} paths failed` : `${endpointLabel} failed`;
     return {
-      id: beatId('failure', endpointIds, t),
+      id: beatId('failure', endpointIds, t, sequence),
       t,
       kind: 'failure',
       severity: 'bad',
@@ -611,7 +611,7 @@ function beatForCluster(cluster: readonly StoryMarker[], rows: readonly FullEndp
   if (slowdownMarkers.length > 1 && endpointIds.length > 1) {
     const count = endpointIds.length;
     return {
-      id: beatId('shared-slowdown', endpointIds, t),
+      id: beatId('shared-slowdown', endpointIds, t, sequence),
       t,
       kind: 'shared-slowdown',
       severity: 'bad',
@@ -626,7 +626,7 @@ function beatForCluster(cluster: readonly StoryMarker[], rows: readonly FullEndp
   if (slowdownMarkers.length > 0) {
     const label = `${endpointLabel} slow`;
     return {
-      id: beatId('slowdown', endpointIds, t),
+      id: beatId('slowdown', endpointIds, t, sequence),
       t,
       kind: 'slowdown',
       severity: 'bad',
@@ -642,7 +642,7 @@ function beatForCluster(cluster: readonly StoryMarker[], rows: readonly FullEndp
     const count = endpointIds.length;
     const label = count > 1 ? `${count} paths recovered` : `${endpointLabel} recovered`;
     return {
-      id: beatId('recovery', endpointIds, t),
+      id: beatId('recovery', endpointIds, t, sequence),
       t,
       kind: 'recovery',
       severity: 'good',
@@ -659,7 +659,7 @@ function beatForCluster(cluster: readonly StoryMarker[], rows: readonly FullEndp
   if (elevationMarkers.length > 0) {
     const label = `${endpointLabel} rose`;
     return {
-      id: beatId('elevation', endpointIds, t),
+      id: beatId('elevation', endpointIds, t, sequence),
       t,
       kind: 'elevation',
       severity: 'watch',
@@ -673,7 +673,7 @@ function beatForCluster(cluster: readonly StoryMarker[], rows: readonly FullEndp
 
   const label = endpointIds.length > 1 ? `${endpointIds.length} paths changed` : `${endpointLabel} changed`;
   return {
-    id: beatId('shared-change', endpointIds, t),
+    id: beatId('shared-change', endpointIds, t, sequence),
     t,
     kind: sharedChangeMarkers[0]?.kind ?? 'shared-change',
     severity: 'info',
@@ -685,8 +685,8 @@ function beatForCluster(cluster: readonly StoryMarker[], rows: readonly FullEndp
   };
 }
 
-function beatId(kind: StoryBeatKind, endpointIds: readonly string[], t: number): string {
-  return `${kind}-${endpointIds.length > 0 ? endpointIds.join('-') : 'all'}-${t}`;
+function beatId(kind: StoryBeatKind, endpointIds: readonly string[], t: number, sequence: number): string {
+  return `${kind}-${endpointIds.length > 0 ? endpointIds.join('-') : 'all'}-${t}-${sequence}`;
 }
 
 function uniqueEndpointIds(markers: readonly StoryMarker[]): string[] {

--- a/tests/unit/components/LiveView.test.ts
+++ b/tests/unit/components/LiveView.test.ts
@@ -1,0 +1,84 @@
+import { render } from '@testing-library/svelte';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { endpointStore } from '../../../src/lib/stores/endpoints';
+import { measurementStore } from '../../../src/lib/stores/measurements';
+import { resetStatisticsCache } from '../../../src/lib/stores/statistics';
+import { settingsStore } from '../../../src/lib/stores/settings';
+import { uiStore } from '../../../src/lib/stores/ui';
+import LiveView from '../../../src/lib/components/LiveView.svelte';
+import { DEFAULT_SETTINGS, type Endpoint } from '../../../src/lib/types';
+
+const endpoints: Endpoint[] = [
+  {
+    id: 'edge',
+    url: 'https://chronoscope.dev/probe',
+    label: 'Edge',
+    enabled: true,
+    color: '#67e8f9',
+  },
+  {
+    id: 'aws',
+    url: 'https://aws.amazon.com',
+    label: 'AWS',
+    enabled: true,
+    color: '#fbbf24',
+  },
+];
+
+const visibleRoundCount = 60;
+
+const seedLiveSamples = (): void => {
+  for (const endpoint of endpoints) {
+    measurementStore.initEndpoint(endpoint.id);
+  }
+  measurementStore.addSamples(
+    endpoints.flatMap((endpoint, endpointIndex) => (
+      Array.from({ length: visibleRoundCount }, (_, index) => ({
+        endpointId: endpoint.id,
+        round: index + 1,
+        latency: endpointIndex === 0 ? 42 : 86,
+        status: 'ok' as const,
+        timestamp: 1_765_000_000_000 + index,
+      }))
+    )),
+  );
+  for (let round = 0; round < visibleRoundCount; round += 1) {
+    measurementStore.incrementRound();
+  }
+  measurementStore.setLifecycle('running');
+};
+
+beforeEach(() => {
+  endpointStore.setEndpoints(endpoints);
+  measurementStore.reset();
+  resetStatisticsCache();
+  settingsStore.set({ ...DEFAULT_SETTINGS, healthThreshold: 120 });
+  uiStore.reset();
+  seedLiveSamples();
+});
+
+describe('LiveView', () => {
+  it('renders a calm live hierarchy with mode, window, round, and scale cues', () => {
+    const { getByRole, getByText } = render(LiveView);
+
+    expect(getByRole('heading', { name: 'Live trace' })).toBeTruthy();
+    expect(getByText('Unified overlay')).toBeTruthy();
+    expect(getByText('2 endpoints')).toBeTruthy();
+    expect(getByText('Round 60')).toBeTruthy();
+    expect(getByText('Last 60 rounds')).toBeTruthy();
+    expect(getByText('Same scale')).toBeTruthy();
+    expect(getByRole('group', { name: /Live view controls/i })).toBeTruthy();
+    expect(getByRole('group', { name: /Slow trigger, 120 milliseconds/i })).toBeTruthy();
+  });
+
+  it('labels endpoint chips with plain-language live and p95 values', () => {
+    const { getByRole } = render(LiveView);
+
+    expect(getByRole('button', {
+      name: /Edge: last 42 ms, p95 42 ms, click to focus this endpoint/i,
+    })).toBeTruthy();
+    expect(getByRole('button', {
+      name: /AWS: last 86 ms, p95 86 ms, click to focus this endpoint/i,
+    })).toBeTruthy();
+  });
+});

--- a/tests/unit/components/ScopeCanvas.test.ts
+++ b/tests/unit/components/ScopeCanvas.test.ts
@@ -1,0 +1,61 @@
+import { render } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import ScopeCanvas from '../../../src/lib/components/ScopeCanvas.svelte';
+import type { Endpoint, MeasurementSample } from '../../../src/lib/types';
+
+const endpoints: Endpoint[] = [
+  {
+    id: 'edge',
+    url: 'https://chronoscope.dev/probe',
+    label: 'Edge',
+    enabled: true,
+    color: '#67e8f9',
+  },
+  {
+    id: 'aws',
+    url: 'https://aws.amazon.com',
+    label: 'AWS',
+    enabled: true,
+    color: '#fbbf24',
+  },
+];
+
+const visibleRoundCount = 60;
+
+const samples = (latency: number): readonly MeasurementSample[] => (
+  Array.from({ length: visibleRoundCount }, (_, index) => ({
+    round: index + 1,
+    latency,
+    status: 'ok' as const,
+    timestamp: 1_765_000_000_000 + index,
+  }))
+);
+
+describe('ScopeCanvas', () => {
+  it('renders compact scale, direction, and trigger labels for the live scope', () => {
+    const { getByRole, getByText } = render(ScopeCanvas, {
+      props: {
+        endpoints,
+        samplesByEndpoint: {
+          edge: samples(42),
+          aws: samples(88),
+        },
+        threshold: 120,
+        currentRound: 60,
+        height: 540,
+        focusedEndpointId: null,
+        p99Across: 88,
+        detailScale: true,
+        onDrill: vi.fn(),
+      },
+    });
+
+    expect(getByText('Latest on right')).toBeTruthy();
+    expect(getByText('Same scale')).toBeTruthy();
+    expect(getByText('0-150 ms')).toBeTruthy();
+    expect(getByText('Trigger 120 ms')).toBeTruthy();
+    expect(getByRole('group', {
+      name: /Live latency scope.*last 60 rounds.*latest on right.*same scale 0-150 ms.*trigger 120 ms/i,
+    })).toBeTruthy();
+  });
+});

--- a/tests/unit/utils/run-storyline.test.ts
+++ b/tests/unit/utils/run-storyline.test.ts
@@ -198,6 +198,24 @@ describe('run storyline derivation', () => {
     expect(result.beats.map((beat) => beat.shortLabel)).toEqual(['AWS slow', 'AWS recovered']);
   });
 
+  it('keeps beat ids unique when same-timestamp events repeat for one endpoint', () => {
+    const repeatedTimestamp = BASE + 42_000;
+    const result = buildRunStoryline({
+      endpoints: [endpoint('aws', 'AWS')],
+      samplesByEndpoint: {
+        aws: series([
+          50, 50, 180, 181, 50, 49, 48, 182, 183,
+        ]).map((entry) => ({ ...entry, timestamp: repeatedTimestamp })),
+      },
+      threshold: 120,
+      runStart: BASE,
+    });
+
+    const beatIds = result.beats.map((beat) => beat.id);
+    expect(result.beats.map((beat) => beat.kind)).toEqual(['slowdown', 'recovery', 'slowdown']);
+    expect(new Set(beatIds).size).toBe(beatIds.length);
+  });
+
   it('does not promote below-threshold elevated latency to slow wording', () => {
     const result = buildRunStoryline({
       endpoints: [endpoint('aws', 'AWS')],


### PR DESCRIPTION
## Summary
- Reframes the Live view header around a stable `Live trace` hierarchy with mode, endpoint count, round, and window cues.
- Adds compact scope direction/scale labels and a plain `Trigger 120 ms` threshold label.
- Makes footer endpoint chips read as plain-language live/p95 values, with defensive p95 guards for malformed or collecting stats.
- Fixes duplicate timeline beat IDs surfaced by the accessibility visual run so repeated same-timestamp events do not trigger Svelte key errors.

## Test Plan
- [x] npm run typecheck
- [x] npm run lint
- [x] npm test
- [x] npm run build
- [x] npm run test:visual -- tests/visual/latency-scale.spec.ts --project=chromium
- [x] npm run test:visual -- tests/visual/accessibility.spec.ts --project=chromium
- [x] npm run test:visual -- tests/visual/overview-no-raw-url.spec.ts --project=chromium
- [x] Local browser smoke of Live view at 127.0.0.1:5174
