### PR TITLE
[codex] Harden redesigned UI across devices

### DIFF
--- a/src/lib/components/CausalVerdictStrip.svelte
+++ b/src/lib/components/CausalVerdictStrip.svelte
@@ -532,7 +532,7 @@
   }
   .verdict-drill:hover { background: rgba(103, 232, 249, 0.15); }
   .verdict-drill:focus-visible {
-    outline: 1.5px solid var(--accent-cyan);
+    outline: 2px solid var(--accent-cyan);
     outline-offset: 2px;
   }
   .verdict-drill-ep {

--- a/src/lib/components/DiagnoseView.svelte
+++ b/src/lib/components/DiagnoseView.svelte
@@ -1526,7 +1526,7 @@
     border-color: transparent;
   }
   .diagnose-chip:focus-visible {
-    outline: 1.5px solid var(--accent-cyan);
+    outline: 2px solid var(--accent-cyan);
     outline-offset: 2px;
   }
   .diagnose-chip-action {

--- a/src/lib/components/EndpointRail.svelte
+++ b/src/lib/components/EndpointRail.svelte
@@ -182,7 +182,7 @@
   }
   .rail-row.disabled, .rail-row:disabled { opacity: 0.5; cursor: not-allowed; }
   .rail-row:focus-visible {
-    outline: 1.5px solid var(--accent-cyan);
+    outline: 2px solid var(--accent-cyan);
     outline-offset: 2px;
   }
 
@@ -258,7 +258,7 @@
     border-color: var(--accent-cyan);
   }
   .rail-add:focus-visible {
-    outline: 1.5px solid var(--accent-cyan);
+    outline: 2px solid var(--accent-cyan);
     outline-offset: 2px;
   }
 

--- a/src/lib/components/EventFeed.svelte
+++ b/src/lib/components/EventFeed.svelte
@@ -169,7 +169,7 @@
     /* Inherit the row's mono + ts-sm so all columns share one baseline. */
     font: inherit;
   }
-  .feed-btn:focus-visible { outline: 1.5px solid var(--accent-cyan); outline-offset: 2px; border-radius: 6px; }
+  .feed-btn:focus-visible { outline: 2px solid var(--accent-cyan); outline-offset: 2px; border-radius: 6px; }
 
   .feed-time {
     color: var(--t2);

--- a/src/lib/components/IntelligencePanel.svelte
+++ b/src/lib/components/IntelligencePanel.svelte
@@ -235,7 +235,7 @@
   }
 
   .intelligence-button:focus-visible {
-    outline: 1.5px solid var(--accent-cyan);
+    outline: 2px solid var(--accent-cyan);
     outline-offset: 2px;
   }
 

--- a/src/lib/components/LiveView.svelte
+++ b/src/lib/components/LiveView.svelte
@@ -330,7 +330,7 @@
     border-color: transparent;
   }
   .live-chip:focus-visible {
-    outline: 1.5px solid var(--accent-cyan);
+    outline: 2px solid var(--accent-cyan);
     outline-offset: 2px;
   }
   .live-chip-back {
@@ -348,7 +348,7 @@
   }
   .live-chip-back:hover { color: var(--t1); border-color: var(--border-bright); }
   .live-chip-back:focus-visible {
-    outline: 1.5px solid var(--accent-cyan);
+    outline: 2px solid var(--accent-cyan);
     outline-offset: 2px;
   }
 
@@ -419,7 +419,7 @@
     border-color: var(--border-bright);
   }
   .live-footer-chip:focus-visible {
-    outline: 1.5px solid var(--accent-cyan);
+    outline: 2px solid var(--accent-cyan);
     outline-offset: 2px;
   }
   .live-footer-pip {

--- a/src/lib/components/OverviewSubtabStrip.svelte
+++ b/src/lib/components/OverviewSubtabStrip.svelte
@@ -92,7 +92,7 @@
     background: var(--accent-cyan);
   }
   button[role="tab"]:focus-visible {
-    outline: 1.5px solid var(--accent-cyan);
+    outline: 2px solid var(--accent-cyan);
     outline-offset: 2px;
     border-radius: 4px;
   }

--- a/src/lib/components/RacingStrip.svelte
+++ b/src/lib/components/RacingStrip.svelte
@@ -210,7 +210,7 @@
   .racing-row:hover { background: rgba(255,255,255,.03); border-color: var(--border-mid); }
   .racing-row.focused { background: rgba(255,255,255,.05); border-color: var(--border-bright); }
   .racing-row.over { background: rgba(249,168,212,.04); }
