### PR TITLE
Harden Figma overview states

### DIFF
--- a/src/lib/components/FigmaOverviewView.svelte
+++ b/src/lib/components/FigmaOverviewView.svelte
@@ -7,7 +7,10 @@
   import { settingsStore } from '$lib/stores/settings';
   import { uiStore } from '$lib/stores/ui';
   import { networkQualityStore, monitoredEndpointsStore } from '$lib/stores/derived';
-  import { buildDiagnosticNarrative, type DiagnosticNarrative } from '$lib/utils/diagnostic-narrative';
+  import {
+    buildDiagnosticNarrative,
+    type DiagnosticNarrative,
+  } from '$lib/utils/diagnostic-narrative';
   import { diagnosticAlignedScore } from '$lib/utils/classify';
   import { buildRunStoryline, type RunStoryline, type StoryBeatSeverity } from '$lib/utils/run-storyline';
   import type { Endpoint, EndpointStatistics, MeasurementSample } from '$lib/types';
@@ -104,7 +107,12 @@
     }
     return diagnosticNarrative.safeSummary.replace(/^This browser test:\s*/i, '');
   });
-  const primaryActionText = 'Verify from outside network';
+  const primaryActionText = $derived(diagnosticNarrative.primaryValidation.label);
+  const primaryActionReason = $derived(diagnosticNarrative.primaryValidation.reason);
+  const primaryActionDisabled = $derived(
+    diagnosticNarrative.primaryValidation.id === 'collect-more-samples'
+      && (measurements.lifecycle === 'running' || measurements.lifecycle === 'starting' || measurements.lifecycle === 'stopping'),
+  );
 
   const endpointRows: readonly EndpointSummary[] = $derived.by(() => (
     monitored.map((endpoint) => {
@@ -201,9 +209,31 @@
   }
 
   function handlePrimaryAction(): void {
-    const target = diagnosticNarrative.primaryValidation.endpointId;
+    const action = diagnosticNarrative.primaryValidation;
+    const target = action.endpointId;
     if (target) uiStore.setFocusedEndpoint(target);
-    uiStore.setActiveView('diagnose');
+
+    switch (action.id) {
+      case 'collect-more-samples':
+        if (
+          measurements.lifecycle === 'idle'
+          || measurements.lifecycle === 'stopped'
+          || measurements.lifecycle === 'completed'
+        ) {
+          measurementStore.setLifecycle('starting');
+        }
+        return;
+      case 'share-snapshot':
+      case 'share-support-report':
+        uiStore.toggleShare();
+        return;
+      case 'explain-browser-visibility':
+      case 'open-investigate':
+      case 'run-remote-check':
+      case 'compare-network':
+        uiStore.setActiveView('diagnose');
+        return;
+    }
   }
 
   function handleEvidenceAction(): void {
@@ -238,7 +268,14 @@
         <p><strong>Measured Fact:</strong> {measuredFact}</p>
         <p class="interpretation"><strong>Interpretation:</strong> {interpretation}</p>
         <div class="verdict-actions">
-          <button type="button" class="primary-action" onclick={handlePrimaryAction}>
+          <button
+            type="button"
+            class="primary-action"
+            title={primaryActionReason}
+            disabled={primaryActionDisabled}
+            aria-disabled={primaryActionDisabled}
+            onclick={handlePrimaryAction}
+          >
             <span aria-hidden="true">◇</span>
             {primaryActionText}
           </button>
@@ -499,6 +536,12 @@
     background: linear-gradient(135deg, var(--accent-cyan), #2f80ff);
     color: var(--shell-bg);
     box-shadow: 0 0 28px rgba(103, 232, 249, 0.26);
+  }
+
+  .primary-action:disabled {
+    cursor: default;
+    opacity: 0.72;
+    box-shadow: none;
   }
 
   .secondary-action {

--- a/tests/visual/figma-alignment.spec.ts
+++ b/tests/visual/figma-alignment.spec.ts
@@ -1,9 +1,71 @@
 import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
 const VIEWPORTS = [
   { name: 'laptop', width: 1440, height: 900 },
   { name: 'mobile', width: 390, height: 844 },
 ] as const;
+
+type OverviewFixture = 'collecting' | 'healthy' | 'isolated-slow' | 'request-failures';
+
+async function seedOverviewFixture(page: Page, fixture: OverviewFixture): Promise<void> {
+  await page.goto('/');
+  await page.waitForSelector('#chronoscope-root');
+  await expect(page.locator('section[aria-label="Overview"]')).toBeVisible();
+
+  await page.evaluate(async (fixtureName) => {
+    const [{ endpointStore }, { measurementStore }, { uiStore }] = await Promise.all([
+      import('/src/lib/stores/endpoints.ts'),
+      import('/src/lib/stores/measurements.ts'),
+      import('/src/lib/stores/ui.ts'),
+    ]);
+    let endpoints = [];
+    const unsubscribe = endpointStore.subscribe((value) => {
+      endpoints = value.filter((endpoint) => endpoint.enabled).slice(0, 4);
+    });
+    unsubscribe();
+
+    const now = Date.now();
+    const count = fixtureName === 'collecting' ? 0 : 36;
+    const slowIndex = Math.min(1, endpoints.length - 1);
+    const samplesFor = (index) => Array.from({ length: count }, (_, sampleIndex) => {
+      const isSlow = fixtureName === 'isolated-slow' && index === slowIndex;
+      const hasFailures = fixtureName === 'request-failures' && index === slowIndex && sampleIndex >= 30;
+      const latency = isSlow ? 320 : 42 + index * 8;
+      return {
+        round: sampleIndex + 1,
+        latency: hasFailures ? 5000 : latency,
+        status: hasFailures ? 'timeout' : 'ok',
+        timestamp: now - (count - sampleIndex) * 1000,
+      };
+    });
+
+    measurementStore.loadSnapshot({
+      lifecycle: 'running',
+      epoch: 9_000,
+      roundCounter: count,
+      startedAt: now - Math.max(count, 1) * 1000,
+      stoppedAt: null,
+      freezeEvents: [],
+      errorCount: 0,
+      timeoutCount: 0,
+      endpoints: Object.fromEntries(endpoints.map((endpoint, index) => {
+        const samples = samplesFor(index);
+        const last = samples.at(-1) ?? null;
+        return [endpoint.id, {
+          endpointId: endpoint.id,
+          tierLevel: 1,
+          lastLatency: last?.latency ?? null,
+          lastStatus: last?.status ?? null,
+          lastErrorMessage: null,
+          samples,
+        }];
+      })),
+    });
+    uiStore.setFocusedEndpoint(null);
+    uiStore.setActiveView('overview');
+  }, fixture);
+}
 
 test.describe('Figma alignment shell', () => {
   for (const viewport of VIEWPORTS) {
@@ -18,7 +80,7 @@ test.describe('Figma alignment shell', () => {
       await expect(page.getByRole('button', { name: 'Investigate', exact: true })).toBeVisible();
       await expect(page.getByRole('button', { name: 'Report', exact: true })).toBeVisible();
       await expect(page.locator('.verdict-card')).toBeVisible();
-      await expect(page.getByRole('button', { name: /Verify from outside network/i })).toBeVisible();
+      await expect(page.locator('.verdict-actions .primary-action')).toBeVisible();
       await expect(page.locator('.rail')).toHaveCount(0);
       await expect(page.locator('svg.dial')).toHaveCount(0);
 
@@ -35,5 +97,42 @@ test.describe('Figma alignment shell', () => {
 
     await expect(page.locator('section[aria-label="Diagnostic report"]')).toBeVisible();
     await expect(page.locator('.rail')).toHaveCount(0);
+  });
+
+  test('Overview collecting state does not ask users to validate a sparse result', async ({ page }) => {
+    await seedOverviewFixture(page, 'collecting');
+
+    await expect(page.locator('.severity-pill')).toHaveText('Collecting');
+    await expect(page.locator('.verdict-card h1')).toContainText('Collecting enough data');
+    await expect(page.locator('.verdict-actions .primary-action')).toHaveText(/Collect more samples/i);
+    await expect(page.locator('.verdict-actions .primary-action')).toBeDisabled();
+    await expect(page.locator('.score-ring strong')).toHaveText('—');
+  });
+
+  test('Overview healthy state promotes a snapshot instead of an outside-network chase', async ({ page }) => {
+    await seedOverviewFixture(page, 'healthy');
+
+    await expect(page.locator('.severity-pill')).toHaveText('Good');
+    await expect(page.locator('.verdict-card h1')).toContainText(/healthy|Looks good/i);
+    await expect(page.locator('.verdict-actions .primary-action')).toHaveText(/Copy Snapshot Link/i);
+    await expect(page.locator('.endpoint-row')).toContainText(['Stable performance']);
+  });
+
+  test('Overview degraded state follows the diagnostic action and highlights the slow endpoint', async ({ page }) => {
+    await seedOverviewFixture(page, 'isolated-slow');
+
+    await expect(page.locator('.severity-pill')).toHaveText('Degraded');
+    await expect(page.locator('.verdict-card h1')).toContainText('is slower than the others');
+    await expect(page.locator('.verdict-actions .primary-action')).toHaveText(/Review browser visibility/i);
+    await expect(page.locator('.endpoint-row[data-tone="warn"]')).toContainText('Latency spikes detected');
+  });
+
+  test('Overview failure state names failed browser checks without implying cause', async ({ page }) => {
+    await seedOverviewFixture(page, 'request-failures');
+
+    await expect(page.locator('.severity-pill')).toHaveText('Degraded');
+    await expect(page.locator('.verdict-card h1')).toContainText('Some requests are failing');
+    await expect(page.locator('.endpoint-row[data-tone="bad"]')).toContainText('Request failed in browser check');
+    await expect(page.locator('.verdict-card')).not.toContainText(/cause|prove|your local Wi-Fi .* fine/i);
   });
 });


### PR DESCRIPTION
## Summary

This continues the Figma alignment recovery with Overview state hardening.

- Drives the Overview primary CTA from `diagnosticNarrative.primaryValidation` instead of the previous hardcoded outside-network CTA.
- Routes primary actions by evidence boundary: sparse runs collect more samples, clean runs open sharing, visibility/proof actions open Investigate.
- Disables the collecting CTA while measurement is already running so sparse data does not present a fake next command.
- Adds deterministic visual guardrails for collecting, healthy, isolated-slow, and request-failure Overview states across desktop and mobile projects.

## Why

The Figma shell is now visible on production, but the Overview still reused one CTA for every state. That was not accurate: a clean run should not push users into an outside-network chase, and sparse data should not ask for validation before the product has enough evidence.

## Fidelity / mismatch ledger

- Preserved: Figma-style top shell, verdict card hierarchy, score ring as supporting module, measured endpoints, event log, no old rail, no old giant dial-first layout.
- Intentional deviation from frozen Figma reference: the primary CTA is no longer always `Verify from outside network`; it now changes based on evidence because trust/accuracy outrank static visual copy.
- Checked screenshots: degraded desktop and collecting mobile were rendered locally after the change.
- Browser plugin note: in-app Browser setup failed with `browser.nameSession is not a function`, so screenshot verification used Playwright fallback.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`
- `npx playwright test tests/visual/figma-alignment.spec.ts`
- `git diff --check`
