### PR TITLE
Align secondary surfaces with Figma shell

### DIFF
--- a/src/lib/components/DiagnoseView.svelte
+++ b/src/lib/components/DiagnoseView.svelte
@@ -326,8 +326,8 @@
   );
 </script>
 
-<section class="diagnose" aria-label="Investigate">
-  <header class="diagnose-header">
+<section class="diagnose diagnose-surface" aria-label="Investigate">
+  <header class="diagnose-header diagnose-hero">
     <div class="diagnose-title-block">
       <div class="diagnose-kicker">Investigate · Distribution and correlation</div>
       <h1 class="diagnose-title">
@@ -402,7 +402,7 @@
       </div>
     </section>
 
-    <div class="diagnose-evidence-layout">
+    <div class="diagnose-evidence-layout diagnose-proof-grid">
       <section class="diagnose-facts-stack" aria-label="Measured browser facts">
         <div class="diagnose-column-head">
           <div class="diagnose-section-kicker">Measured browser facts</div>
@@ -785,10 +785,12 @@
 
 <style>
   .diagnose {
-    padding: 18px 28px 40px;
+    width: min(100%, 1320px);
+    margin: 0 auto;
+    padding: clamp(24px, 4vw, 48px) clamp(16px, 4vw, 48px) 44px;
     display: flex;
     flex-direction: column;
-    gap: 18px;
+    gap: 22px;
     min-height: 0;
     overflow-y: auto;
     flex: 1;
@@ -797,9 +799,16 @@
   .diagnose-header {
     display: flex;
     justify-content: space-between;
-    align-items: flex-end;
-    gap: 20px;
+    align-items: center;
+    gap: 24px;
     flex-wrap: wrap;
+    padding: clamp(20px, 3vw, 30px);
+    border: 1px solid var(--shell-border-strong);
+    border-radius: 18px;
+    background:
+      radial-gradient(circle at 12% 40%, var(--shell-bg-cyan), transparent 32%),
+      linear-gradient(135deg, var(--shell-panel-raised), rgba(16, 23, 34, 0.72));
+    box-shadow: 0 28px 90px rgba(0, 0, 0, 0.18);
   }
   .diagnose-kicker {
     font-family: var(--mono);
@@ -828,9 +837,9 @@
     flex-direction: column;
     gap: 8px;
     padding: 16px;
-    background: rgba(255, 255, 255, 0.025);
-    border: 1px solid var(--border-mid);
-    border-radius: 10px;
+    background: rgba(8, 14, 24, 0.62);
+    border: 1px solid var(--shell-border);
+    border-radius: 14px;
   }
   .distro-stats {
     display: flex;
@@ -899,9 +908,9 @@
     flex-direction: column;
     gap: 10px;
     padding: 16px;
-    background: rgba(255, 255, 255, 0.025);
-    border: 1px solid var(--border-mid);
-    border-radius: 10px;
+    background: rgba(8, 14, 24, 0.62);
+    border: 1px solid var(--shell-border);
+    border-radius: 14px;
   }
   .diagnose-brief {
     display: grid;
@@ -912,10 +921,10 @@
     min-height: 220px;
     background:
       linear-gradient(135deg, rgba(103, 232, 249, 0.07), rgba(37, 99, 235, 0.035) 42%, rgba(255, 255, 255, 0.022)),
-      rgba(255, 255, 255, 0.026);
-    border-color: color-mix(in srgb, var(--accent-cyan) 18%, var(--border-mid));
-    border-radius: 16px;
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.24);
+      var(--shell-panel-raised);
+    border-color: color-mix(in srgb, var(--accent-cyan) 20%, var(--shell-border-strong));
+    border-radius: 18px;
+    box-shadow: 0 28px 90px rgba(0, 0, 0, 0.18);
   }
   .diagnose-brief-score {
     width: clamp(112px, 12vw, 148px);
@@ -967,7 +976,7 @@
   .diagnose-evidence-layout {
     display: grid;
     grid-template-columns: minmax(0, 1.22fr) minmax(320px, 0.78fr);
-    gap: 18px;
+    gap: 22px;
     align-items: start;
   }
   .diagnose-facts-stack,
@@ -1062,9 +1071,8 @@
     color: var(--t1);
     font-family: var(--mono);
     font-size: var(--ts-sm);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    line-height: 1.35;
+    overflow-wrap: anywhere;
   }
   .visibility-headline {
     color: var(--t1);
@@ -1317,9 +1325,9 @@
     flex-direction: column;
     gap: 10px;
     padding: 16px;
-    background: rgba(255, 255, 255, 0.025);
-    border: 1px solid var(--border-mid);
-    border-radius: 10px;
+    background: rgba(8, 14, 24, 0.62);
+    border: 1px solid var(--shell-border);
+    border-radius: 14px;
   }
   .correlation-headline {
     margin: 0;
@@ -1396,9 +1404,9 @@
 
   /* ── Phase breakdown (collapsed by default) ────────────────────────────── */
   .diagnose-phases {
-    background: rgba(255, 255, 255, 0.025);
-    border: 1px solid var(--border-mid);
-    border-radius: 10px;
+    background: rgba(8, 14, 24, 0.62);
+    border: 1px solid var(--shell-border);
+    border-radius: 14px;
     padding: 16px;
   }
   .diagnose-phases summary {
@@ -1474,8 +1482,9 @@
   }
   .diagnose-title {
     margin: 0;
-    font-size: var(--ts-2xl);
-    font-weight: 500;
+    font-size: clamp(30px, 3.6vw, 46px);
+    line-height: 1.06;
+    font-weight: 700;
     letter-spacing: var(--tr-tight);
     color: var(--t1);
     display: flex;
@@ -1530,8 +1539,8 @@
     outline-offset: 2px;
   }
   .diagnose-chip-action {
-    background: transparent;
-    border: 1px solid var(--border-mid);
+    background: rgba(8, 14, 24, 0.44);
+    border: 1px solid var(--shell-border);
   }
 
   /* Empty states */
@@ -1676,8 +1685,8 @@
 
   /* Samples */
   .diagnose-samples {
-    background: var(--glass-bg-rail-hover);
-    border: 1px solid var(--border-mid);
+    background: rgba(8, 14, 24, 0.62);
+    border: 1px solid var(--shell-border);
     border-radius: 14px;
     padding: 14px 18px;
     display: flex;
@@ -1757,8 +1766,8 @@
   }
 
   @media (max-width: 767px) {
-    .diagnose { padding: 12px; gap: 12px; }
-    .diagnose-header { flex-direction: column; align-items: flex-start; }
+    .diagnose { width: 100%; padding: 16px; gap: 14px; }
+    .diagnose-header { flex-direction: column; align-items: flex-start; gap: 14px; }
     .diagnose-brief {
       display: flex;
       flex-direction: column;

--- a/src/lib/components/LiveView.svelte
+++ b/src/lib/components/LiveView.svelte
@@ -103,11 +103,11 @@
   }
 </script>
 
-<section class="live-wrap" aria-label="Live latency trace">
-  <header class="live-header">
+<section class="live-wrap live-surface" aria-label="Live latency trace">
+  <header class="live-header live-hero">
     <div class="live-title-block">
       <div class="live-kicker">Live</div>
-      <h1 class="live-title">Live trace</h1>
+      <h1 class="live-title">Live latency trace</h1>
       <div class="live-status-strip" aria-label="Live trace summary">
         <span>{modeLabel}</span>
         {#if soloEndpoint}
@@ -169,35 +169,37 @@
     </div>
   </header>
 
-  {#if mode === 'split'}
-    <div class="scope-stack">
-      {#each visibleEndpoints as ep (ep.id)}
-        <ScopeCanvas
-          endpoints={[ep]}
-          samplesByEndpoint={{ [ep.id]: samplesByEndpoint[ep.id] ?? [] }}
-          {threshold}
-          {currentRound}
-          height={scopeHeight}
-          focusedEndpointId={null}
-          {p99Across}
-          detailScale={true}
-          onDrill={handleDrill}
-        />
-      {/each}
-    </div>
-  {:else}
-    <ScopeCanvas
-      endpoints={visibleEndpoints}
-      {samplesByEndpoint}
-      {threshold}
-      {currentRound}
-      height={scopeHeight}
-      focusedEndpointId={soloEndpoint ? null : focusedId}
-      {p99Across}
-      detailScale={true}
-      onDrill={handleDrill}
-    />
-  {/if}
+  <div class="live-scope-panel" data-mode={mode}>
+    {#if mode === 'split'}
+      <div class="scope-stack">
+        {#each visibleEndpoints as ep (ep.id)}
+          <ScopeCanvas
+            endpoints={[ep]}
+            samplesByEndpoint={{ [ep.id]: samplesByEndpoint[ep.id] ?? [] }}
+            {threshold}
+            {currentRound}
+            height={scopeHeight}
+            focusedEndpointId={null}
+            {p99Across}
+            detailScale={true}
+            onDrill={handleDrill}
+          />
+        {/each}
+      </div>
+    {:else}
+      <ScopeCanvas
+        endpoints={visibleEndpoints}
+        {samplesByEndpoint}
+        {threshold}
+        {currentRound}
+        height={scopeHeight}
+        focusedEndpointId={soloEndpoint ? null : focusedId}
+        {p99Across}
+        detailScale={true}
+        onDrill={handleDrill}
+      />
+    {/if}
+  </div>
 
   <footer class="live-footer" aria-label="Endpoint summary">
     <span class="live-footer-kicker">Endpoints</span>
@@ -230,21 +232,31 @@
 
 <style>
   .live-wrap {
-    padding: 18px 24px 24px;
+    width: min(100%, 1320px);
+    margin: 0 auto;
+    padding: clamp(24px, 4vw, 48px) clamp(16px, 4vw, 48px) 40px;
     display: flex;
     flex-direction: column;
-    gap: 14px;
+    gap: 22px;
     min-height: 0;
     overflow-y: auto;
     flex: 1;
+    color: var(--t1);
   }
 
   .live-header {
     display: flex;
     justify-content: space-between;
-    align-items: flex-end;
-    gap: 20px;
+    align-items: center;
+    gap: 24px;
     flex-wrap: wrap;
+    padding: clamp(20px, 3vw, 30px);
+    border: 1px solid var(--shell-border-strong);
+    border-radius: 18px;
+    background:
+      radial-gradient(circle at 12% 40%, var(--shell-bg-cyan), transparent 32%),
+      linear-gradient(135deg, var(--shell-panel-raised), rgba(16, 23, 34, 0.72));
+    box-shadow: 0 28px 90px rgba(0, 0, 0, 0.18);
   }
   .live-kicker {
     font-family: var(--mono);
@@ -256,8 +268,9 @@
   }
   .live-title {
     margin: 0;
-    font-size: var(--ts-2xl);
-    font-weight: 500;
+    font-size: clamp(30px, 3.6vw, 46px);
+    line-height: 1.06;
+    font-weight: 700;
     letter-spacing: var(--tr-tight);
     color: var(--t1);
   }
@@ -275,9 +288,9 @@
     gap: 5px;
     min-width: 0;
     padding: 3px 7px;
-    border: 1px solid var(--border-mid);
-    border-radius: 5px;
-    background: rgba(255,255,255,.035);
+    border: 1px solid var(--shell-border);
+    border-radius: 6px;
+    background: rgba(255,255,255,.04);
     color: var(--t2);
     font-family: var(--mono);
     font-size: var(--ts-xs);
@@ -291,7 +304,16 @@
     box-shadow: 0 0 6px currentColor;
   }
 
-  .live-controls { display: flex; align-items: flex-end; gap: 14px; flex-wrap: wrap; }
+  .live-controls {
+    display: flex;
+    align-items: flex-end;
+    gap: 14px;
+    flex-wrap: wrap;
+    padding: 12px;
+    border: 1px solid var(--shell-border);
+    border-radius: 14px;
+    background: rgba(8, 14, 24, 0.58);
+  }
   .live-control { display: flex; flex-direction: column; gap: 4px; }
   .live-control-label {
     font-family: var(--mono);
@@ -305,7 +327,7 @@
     padding: 2px;
     background: rgba(255, 255, 255, 0.04);
     border-radius: 7px;
-    border: 1px solid var(--border-mid);
+    border: 1px solid var(--shell-border);
     gap: 2px;
   }
   .live-chip {
@@ -322,10 +344,10 @@
   }
   .live-chip:hover {
     color: var(--t1);
-    border-color: var(--border-bright);
+    border-color: var(--shell-border-strong);
   }
   .live-chip.on {
-    background: rgba(255, 255, 255, 0.08);
+    background: var(--shell-panel-active);
     color: var(--t1);
     border-color: transparent;
   }
@@ -337,7 +359,7 @@
     padding: 6px 12px;
     border-radius: 5px;
     background: transparent;
-    border: 1px solid var(--border-mid);
+    border: 1px solid var(--shell-border);
     color: var(--t2);
     font-family: var(--mono);
     font-size: var(--ts-xs);
@@ -346,7 +368,7 @@
     transition: color 160ms ease, background 160ms ease, border-color 160ms ease;
     align-self: flex-end;
   }
-  .live-chip-back:hover { color: var(--t1); border-color: var(--border-bright); }
+  .live-chip-back:hover { color: var(--t1); border-color: var(--shell-border-strong); }
   .live-chip-back:focus-visible {
     outline: 2px solid var(--accent-cyan);
     outline-offset: 2px;
@@ -370,6 +392,16 @@
     letter-spacing: var(--tr-label);
   }
 
+  .live-scope-panel {
+    min-width: 0;
+    padding: clamp(12px, 2vw, 18px);
+    border: 1px solid var(--shell-border);
+    border-radius: 18px;
+    background: rgba(8, 14, 24, 0.68);
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.18);
+    overflow: hidden;
+  }
+
   .scope-stack {
     display: flex;
     flex-direction: column;
@@ -382,9 +414,9 @@
     gap: 6px;
     flex-wrap: wrap;
     padding: 10px 12px;
-    background: var(--glass-bg-rail-hover);
-    border: 1px solid var(--border-mid);
-    border-radius: 10px;
+    background: rgba(8, 14, 24, 0.62);
+    border: 1px solid var(--shell-border);
+    border-radius: 14px;
   }
   .live-footer-kicker {
     font-family: var(--mono);
@@ -401,7 +433,7 @@
     padding: 5px 10px;
     border-radius: 6px;
     background: rgba(255, 255, 255, 0.03);
-    border: 1px solid var(--border-mid);
+    border: 1px solid var(--shell-border);
     color: var(--t2);
     font-family: var(--mono);
     font-size: var(--ts-xs);
@@ -411,12 +443,12 @@
   }
   .live-footer-chip:hover {
     color: var(--t1);
-    border-color: var(--border-bright);
+    border-color: var(--shell-border-strong);
   }
   .live-footer-chip.on {
     background: rgba(255, 255, 255, 0.06);
     color: var(--t1);
-    border-color: var(--border-bright);
+    border-color: var(--shell-border-strong);
   }
   .live-footer-chip:focus-visible {
     outline: 2px solid var(--accent-cyan);
@@ -451,7 +483,10 @@
   }
 
   @media (max-width: 767px) {
-    .live-wrap { padding: 12px; gap: 10px; }
-    .live-header { flex-direction: column; align-items: flex-start; gap: 10px; }
+    .live-wrap { width: 100%; padding: 16px; gap: 14px; }
+    .live-header { flex-direction: column; align-items: flex-start; gap: 14px; }
+    .live-controls { width: 100%; align-items: stretch; }
+    .live-control { flex: 1 1 120px; min-width: 0; }
+    .live-scope-panel { padding: 10px; border-radius: 14px; }
   }
 </style>

--- a/src/lib/components/ReportView.svelte
+++ b/src/lib/components/ReportView.svelte
@@ -290,7 +290,7 @@
 </script>
 
 <section
-  class="report"
+  class="report report-surface"
   aria-label="Diagnostic report"
   style:--accent-cyan={tokens.color.accent.cyan}
   style:--accent-green={tokens.color.accent.green}
@@ -600,9 +600,9 @@
 <style>
   .report {
     width: 100%;
-    max-width: min(1120px, calc(100vw - 32px));
+    max-width: min(1320px, calc(100vw - 32px));
     margin: 0 auto;
-    padding: 22px 0 32px;
+    padding: clamp(24px, 4vw, 48px) 0 44px;
     color: var(--t1);
     font-family: var(--sans);
   }
@@ -610,12 +610,12 @@
   .report-hero {
     position: relative;
     overflow: hidden;
-    border: 1px solid var(--border-mid);
-    border-radius: 8px;
+    border: 1px solid var(--shell-border-strong);
+    border-radius: 18px;
     background:
-      linear-gradient(135deg, rgba(103,232,249,.085), transparent 32%),
-      linear-gradient(145deg, rgba(16,23,34,.88), rgba(8,12,19,.82));
-    box-shadow: 0 24px 80px rgba(0,0,0,.22);
+      radial-gradient(circle at 12% 40%, var(--shell-bg-cyan), transparent 32%),
+      linear-gradient(135deg, var(--shell-panel-raised), rgba(16, 23, 34, 0.72));
+    box-shadow: 0 28px 90px rgba(0,0,0,.18);
   }
   .report-hero::after {
     content: "";
@@ -629,7 +629,7 @@
     display: grid;
     grid-template-columns: minmax(0, 1fr) minmax(260px, 340px);
     gap: 24px;
-    padding: 28px;
+    padding: clamp(22px, 3vw, 34px);
   }
   .report-copy {
     min-width: 0;
@@ -659,8 +659,8 @@
   h1 {
     margin: 0;
     max-width: 820px;
-    font-size: 44px;
-    line-height: 1.02;
+    font-size: clamp(32px, 4.1vw, 52px);
+    line-height: 1.06;
     letter-spacing: 0;
   }
 
@@ -685,8 +685,8 @@
     flex-direction: column;
     gap: 8px;
     padding: 16px;
-    border: 1px solid rgba(103,232,249,.18);
-    border-radius: 8px;
+    border: 1px solid var(--shell-border);
+    border-radius: 14px;
     background: rgba(7,11,18,.62);
   }
   .report-fact-card span {
@@ -739,7 +739,7 @@
   .action {
     min-height: 44px;
     border-radius: 8px;
-    border: 1px solid var(--border-mid);
+    border: 1px solid var(--shell-border);
     background: rgba(255,255,255,.025);
     color: var(--t2);
     padding: 0 13px;
@@ -749,7 +749,7 @@
   }
   .action:hover {
     color: var(--t1);
-    border-color: var(--border-bright);
+    border-color: var(--shell-border-strong);
   }
   .action-primary {
     color: var(--accent-cyan);
@@ -796,15 +796,15 @@
     grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: 1px;
     margin: 18px 0;
-    border: 1px solid var(--border-mid);
-    border-radius: 8px;
+    border: 1px solid var(--shell-border);
+    border-radius: 14px;
     overflow: hidden;
-    background: var(--border-mid);
+    background: var(--shell-border);
   }
   .report-strip > div {
     min-width: 0;
     padding: 13px 14px;
-    background: rgba(12,10,20,.68);
+    background: rgba(8, 14, 24, 0.68);
     display: flex;
     flex-direction: column;
     gap: 4px;
@@ -816,9 +816,9 @@
 
   .evidence-trail {
     margin-bottom: 18px;
-    border: 1px solid var(--border-mid);
-    border-radius: 8px;
-    background: rgba(12,10,20,.58);
+    border: 1px solid var(--shell-border);
+    border-radius: 14px;
+    background: rgba(8, 14, 24, 0.62);
     padding: 14px;
   }
 
@@ -932,9 +932,9 @@
 
   .report-panel,
   .next-steps {
-    border: 1px solid var(--border-mid);
-    border-radius: 8px;
-    background: rgba(12,10,20,.58);
+    border: 1px solid var(--shell-border);
+    border-radius: 14px;
+    background: rgba(8, 14, 24, 0.62);
     padding: 16px;
   }
   .next-steps {

--- a/tests/unit/components/LiveView.test.ts
+++ b/tests/unit/components/LiveView.test.ts
@@ -61,7 +61,7 @@ describe('LiveView', () => {
   it('renders a calm live hierarchy with mode, window, round, and scale cues', () => {
     const { getByRole, getByText } = render(LiveView);
 
-    expect(getByRole('heading', { name: 'Live trace' })).toBeTruthy();
+    expect(getByRole('heading', { name: 'Live latency trace' })).toBeTruthy();
     expect(getByText('Unified overlay')).toBeTruthy();
     expect(getByText('2 endpoints')).toBeTruthy();
     expect(getByText('Round 60')).toBeTruthy();

--- a/tests/visual/figma-alignment.spec.ts
+++ b/tests/visual/figma-alignment.spec.ts
@@ -69,6 +69,11 @@ async function seedOverviewFixture(page: Page, fixture: OverviewFixture): Promis
   }, fixture);
 }
 
+async function expectNoHorizontalOverflow(page: Page): Promise<void> {
+  const overflow = await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth);
+  expect(overflow).toBe(false);
+}
+
 test.describe('Figma alignment shell', () => {
   for (const viewport of VIEWPORTS) {
     test(`Overview first impression matches aligned shell at ${viewport.name}`, async ({ page }) => {
@@ -86,8 +91,7 @@ test.describe('Figma alignment shell', () => {
       await expect(page.locator('.rail')).toHaveCount(0);
       await expect(page.locator('svg.dial')).toHaveCount(0);
 
-      const overflow = await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth);
-      expect(overflow).toBe(false);
+      await expectNoHorizontalOverflow(page);
     });
   }
 
@@ -177,7 +181,63 @@ test.describe('Figma alignment shell', () => {
     expect(box?.height ?? 0).toBeGreaterThanOrEqual(MIN_ENDPOINT_HISTORY_HEIGHT);
     await expect(page.locator('.event-timeline')).toBeVisible();
 
-    const overflow = await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth);
-    expect(overflow).toBe(false);
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test('Live surface uses the aligned shell with compact endpoint evidence', async ({ page }) => {
+    await seedOverviewFixture(page, 'isolated-slow');
+
+    await page.getByRole('button', { name: 'Live', exact: true }).click();
+
+    await expect(page.locator('section[aria-label="Live latency trace"]')).toBeVisible();
+    await expect(page.locator('.live-surface')).toBeVisible();
+    await expect(page.locator('.live-hero')).toBeVisible();
+    await expect(page.locator('.live-scope-panel')).toBeVisible();
+    await expect(page.locator('.live-footer')).toBeVisible();
+    await expect(page.locator('.live-footer-chip')).toHaveCount(4);
+    await expect(page.locator('.rail')).toHaveCount(0);
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test('Live surface stays scroll-safe at mobile width', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await seedOverviewFixture(page, 'isolated-slow');
+
+    await page.getByRole('button', { name: 'Live', exact: true }).click();
+
+    await expect(page.locator('.live-surface')).toBeVisible();
+    await expect(page.locator('.live-hero')).toBeVisible();
+    await expect(page.locator('.live-scope-panel')).toBeVisible();
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test('Investigate surface separates facts, interpretation, and proof boundaries', async ({ page }) => {
+    await seedOverviewFixture(page, 'isolated-slow');
+
+    await page.getByRole('button', { name: 'Investigate', exact: true }).click();
+
+    await expect(page.locator('section[aria-label="Investigate"]')).toBeVisible();
+    await expect(page.locator('.diagnose-surface')).toBeVisible();
+    await expect(page.locator('.diagnose-hero')).toBeVisible();
+    await expect(page.locator('.diagnose-proof-grid')).toBeVisible();
+    await expect(page.locator('.diagnose-answer-fact')).toContainText('Measured fact:');
+    await expect(page.locator('.diagnose-answer-interpretation')).toContainText('Interpretation:');
+    await expect(page.locator('.diagnose-proof-stack')).toContainText('Next proof actions');
+    await expect(page.locator('.diagnose')).not.toContainText(/prove your local|root cause|definitely/i);
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test('Report surface is aligned, shareable, and scroll-safe', async ({ page }) => {
+    await seedOverviewFixture(page, 'healthy');
+
+    await page.getByRole('button', { name: 'Report', exact: true }).click();
+
+    await expect(page.locator('section[aria-label="Diagnostic report"]')).toBeVisible();
+    await expect(page.locator('.report-surface')).toBeVisible();
+    await expect(page.locator('.report-hero')).toBeVisible();
+    await expect(page.locator('.report-strip')).toBeVisible();
+    await expect(page.locator('.evidence-trail')).toBeVisible();
+    await expect(page.getByRole('button', { name: /Copy Report Link/i })).toBeVisible();
+    await expectNoHorizontalOverflow(page);
   });
 });


### PR DESCRIPTION
## Summary
- Align Live with the Figma shell using a hero header, scoped canvas panel, and compact endpoint evidence chips.
- Align Investigate with the same shell while preserving measured-fact, interpretation, browser-limitation, and next-proof boundaries.
- Align Report with wider shell geometry, stronger hero/card treatment, and scroll-safe visual acceptance coverage.

## Verification
- npm run typecheck
- npm run lint
- npm test
- npm run build
- npx playwright test tests/visual/figma-alignment.spec.ts --project=chromium
- git diff --check

## Visual QA
- Captured and inspected local screenshots for Live, Investigate, Report, and mobile Live.
- Browser plugin was unavailable earlier in this thread, so rendered QA used Playwright Chromium.