-  .racing-row:focus-visible { outline: 1.5px solid var(--accent-cyan); outline-offset: 2px; }
+  .racing-row:focus-visible { outline: 2px solid var(--accent-cyan); outline-offset: 2px; }
 
   .racing-label { display: flex; align-items: center; gap: 8px; min-width: 0; }
   .racing-dot {

--- a/src/lib/components/RunStorylineCard.svelte
+++ b/src/lib/components/RunStorylineCard.svelte
@@ -553,7 +553,7 @@
     background: rgba(18, 42, 52, .88);
   }
   .story-beat:focus-visible {
-    outline: 1.5px solid var(--accent-cyan);
+    outline: 2px solid var(--accent-cyan);
     outline-offset: 2px;
   }
   .story-beat-pin {
@@ -626,7 +626,7 @@
     border-color: var(--border-mid);
   }
   .story-row:focus-visible {
-    outline: 1.5px solid var(--accent-cyan);
+    outline: 2px solid var(--accent-cyan);
     outline-offset: 2px;
   }
   .story-label {

--- a/src/lib/components/Topbar.svelte
+++ b/src/lib/components/Topbar.svelte
@@ -388,7 +388,7 @@
     background: var(--shell-panel-hover);
   }
   .icon-btn:focus-visible {
-    outline: 1.5px solid var(--accent-cyan);
+    outline: 2px solid var(--accent-cyan);
     outline-offset: 2px;
   }
 
@@ -416,7 +416,7 @@
   .run-btn:hover:not(:disabled) { filter: brightness(1.15); }
   .run-btn:disabled { opacity: 0.55; cursor: not-allowed; }
   .run-btn:focus-visible {
-    outline: 1.5px solid var(--accent-cyan);
+    outline: 2px solid var(--accent-cyan);
     outline-offset: 2px;
   }
   .run-btn-icon { font-size: var(--ts-xs); }

--- a/src/lib/components/ViewSwitcher.svelte
+++ b/src/lib/components/ViewSwitcher.svelte
@@ -112,7 +112,7 @@
     box-shadow: 0 0 10px var(--glow-cyan);
   }
   .view-tab:focus-visible {
-    outline: 1.5px solid var(--accent-cyan);
+    outline: 2px solid var(--accent-cyan);
     outline-offset: 2px;
     border-radius: 4px;
   }

