### PR TITLE
Add Figma fidelity gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:visual": "playwright test",
+    "smoke:live": "node scripts/smoke-live-site.cjs",
     "companion": "node companion/local-agent.cjs",
     "deploy": "npm run build && wrangler pages deploy dist --project-name chronoscope"
   },

--- a/scripts/smoke-live-site.cjs
+++ b/scripts/smoke-live-site.cjs
@@ -1,0 +1,87 @@
+const { chromium } = require('playwright');
+
+const url = process.env.LIVE_SMOKE_URL ?? 'https://chronoscope.dev/';
+
+function noHorizontalOverflow(page) {
+  return page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth);
+}
+
+function count(page, selector) {
+  return page.locator(selector).count();
+}
+
+async function main() {
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1440, height: 900 }, deviceScaleFactor: 1 });
+  const errors = [];
+
+  try {
+    page.on('console', (message) => {
+      if (message.type() === 'error') errors.push(message.text());
+    });
+    page.on('pageerror', (error) => errors.push(error.message));
+
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+    await page.waitForSelector('#chronoscope-root', { timeout: 30_000 });
+
+    const checks = [];
+
+    await page.getByRole('button', { name: 'Live', exact: true }).click();
+    await page.waitForSelector('.live-surface', { timeout: 10_000 });
+    await page.waitForTimeout(250);
+    checks.push({
+      name: 'live',
+      hero: await count(page, '.live-hero'),
+      primaryPanel: await count(page, '.live-scope-panel'),
+      noHorizontalOverflow: await noHorizontalOverflow(page),
+    });
+
+    await page.getByRole('button', { name: 'Investigate', exact: true }).click();
+    await page.waitForSelector('.diagnose-surface', { timeout: 10_000 });
+    await page.waitForTimeout(250);
+    checks.push({
+      name: 'investigate',
+      hero: await count(page, '.diagnose-hero'),
+      primaryPanel: await count(page, '.diagnose-proof-grid'),
+      noHorizontalOverflow: await noHorizontalOverflow(page),
+    });
+
+    await page.getByRole('button', { name: 'Report', exact: true }).click();
+    await page.waitForSelector('.report-surface', { timeout: 10_000 });
+    await page.waitForTimeout(250);
+    checks.push({
+      name: 'report',
+      hero: await count(page, '.report-hero'),
+      primaryPanel: await count(page, '.report-strip'),
+      noHorizontalOverflow: await noHorizontalOverflow(page),
+    });
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.getByRole('button', { name: 'Live', exact: true }).click();
+    await page.waitForSelector('.live-surface', { timeout: 10_000 });
+    await page.waitForTimeout(250);
+    checks.push({
+      name: 'mobile-live',
+      hero: await count(page, '.live-hero'),
+      primaryPanel: await count(page, '.live-scope-panel'),
+      noHorizontalOverflow: await noHorizontalOverflow(page),
+    });
+
+    const failures = checks.filter((check) => (
+      check.hero !== 1 || check.primaryPanel !== 1 || !check.noHorizontalOverflow
+    ));
+
+    process.stdout.write(`${JSON.stringify({ url, checks, errors }, null, 2)}\n`);
+
+    if (errors.length > 0 || failures.length > 0) {
+      process.exitCode = 1;
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/src/lib/components/FigmaOverviewView.svelte
+++ b/src/lib/components/FigmaOverviewView.svelte
@@ -399,6 +399,7 @@
             <button
               type="button"
               class="endpoint-row"
+              data-endpoint-id={row.endpoint.id}
               data-tone={row.tone}
               aria-label="{row.endpoint.label}. {row.status}. {row.recent}. Latest {formatLatency(row.latency)} milliseconds."
               onclick={() => handleEndpointDrill(row.endpoint.id, 'live')}

--- a/tests/visual/accessibility.spec.ts
+++ b/tests/visual/accessibility.spec.ts
@@ -113,12 +113,16 @@ test.describe('Accessibility', () => {
 
     await expectNoAxeViolations(page);
 
-    await page.getByRole('button', { name: /^Live/ }).click();
+    await page.getByRole('button', { name: 'Live', exact: true }).click();
     await page.waitForSelector('section[aria-label="Live latency trace"]');
     await expectNoAxeViolations(page);
 
-    await page.getByRole('button', { name: /^Investigate/ }).click();
+    await page.getByRole('button', { name: 'Investigate', exact: true }).click();
     await page.waitForSelector('section[aria-label="Investigate"]');
+    await expectNoAxeViolations(page);
+
+    await page.getByRole('button', { name: 'Report', exact: true }).click();
+    await page.waitForSelector('section[aria-label="Diagnostic report"]');
     await expectNoAxeViolations(page);
   });
 
@@ -130,8 +134,8 @@ test.describe('Accessibility', () => {
     const timelineTab = page.getByRole('tab', { name: 'Timeline' });
     if (await timelineTab.isVisible()) await timelineTab.click();
 
-    await expect(page.locator('.story-beat').first()).toBeVisible();
-    const opacities = await page.locator('.story-beat').evaluateAll((rows) => (
+    await expect(page.locator('.event-entry').first()).toBeVisible();
+    const opacities = await page.locator('.event-entry').evaluateAll((rows) => (
       rows.map((row) => Number(getComputedStyle(row).opacity))
     ));
     for (const opacity of opacities) {

--- a/tests/visual/figma-fidelity-gate.spec.ts
+++ b/tests/visual/figma-fidelity-gate.spec.ts
@@ -1,0 +1,282 @@
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { expect, test, type Page, type TestInfo } from '@playwright/test';
+
+interface ReferenceRoute {
+  readonly route: 'overview' | 'live' | 'investigate' | 'report';
+  readonly viewport: 'desktop' | 'laptop' | 'mobile';
+  readonly width: number;
+  readonly height: number;
+  readonly file: string;
+  readonly text: string;
+}
+
+interface ReferenceManifest {
+  readonly routes: readonly ReferenceRoute[];
+}
+
+const REFERENCE_ROOT = path.join(process.cwd(), 'docs/artifacts/figma-alignment-reference');
+const REFERENCE_MANIFEST = JSON.parse(
+  readFileSync(path.join(REFERENCE_ROOT, 'manifest.json'), 'utf8'),
+) as ReferenceManifest;
+
+const ROUTES = ['overview', 'live', 'investigate', 'report'] as const;
+const VIEWPORTS = [
+  { viewport: 'desktop', width: 2048, height: 1330 },
+  { viewport: 'laptop', width: 1440, height: 900 },
+  { viewport: 'mobile', width: 390, height: 844 },
+] as const;
+
+function pngSize(file: string): { width: number; height: number } {
+  const buffer = readFileSync(file);
+  expect(buffer.toString('ascii', 1, 4), `${file} must be a PNG`).toBe('PNG');
+  return {
+    width: buffer.readUInt32BE(16),
+    height: buffer.readUInt32BE(20),
+  };
+}
+
+function referenceFor(
+  route: ReferenceRoute['route'],
+  viewport: ReferenceRoute['viewport'],
+): ReferenceRoute {
+  const entry = REFERENCE_MANIFEST.routes.find((candidate) => (
+    candidate.route === route && candidate.viewport === viewport
+  ));
+  if (!entry) throw new Error(`Missing Figma reference for ${route}/${viewport}`);
+  return entry;
+}
+
+async function seedDegradedFixture(page: Page): Promise<void> {
+  await page.goto('/');
+  await page.waitForSelector('#chronoscope-root');
+
+  await page.evaluate(async () => {
+    const [{ endpointStore }, { measurementStore }, { uiStore }] = await Promise.all([
+      import('/src/lib/stores/endpoints.ts'),
+      import('/src/lib/stores/measurements.ts'),
+      import('/src/lib/stores/ui.ts'),
+    ]);
+
+    const endpoints = [
+      {
+        id: 'app',
+        url: 'https://app.chronoscope.dev/health',
+        label: 'app.chronoscope.dev',
+        enabled: true,
+        color: '#2cf5a9',
+      },
+      {
+        id: 'api',
+        url: 'https://api.service.net/status',
+        label: 'api.service.net',
+        enabled: true,
+        color: '#fbbf24',
+      },
+      {
+        id: 'cdn',
+        url: 'https://cdn.assets.io/ping',
+        label: 'cdn.assets.io',
+        enabled: true,
+        color: '#67e8f9',
+      },
+      {
+        id: 'auth',
+        url: 'https://auth.identity.net/ping',
+        label: 'auth.identity.net',
+        enabled: true,
+        color: '#f9a8d4',
+      },
+    ];
+    endpointStore.setEndpoints(endpoints);
+
+    const now = Date.now();
+    const count = 48;
+    const samplesFor = (endpointId: string) => Array.from({ length: count }, (_, sampleIndex) => {
+      const apiSpike = endpointId === 'api' && sampleIndex >= 24 && sampleIndex % 5 === 0;
+      const timeout = endpointId === 'api' && sampleIndex === 43;
+      const baseLatency = endpointId === 'api' ? 185 : endpointId === 'cdn' ? 28 : endpointId === 'auth' ? 56 : 42;
+      return {
+        round: sampleIndex + 1,
+        latency: timeout ? 5000 : apiSpike ? 450 : baseLatency,
+        status: timeout ? 'timeout' : 'ok',
+        timestamp: now - (count - sampleIndex) * 1000,
+      };
+    });
+
+    measurementStore.reset();
+    measurementStore.loadSnapshot({
+      lifecycle: 'running',
+      epoch: 9_000,
+      roundCounter: count,
+      startedAt: now - count * 1000,
+      stoppedAt: null,
+      freezeEvents: [],
+      errorCount: 0,
+      timeoutCount: 1,
+      endpoints: Object.fromEntries(endpoints.map((endpoint) => {
+        const samples = samplesFor(endpoint.id);
+        const lastOk = [...samples].reverse().find((sample) => sample.status === 'ok');
+        return [endpoint.id, {
+          endpointId: endpoint.id,
+          tierLevel: 1,
+          lastLatency: lastOk?.latency ?? null,
+          lastStatus: lastOk?.status ?? null,
+          lastErrorMessage: null,
+          samples,
+        }];
+      })),
+    });
+    uiStore.setFocusedEndpoint(null);
+    uiStore.setActiveView('overview');
+  });
+}
+
+async function activateRoute(page: Page, route: ReferenceRoute['route']): Promise<void> {
+  if (route === 'overview') {
+    await page.getByRole('button', { name: 'Overview', exact: true }).click();
+    await page.waitForSelector('.figma-overview');
+    return;
+  }
+  if (route === 'live') {
+    await page.getByRole('button', { name: 'Live', exact: true }).click();
+    await page.waitForSelector('.live-surface');
+    return;
+  }
+  if (route === 'investigate') {
+    await page.getByRole('button', { name: 'Investigate', exact: true }).click();
+    await page.waitForSelector('.diagnose-surface');
+    return;
+  }
+  await page.getByRole('button', { name: 'Report', exact: true }).click();
+  await page.waitForSelector('.report-surface');
+}
+
+async function expectNoHorizontalOverflow(page: Page): Promise<void> {
+  const overflow = await page.evaluate(() => {
+    const doc = document.documentElement;
+    const hasHorizontalScrollAncestor = (element: HTMLElement): boolean => {
+      let parent = element.parentElement;
+      while (parent && parent !== document.body) {
+        const style = getComputedStyle(parent);
+        const scrollable = style.overflowX === 'auto' || style.overflowX === 'scroll';
+        if (scrollable && parent.scrollWidth > parent.clientWidth) return true;
+        parent = parent.parentElement;
+      }
+      return false;
+    };
+    const overflowing = Array.from(document.querySelectorAll<HTMLElement>('body *'))
+      .filter((element) => !hasHorizontalScrollAncestor(element))
+      .map((element) => {
+        const rect = element.getBoundingClientRect();
+        return {
+          tag: element.tagName,
+          className: String(element.className),
+          text: element.textContent?.trim().slice(0, 40) ?? '',
+          right: Math.round(rect.right),
+          width: Math.round(rect.width),
+        };
+      })
+      .filter((entry) => entry.right > doc.clientWidth + 1)
+      .slice(0, 8);
+    return { scrollWidth: doc.scrollWidth, clientWidth: doc.clientWidth, overflowing };
+  });
+  expect(overflow.scrollWidth, JSON.stringify(overflow)).toBeLessThanOrEqual(overflow.clientWidth);
+  expect(overflow.overflowing).toEqual([]);
+}
+
+async function expectRouteAnchors(page: Page, route: ReferenceRoute['route']): Promise<void> {
+  await expect(page.getByRole('button', { name: 'Overview', exact: true })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Live', exact: true })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Investigate', exact: true })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Report', exact: true })).toBeVisible();
+  await expect(page.locator('.rail')).toHaveCount(0);
+  await expect(page.locator('svg.dial')).toHaveCount(0);
+
+  if (route === 'overview') {
+    await expect(page.locator('.verdict-card')).toBeVisible();
+    await expect(page.locator('.score-ring')).toBeVisible();
+    await expect(page.locator('.endpoint-row')).toHaveCount(4);
+    await expect(page.locator('.event-timeline')).toBeVisible();
+    return;
+  }
+
+  if (route === 'live') {
+    await expect(page.locator('.live-hero')).toBeVisible();
+    await expect(page.locator('.live-scope-panel')).toBeVisible();
+    await expect(page.locator('.live-footer-chip')).toHaveCount(4);
+    return;
+  }
+
+  if (route === 'investigate') {
+    await expect(page.locator('.diagnose-hero')).toBeVisible();
+    await expect(page.locator('.diagnose-answer-fact')).toContainText('Measured fact:');
+    await expect(page.locator('.diagnose-answer-interpretation')).toContainText('Interpretation:');
+    await expect(page.locator('.diagnose-proof-stack')).toContainText('Next proof actions');
+    await expect(page.locator('.diagnose')).not.toContainText(/prove your local|root cause|definitely/i);
+    return;
+  }
+
+  await expect(page.locator('.report-hero')).toBeVisible();
+  await expect(page.locator('.report-strip')).toBeVisible();
+  await expect(page.locator('.evidence-trail')).toBeVisible();
+  await expect(page.getByRole('button', { name: /Copy Report Link/i })).toBeVisible();
+}
+
+async function captureGateScreenshot(
+  page: Page,
+  testInfo: TestInfo,
+  route: ReferenceRoute['route'],
+  viewport: ReferenceRoute['viewport'],
+): Promise<void> {
+  const outputDir = testInfo.outputPath('figma-fidelity');
+  mkdirSync(outputDir, { recursive: true });
+  const screenshotPath = path.join(outputDir, `${route}-${viewport}.png`);
+  await page.screenshot({ path: screenshotPath, fullPage: false });
+  await testInfo.attach(`${route}-${viewport}`, {
+    path: screenshotPath,
+    contentType: 'image/png',
+  });
+  expect(pngSize(screenshotPath)).toEqual({
+    width: page.viewportSize()?.width,
+    height: page.viewportSize()?.height,
+  });
+}
+
+test.describe('Figma fidelity gate', () => {
+  test('frozen reference assets match the manifest dimensions', () => {
+    expect(REFERENCE_MANIFEST.routes).toHaveLength(12);
+    for (const route of ROUTES) {
+      for (const viewport of VIEWPORTS) {
+        const reference = referenceFor(route, viewport.viewport);
+        const file = path.join(REFERENCE_ROOT, reference.file);
+        expect(existsSync(file), `${reference.file} exists`).toBe(true);
+        expect(pngSize(file), `${reference.file} dimensions`).toEqual({
+          width: reference.width,
+          height: reference.height,
+        });
+        expect(reference.text).toContain('CHRONOSCOPE');
+        expect(reference.text).toContain('OVERVIEW');
+        expect(reference.text).toContain('LIVE');
+        expect(reference.text).toContain('INVESTIGATE');
+        expect(reference.text).toContain('REPORT');
+      }
+    }
+  });
+
+  for (const viewport of VIEWPORTS) {
+    for (const route of ROUTES) {
+      test(`${route} matches the Figma shell contract at ${viewport.viewport}`, async ({ page }, testInfo) => {
+        const reference = referenceFor(route, viewport.viewport);
+        await page.setViewportSize({ width: reference.width, height: reference.height });
+        await seedDegradedFixture(page);
+        await activateRoute(page, route);
+        await page.waitForTimeout(250);
+
+        await expectRouteAnchors(page, route);
+        await expectNoHorizontalOverflow(page);
+        await captureGateScreenshot(page, testInfo, route, viewport.viewport);
+      });
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- Add a final Figma fidelity Playwright gate that verifies every frozen reference route/viewport asset, captures deterministic degraded screenshots, checks the four-surface shell anchors, blocks the old rail/dial regression, and guards mobile horizontal overflow.
- Extend accessibility coverage to the top-level Report surface and update legacy selectors for the Figma event log.
- Add a reusable live-site smoke command for post-deploy verification: npm run smoke:live.

## Mismatch ledger
- Intentional difference: the automated gate checks structural fidelity and shell anchors against the frozen reference instead of pixel-matching, because Chronoscope uses real Svelte data/rendering and evidence-bound copy rather than the static Figma text.
- Mobile nav: horizontal tab scrolling is allowed as a deliberate shell behavior; document-level overflow is still blocked.
- Restored data-endpoint-id on Figma endpoint rows so tests and assistive tooling can target real endpoint rows without changing visible UI.

## Verification
- npm run typecheck
- npm run lint
- npm test
- npm run build
- npx playwright test tests/visual/figma-alignment.spec.ts tests/visual/figma-fidelity-gate.spec.ts tests/visual/accessibility.spec.ts --project=chromium
- npm run smoke:live
- git diff --check