--- a/tests/visual/redesign-hardening.spec.ts
+++ b/tests/visual/redesign-hardening.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect, type Locator, type Page } from '@playwright/test';
+import { encodeSharePayload } from '../../src/lib/share/share-manager';
+import type { SharePayload } from '../../src/lib/types';
+
+const VIEWPORTS = [
+  { name: 'iphone-se', width: 375, height: 667 },
+  { name: 'mobile-390', width: 390, height: 844 },
+  { name: 'desktop', width: 1440, height: 900 },
+] as const;
+
+function sharedReportUrl(): string {
+  const payload: SharePayload = {
+    v: 2,
+    mode: 'results',
+    endpoints: [
+      { url: 'https://api.example.com', enabled: true },
+      { url: 'https://www.google.com', enabled: true },
+      { url: 'https://www.cloudflare.com', enabled: true },
+    ],
+    settings: {
+      timeout: 5000,
+      delay: 0,
+      burstRounds: 50,
+      monitorDelay: 1000,
+      cap: 250,
+      corsMode: 'no-cors',
+    },
+    report: {
+      reportKind: 'support',
+      createdAt: 1778352000000,
+      healthThreshold: 120,
+      corsMode: 'no-cors',
+      roundCount: 35,
+      totalSampleCount: 105,
+      keptSampleCount: 105,
+      truncated: false,
+    },
+    results: [240, 45, 38].map((latency) => ({
+      samples: Array.from({ length: 35 }, (_, index) => ({
+        round: index + 1,
+        latency,
+        status: 'ok' as const,
+      })),
+    })),
+  };
+
+  return `/?hardening-report=1#s=${encodeSharePayload(payload)}`;
+}
+
+async function expectNoHorizontalOverflow(page: Page, label: string): Promise<void> {
+  const overflow = await page.evaluate(() => {
+    const doc = document.documentElement;
+    const main = document.querySelector<HTMLElement>('main#main-content');
+    const overflowing = Array.from(document.querySelectorAll<HTMLElement>('body *'))
+      .map((element) => {
+        const rect = element.getBoundingClientRect();
+        return {
+          tag: element.tagName,
+          className: String(element.className),
+          text: element.textContent?.trim().slice(0, 40) ?? '',
+          right: Math.round(rect.right),
+          width: Math.round(rect.width),
+        };
+      })
+      .filter((entry) => entry.right > doc.clientWidth + 1)
+      .slice(0, 8);
+
+    return {
+      documentScrollWidth: doc.scrollWidth,
+      documentClientWidth: doc.clientWidth,
+      mainScrollWidth: main?.scrollWidth ?? 0,
+      mainClientWidth: main?.clientWidth ?? 0,
+      overflowing,
+    };
+  });
+
+  expect(
+    overflow.documentScrollWidth,
+    `${label}: document overflow ${JSON.stringify(overflow)}`,
+  ).toBeLessThanOrEqual(overflow.documentClientWidth);
+  expect(
+    overflow.mainScrollWidth,
+    `${label}: main overflow ${JSON.stringify(overflow)}`,
+  ).toBeLessThanOrEqual(overflow.mainClientWidth);
+  expect(overflow.overflowing, `${label}: overflowing elements`).toEqual([]);
+}
+
+async function expectStrongFocusRing(control: Locator, label: string): Promise<void> {
+  await control.focus();
+  const focus = await control.evaluate((element) => {
+    const style = getComputedStyle(element);
+    return {
+      outlineStyle: style.outlineStyle,
+      outlineWidth: Number.parseFloat(style.outlineWidth),
+      outlineColor: style.outlineColor,
+    };
+  });
+
+  expect(focus.outlineStyle, `${label}: outline style`).not.toBe('none');
+  expect(focus.outlineWidth, `${label}: outline width`).toBeGreaterThanOrEqual(2);
+  expect(focus.outlineColor, `${label}: outline color`).toContain('103, 232, 249');
+}
+
+test.describe('Figma redesign hardening', () => {
+  for (const viewport of VIEWPORTS) {
+    test(`primary surfaces do not create horizontal overflow at ${viewport.name}`, async ({ page }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await page.goto('/');
+      await page.waitForSelector('#chronoscope-root');
+      await expectNoHorizontalOverflow(page, `${viewport.name} Status`);
+
+      await page.getByRole('button', { name: /^Live/ }).click();
+      await page.waitForSelector('section[aria-label="Live latency trace"]');
+      await expectNoHorizontalOverflow(page, `${viewport.name} Live`);
+
+      await page.getByRole('button', { name: /^Investigate/ }).click();
+      await page.waitForSelector('section[aria-label="Investigate"]');
+      await expectNoHorizontalOverflow(page, `${viewport.name} Investigate`);
+
+      await page.goto(sharedReportUrl());
+      await page.waitForSelector('section[aria-label="Diagnostic report"]');
+      await expectNoHorizontalOverflow(page, `${viewport.name} Report`);
+    });
+  }
+
+  test('primary keyboard focus rings remain strong on the dark interface', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto('/');
+    await page.waitForSelector('#chronoscope-root');
+
+    await expectStrongFocusRing(page.getByRole('button', { name: /Run Your Own Test|Stop|Start/i }).first(), 'topbar run control');
+    await expectStrongFocusRing(page.getByRole('button', { name: /^Live/ }), 'Live tab');
+    await expectStrongFocusRing(page.getByRole('button', { name: /^Investigate/ }), 'Investigate tab');
+
+    await page.goto(sharedReportUrl());
+    await page.waitForSelector('section[aria-label="Diagnostic report"]');
+    await expectStrongFocusRing(page.getByRole('button', { name: /Copy Support Summary/i }), 'report copy summary');
+    await expectStrongFocusRing(page.getByRole('button', { name: /Copy Report Link/i }), 'report copy link');
+  });
+});


### PR DESCRIPTION
## Summary
- Add a final redesign hardening Playwright suite for 375x667, 390x844, and 1440x900 across Status, Live, Investigate, and shared Report.
- Assert primary keyboard focus rings remain visible on the dark UI.
- Strengthen component-level focus outlines from 1.5px to 2px across the redesigned interactive surfaces.

## Test Plan
- npm run typecheck
- npm run lint
- npm test
- npm run build
- npx playwright test tests/visual/redesign-hardening.spec.ts tests/visual/accessibility.spec.ts
- npx playwright test tests/visual/overview-no-scroll.spec.ts