### PR TITLE
feat(router): PR 4 — URL routing + nav suffix drop + mobile fade affordance

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -28,9 +28,8 @@ src/lib/components/RunStorylineCard.svelte
 src/lib/components/OverviewSubtabStrip.svelte
 src/lib/components/EventFeed.svelte
 
-# PR 4 (router + shell calmness) — these files are REWRITTEN. Clean violations during rewrite.
-src/lib/components/Topbar.svelte
-src/lib/components/ViewSwitcher.svelte
+# PR 4 (router + shell calmness) — REMOVED from ignore: violations cleaned in PR 4
+# (Topbar: tokenized rgba shell-backdrop + cyan-gradient color-mix; ViewSwitcher: same).
 
 # PR 6 (NetworkTopology + Overview placement) — FigmaOverviewView renamed to OverviewView; clean during rename.
 src/lib/components/FigmaOverviewView.svelte

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,6 @@
-/r/* /index.html 200
+/r/*           /index.html  200
+/endpoint/*    /index.html  200
+/live          /index.html  200
+/investigate   /index.html  200
+/report        /index.html  200
+/diagnose      /investigate 301

--- a/src/lib/components/App.svelte
+++ b/src/lib/components/App.svelte
@@ -16,6 +16,7 @@
   import { applyPersistedSettings } from '$lib/utils/apply-persisted-settings';
   import { loadPersistedSettings, saveSettings, CURRENT_VERSION } from '$lib/utils/persistence';
   import { initHashRouter, initHostedReportRouter } from '$lib/share/hash-router';
+  import { initRouter } from '$lib/router';
   import { initShortcuts } from '$lib/utils/shortcuts';
   import { autoStartDecision } from '$lib/utils/status-intent';
   import type { PersistedSettings } from '$lib/types';
@@ -266,19 +267,29 @@
       }
     }
 
-    // 4. Create engine
+    // 4. URL routing — the URL is authoritative for activeView from here
+    //    on. Runs AFTER persistence so it can override any persisted
+    //    activeView; runs BEFORE engine creation so views mount with the
+    //    correct route already wired. focusedEndpointId is preserved across
+    //    non-endpoint navigations (LiveView solo-mode, Report highlighting,
+    //    persisted-focus rehydration all continue to own that field for
+    //    their own in-page focus needs). See src/lib/router.ts for the
+    //    full contract.
+    initRouter();
+
+    // 5. Create engine
     engine = new MeasurementEngine();
 
-    // 5. Setup persistence sync
+    // 6. Setup persistence sync
     setupPersistenceSync();
 
-    // 6. Local-only history baselines
+    // 7. Local-only history baselines
     setupHistorySync();
 
-    // 7. Register keyboard shortcuts
+    // 8. Register keyboard shortcuts
     destroyShortcuts = initShortcuts();
 
-    // 8. Safe auto-start for ordinary public sessions only
+    // 9. Safe auto-start for ordinary public sessions only
     const ui = get(uiStore);
     const decision = autoStartDecision({
       endpoints: get(endpointStore),

--- a/src/lib/components/Topbar.svelte
+++ b/src/lib/components/Topbar.svelte
@@ -232,7 +232,7 @@
     align-items: center;
     gap: 14px;
     flex-shrink: 0;
-    background: rgba(7, 11, 18, 0.78);
+    background: var(--shell-backdrop);
     backdrop-filter: var(--shell-topbar-backdrop);
     -webkit-backdrop-filter: var(--shell-topbar-backdrop);
     border-bottom: 1px solid var(--shell-border);
@@ -243,12 +243,12 @@
   .brand-mark {
     width: 32px; height: 32px;
     border-radius: 8px;
-    background: linear-gradient(135deg, var(--accent-cyan), #0891b2);
+    background: linear-gradient(135deg, var(--accent-cyan), color-mix(in srgb, var(--accent-cyan), black 40%));
     border: 0;
     display: grid; place-items: center;
     color: var(--shell-bg);
     flex-shrink: 0;
-    box-shadow: 0 0 24px rgba(103, 232, 249, 0.22);
+    box-shadow: 0 0 24px color-mix(in srgb, var(--accent-cyan) 22%, transparent);
   }
   .brand-mark svg circle { display: none; }
   .brand-meta { display: flex; flex-direction: column; gap: 1px; min-width: 0; }

--- a/src/lib/components/ViewSwitcher.svelte
+++ b/src/lib/components/ViewSwitcher.svelte
@@ -4,20 +4,29 @@
   import { uiStore } from '$lib/stores/ui';
   import type { ActiveView } from '$lib/types';
 
+  import { navigateTo } from '$lib/router';
+
+  // ViewSwitcher only navigates to non-endpoint top-level routes. Narrowing
+  // the union so TypeScript knows endpointId is always null here.
+  type SwitcherRoute = 'overview' | 'live' | 'investigate' | 'report';
+
   interface ViewDef {
     readonly id: ActiveView;
-    readonly key: string;
+    readonly route: SwitcherRoute;
     readonly label: string;
     readonly icon: 'activity' | 'bars' | 'search' | 'share';
   }
 
   // Visible label list. Order matches the Figma alignment reference.
-  // Numeric keys mirror this order: 1 Overview, 2 Live, 3 Investigate, 4 Report.
+  // Numeric key suffixes that used to appear after each label were removed
+  // per the synthesis design contract — they crept into the accessible name
+  // even with aria-hidden because WAI-ARIA's name-from-content rules for
+  // buttons still include aria-hidden descendant text.
   const VIEWS: readonly ViewDef[] = [
-    { id: 'overview', key: '1', label: 'Overview',    icon: 'activity' },
-    { id: 'live',     key: '2', label: 'Live',        icon: 'bars' },
-    { id: 'diagnose', key: '3', label: 'Investigate', icon: 'search' },
-    { id: 'report',   key: '4', label: 'Report',      icon: 'share' },
+    { id: 'overview', route: 'overview',    label: 'Overview',    icon: 'activity' },
+    { id: 'live',     route: 'live',        label: 'Live',        icon: 'bars' },
+    { id: 'diagnose', route: 'investigate', label: 'Investigate', icon: 'search' },
+    { id: 'report',   route: 'report',      label: 'Report',      icon: 'share' },
   ];
 
   const activeView = $derived($uiStore.activeView);
@@ -27,39 +36,69 @@
   }
 
   function selectView(view: ViewDef): void {
-    uiStore.setActiveView(view.id);
+    // Route through the router so the URL stays in sync.
+    navigateTo({ name: view.route, endpointId: null });
+  }
+
+  // Mobile fade-affordance state — true when the scroll strip can scroll
+  // right (i.e. the rightmost tab is partially or fully off-screen).
+  let switcherEl: HTMLElement | null = $state(null);
+  let canScrollRight = $state(false);
+  let canScrollLeft = $state(false);
+
+  function updateScrollAffordance(): void {
+    if (switcherEl === null) return;
+    const max = switcherEl.scrollWidth - switcherEl.clientWidth;
+    canScrollRight = switcherEl.scrollLeft < max - 1;
+    canScrollLeft = switcherEl.scrollLeft > 1;
   }
 </script>
 
-<nav class="view-switcher" aria-label="Views">
-  {#each VIEWS as view (view.id)}
-    {@const active = isActive(view.id)}
-    <button
-      type="button"
-      class="view-tab"
-      class:active
-      aria-current={active ? 'page' : undefined}
-      aria-pressed={active}
-      onclick={() => selectView(view)}
-    >
-      <span class="view-tab-icon" aria-hidden="true" data-icon={view.icon}>
-        {#if view.icon === 'activity'}
-          <svg viewBox="0 0 16 16"><path d="M1.8 8h2.4l1.2-3.8 2 7.6L9.1 8h2.1l.8-2.2.9 2.2h1.3" /></svg>
-        {:else if view.icon === 'bars'}
-          <svg viewBox="0 0 16 16"><path d="M3.5 12V7.5M8 12V4M12.5 12V2.5" /></svg>
-        {:else if view.icon === 'search'}
-          <svg viewBox="0 0 16 16"><circle cx="7" cy="7" r="4.2" /><path d="M10.2 10.2 14 14" /></svg>
-        {:else}
-          <svg viewBox="0 0 16 16"><path d="M5 8.5V12a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V8.5M8 4l3-3m0 0 3 3m-3-3v9" /></svg>
-        {/if}
-      </span>
-      <span class="view-tab-label">{view.label}</span>
-      <span class="view-tab-key" aria-hidden="true">{view.key}</span>
-    </button>
-  {/each}
-</nav>
+<div
+  class="view-switcher-wrap"
+  data-scroll-left={canScrollLeft ? 'true' : 'false'}
+  data-scroll-right={canScrollRight ? 'true' : 'false'}
+>
+  <nav
+    class="view-switcher"
+    aria-label="Views"
+    bind:this={switcherEl}
+    onscroll={updateScrollAffordance}
+  >
+    {#each VIEWS as view (view.id)}
+      {@const active = isActive(view.id)}
+      <button
+        type="button"
+        class="view-tab"
+        class:active
+        aria-current={active ? 'page' : undefined}
+        aria-pressed={active}
+        onclick={() => selectView(view)}
+      >
+        <span class="view-tab-icon" aria-hidden="true" data-icon={view.icon}>
+          {#if view.icon === 'activity'}
+            <svg viewBox="0 0 16 16"><path d="M1.8 8h2.4l1.2-3.8 2 7.6L9.1 8h2.1l.8-2.2.9 2.2h1.3" /></svg>
+          {:else if view.icon === 'bars'}
+            <svg viewBox="0 0 16 16"><path d="M3.5 12V7.5M8 12V4M12.5 12V2.5" /></svg>
+          {:else if view.icon === 'search'}
+            <svg viewBox="0 0 16 16"><circle cx="7" cy="7" r="4.2" /><path d="M10.2 10.2 14 14" /></svg>
+          {:else}
+            <svg viewBox="0 0 16 16"><path d="M5 8.5V12a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V8.5M8 4l3-3m0 0 3 3m-3-3v9" /></svg>
+          {/if}
+        </span>
+        <span class="view-tab-label">{view.label}</span>
+      </button>
+    {/each}
+  </nav>
+  <!-- Mobile fade-affordance: visible only at <420px when content is clipped on the right. -->
+  <span class="view-switcher-fade" aria-hidden="true"></span>
+</div>
 
 <style>
+  .view-switcher-wrap {
+    position: relative;
+    flex-shrink: 0;
+  }
   .view-switcher {
     min-height: 50px;
     display: flex;
@@ -67,7 +106,7 @@
     padding: 0 24px;
     align-items: stretch;
     border-bottom: 1px solid var(--shell-border);
-    background: rgba(7, 11, 18, 0.68);
+    background: var(--shell-backdrop);
     flex-shrink: 0;
     overflow-x: auto;
     scroll-snap-type: x proximity;
@@ -144,15 +183,34 @@
     letter-spacing: var(--tr-label);
     white-space: nowrap;
   }
-  .view-tab-key {
-    font-family: var(--mono);
-    font-size: var(--ts-xs);
-    color: var(--t3);
-    opacity: 0.5;
+
+  /* Mobile fade-affordance: visible only when content is clipped on the
+     right. Hidden when nothing is being clipped or at desktop widths
+     where all four tabs always fit. */
+  .view-switcher-fade {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 1px;
+    width: 36px;
+    pointer-events: none;
+    background: linear-gradient(to right, transparent, var(--shell-backdrop));
+    opacity: 0;
+    transition: opacity 160ms ease;
+  }
+  .view-switcher-wrap[data-scroll-right='true'] .view-switcher-fade {
+    opacity: 1;
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .view-tab, .view-tab::after { transition: none; }
+    .view-tab,
+    .view-tab::after,
+    .view-switcher-fade { transition: none; }
+  }
+
+  /* Desktop / laptop: all 4 tabs always fit; fade affordance is forced off. */
+  @media (min-width: 420px) {
+    .view-switcher-fade { display: none; }
   }
 
   @media (max-width: 767px) {
@@ -165,6 +223,5 @@
       padding: 0 14px;
     }
     .view-tab-label { font-size: var(--ts-md); }
-    .view-tab-key { display: none; }
   }
 </style>

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -1,0 +1,198 @@
+// src/lib/router.ts
+// Hand-rolled URL router for the synthesis arc. The codebase had no
+// client-side router before this; views were mounted by Layout via an
+// {#if activeView === ...} switch on $uiStore.activeView.
+//
+// This wrapper turns the browser URL into the source of truth for the
+// active view (and the focused endpoint when the route is /endpoint/:id).
+// It does NOT take exclusive ownership of uiStore.focusedEndpointId —
+// LiveView's solo-mode trace, ReportView's endpoint highlighting,
+// keyboard shortcuts, and persisted-focus rehydration all continue to
+// read and write that field directly. See the synthesis design contract
+// section "Routing Infrastructure" for the full contract.
+
+import { uiStore } from './stores/ui';
+import type { ActiveView } from './types';
+
+export type RouteName = 'overview' | 'live' | 'investigate' | 'endpoint' | 'report';
+
+// Discriminated union so { name: 'endpoint', endpointId: null } cannot typecheck.
+export type RouteState =
+  | { readonly name: 'overview' | 'live' | 'investigate' | 'report'; readonly endpointId: null }
+  | { readonly name: 'endpoint'; readonly endpointId: string };
+
+const ENDPOINT_ID_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/;
+
+// Map router → uiStore. The router uses 'investigate' as the user-facing
+// label; uiStore retains the legacy 'diagnose' value for the same surface.
+function routeToActiveView(name: RouteName): ActiveView {
+  switch (name) {
+    case 'overview':    return 'overview';
+    case 'live':        return 'live';
+    case 'investigate': return 'diagnose';
+    case 'endpoint':    return 'diagnose';
+    case 'report':      return 'report';
+  }
+}
+
+// Map uiStore → router. Legacy persisted values ('strata', 'terminal')
+// coerce to 'overview' — same fallback as readActiveView in persistence.ts.
+function activeViewToRoute(active: ActiveView): RouteName {
+  switch (active) {
+    case 'overview': return 'overview';
+    case 'live':     return 'live';
+    case 'diagnose': return 'investigate';
+    case 'report':   return 'report';
+    case 'strata':   return 'overview';
+    case 'terminal': return 'overview';
+  }
+}
+
+// Build the canonical path for a RouteState. Private — only navigateTo
+// and initRouter call this.
+function pathFor(state: RouteState): string {
+  switch (state.name) {
+    case 'overview':    return '/';
+    case 'live':        return '/live';
+    case 'investigate': return '/investigate';
+    case 'endpoint':    return `/endpoint/${state.endpointId}`;
+    case 'report':      return '/report';
+  }
+}
+
+// Parse a pathname into a RouteState, OR null if the pathname is unknown
+// or contains an invalid endpoint id. Callers redirect to '/investigate'
+// (for /endpoint/* failures) or '/' (for other unknowns) when this returns
+// null. Note: /diagnose is intentionally NOT handled here — Cloudflare's
+// _redirects rewrites it to /investigate at the edge before JS runs.
+function parsePath(pathname: string): RouteState | null {
+  if (pathname === '/' || pathname === '') {
+    return { name: 'overview', endpointId: null };
+  }
+  if (pathname === '/live') return { name: 'live', endpointId: null };
+  if (pathname === '/investigate') return { name: 'investigate', endpointId: null };
+  if (pathname === '/report') return { name: 'report', endpointId: null };
+  if (pathname.startsWith('/endpoint/')) {
+    const id = pathname.slice('/endpoint/'.length);
+    // Empty id (/endpoint/), trailing slash, or anything that fails the
+    // anchored validation regex → null (caller redirects to /investigate).
+    if (id === '' || !ENDPOINT_ID_PATTERN.test(id)) return null;
+    return { name: 'endpoint', endpointId: id };
+  }
+  return null;
+}
+
+// ── Module state ────────────────────────────────────────────────────────────
+
+let currentState: RouteState = { name: 'overview', endpointId: null };
+let subscribers = new Set<(state: RouteState) => void>();
+let popstateBound = false;
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+export function currentRoute(): RouteState {
+  return currentState;
+}
+
+export interface NavigateOptions {
+  readonly replace?: boolean;
+}
+
+export function navigateTo(state: RouteState, options?: NavigateOptions): void {
+  const path = pathFor(state);
+  const history = typeof window !== 'undefined' ? window.history : null;
+  if (history) {
+    if (options?.replace === true) {
+      history.replaceState({}, '', path);
+    } else {
+      history.pushState({}, '', path);
+    }
+  }
+  applyRouteToStore(state);
+  notify(state);
+}
+
+export function subscribeRoute(handler: (state: RouteState) => void): () => void {
+  subscribers.add(handler);
+  return () => { subscribers.delete(handler); };
+}
+
+// Called once from App.svelte's bootstrap, AFTER initHashRouter,
+// initHostedReportRouter, and loadPersistedSettings have completed.
+// The URL is authoritative for activeView from this point forward. For
+// focusedEndpointId, the router writes when navigating TO an endpoint
+// route but does not clear when navigating away — see the contract's
+// "focusedEndpointId is semantically overloaded" section.
+export function initRouter(): void {
+  if (typeof window === 'undefined') return;
+  const initial = parsePath(window.location.pathname);
+
+  if (initial === null) {
+    // Unknown path or invalid endpoint id. Redirect to /investigate for
+    // endpoint failures (preserves intent); otherwise normalize to /.
+    if (window.location.pathname.startsWith('/endpoint/')) {
+      navigateTo({ name: 'investigate', endpointId: null }, { replace: true });
+    } else {
+      navigateTo({ name: 'overview', endpointId: null }, { replace: true });
+    }
+  } else {
+    currentState = initial;
+    applyRouteToStore(initial);
+  }
+
+  if (!popstateBound) {
+    window.addEventListener('popstate', handlePopstate);
+    popstateBound = true;
+  }
+}
+
+// ── Internals ───────────────────────────────────────────────────────────────
+
+function applyRouteToStore(state: RouteState): void {
+  currentState = state;
+  uiStore.setActiveView(routeToActiveView(state.name));
+  // Write focusedEndpointId only when navigating TO an endpoint route.
+  // Never clear it on other routes — preserves in-page focus state for
+  // Live solo-mode, Report highlighting, etc.
+  if (state.name === 'endpoint') {
+    uiStore.setFocusedEndpoint(state.endpointId);
+  }
+}
+
+function handlePopstate(): void {
+  if (typeof window === 'undefined') return;
+  const next = parsePath(window.location.pathname);
+  if (next === null) {
+    // Browser back/forward to an unknown URL — redirect.
+    if (window.location.pathname.startsWith('/endpoint/')) {
+      navigateTo({ name: 'investigate', endpointId: null }, { replace: true });
+    } else {
+      navigateTo({ name: 'overview', endpointId: null }, { replace: true });
+    }
+    return;
+  }
+  applyRouteToStore(next);
+  notify(next);
+}
+
+function notify(state: RouteState): void {
+  for (const handler of subscribers) {
+    try {
+      handler(state);
+    } catch {
+      // Subscriber crashes must not break navigation. Swallow.
+    }
+  }
+}
+
+// Test-only escape hatch — resets module state between unit tests.
+// NOT for production use; not exported from any public barrel.
+export function __resetRouterForTests(): void {
+  currentState = { name: 'overview', endpointId: null };
+  subscribers = new Set();
+  popstateBound = false;
+}
+
+// Expose mapping for callers (e.g. tests, or surfaces that need the
+// uiStore equivalent of a RouteName). Pure function, no side effects.
+export { routeToActiveView, activeViewToRoute };

--- a/tests/unit/router.test.ts
+++ b/tests/unit/router.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { get } from 'svelte/store';
+import {
+  currentRoute,
+  navigateTo,
+  subscribeRoute,
+  initRouter,
+  __resetRouterForTests,
+  routeToActiveView,
+  activeViewToRoute,
+  type RouteState,
+} from '../../src/lib/router';
+import { uiStore } from '../../src/lib/stores/ui';
+
+function setPath(pathname: string): void {
+  window.history.replaceState({}, '', pathname);
+}
+
+beforeEach(() => {
+  __resetRouterForTests();
+  setPath('/');
+  uiStore.reset();
+});
+
+afterEach(() => {
+  // Defensive: dispatching popstate after a test ends would invoke the
+  // listener installed by initRouter in another test's context. Reset.
+  __resetRouterForTests();
+});
+
+describe('routeToActiveView ↔ activeViewToRoute', () => {
+  it('maps router names to uiStore ActiveView values', () => {
+    expect(routeToActiveView('overview')).toBe('overview');
+    expect(routeToActiveView('live')).toBe('live');
+    expect(routeToActiveView('investigate')).toBe('diagnose');
+    expect(routeToActiveView('endpoint')).toBe('diagnose');
+    expect(routeToActiveView('report')).toBe('report');
+  });
+
+  it('maps uiStore ActiveView values back to router names', () => {
+    expect(activeViewToRoute('overview')).toBe('overview');
+    expect(activeViewToRoute('live')).toBe('live');
+    expect(activeViewToRoute('diagnose')).toBe('investigate');
+    expect(activeViewToRoute('report')).toBe('report');
+  });
+
+  it('coerces legacy strata/terminal ActiveView values to overview', () => {
+    expect(activeViewToRoute('strata')).toBe('overview');
+    expect(activeViewToRoute('terminal')).toBe('overview');
+  });
+});
+
+describe('initRouter — URL parsing on boot', () => {
+  it('parses / as overview', () => {
+    setPath('/');
+    initRouter();
+    expect(currentRoute()).toEqual({ name: 'overview', endpointId: null });
+    expect(get(uiStore).activeView).toBe('overview');
+  });
+
+  it('parses /live as live route', () => {
+    setPath('/live');
+    initRouter();
+    expect(currentRoute()).toEqual({ name: 'live', endpointId: null });
+    expect(get(uiStore).activeView).toBe('live');
+  });
+
+  it('parses /investigate as investigate landing', () => {
+    setPath('/investigate');
+    initRouter();
+    expect(currentRoute()).toEqual({ name: 'investigate', endpointId: null });
+    expect(get(uiStore).activeView).toBe('diagnose');
+  });
+
+  it('parses /report as report', () => {
+    setPath('/report');
+    initRouter();
+    expect(currentRoute()).toEqual({ name: 'report', endpointId: null });
+    expect(get(uiStore).activeView).toBe('report');
+  });
+
+  it('parses /endpoint/<valid-id> as endpoint route and writes focusedEndpointId', () => {
+    setPath('/endpoint/abc123');
+    initRouter();
+    expect(currentRoute()).toEqual({ name: 'endpoint', endpointId: 'abc123' });
+    expect(get(uiStore).activeView).toBe('diagnose');
+    expect(get(uiStore).focusedEndpointId).toBe('abc123');
+  });
+
+  it('parses /endpoint/<id-with-dashes-and-underscores> correctly', () => {
+    setPath('/endpoint/shared-ep-3-1721481234567');
+    initRouter();
+    expect(currentRoute()).toEqual({ name: 'endpoint', endpointId: 'shared-ep-3-1721481234567' });
+  });
+
+  it('URL is authoritative — overrides persisted activeView', () => {
+    uiStore.setActiveView('live');
+    setPath('/');
+    initRouter();
+    expect(get(uiStore).activeView).toBe('overview');
+  });
+
+  it('does NOT clear persisted focusedEndpointId on non-endpoint routes', () => {
+    uiStore.setFocusedEndpoint('persisted-id');
+    setPath('/live');
+    initRouter();
+    expect(get(uiStore).activeView).toBe('live');
+    // The router writes focusedEndpointId only when navigating TO an
+    // endpoint route. Persisted in-page focus survives.
+    expect(get(uiStore).focusedEndpointId).toBe('persisted-id');
+  });
+});
+
+describe('initRouter — endpointId validation (anchored regex)', () => {
+  it('redirects /endpoint/abc@malicious to /investigate', () => {
+    setPath('/endpoint/abc@malicious');
+    initRouter();
+    expect(currentRoute()).toEqual({ name: 'investigate', endpointId: null });
+    expect(window.location.pathname).toBe('/investigate');
+  });
+
+  it('redirects /endpoint/abc/def to /investigate', () => {
+    setPath('/endpoint/abc/def');
+    initRouter();
+    expect(currentRoute()).toEqual({ name: 'investigate', endpointId: null });
+  });
+
+  it('redirects /endpoint/abc.def to /investigate', () => {
+    setPath('/endpoint/abc.def');
+    initRouter();
+    expect(currentRoute()).toEqual({ name: 'investigate', endpointId: null });
+  });
+
+  it('redirects /endpoint/<script> to /investigate', () => {
+    setPath('/endpoint/<script>');
+    initRouter();
+    expect(currentRoute()).toEqual({ name: 'investigate', endpointId: null });
+  });
+
+  it('redirects /endpoint/ (empty id) to /investigate', () => {
+    setPath('/endpoint/');
+    initRouter();
+    expect(currentRoute()).toEqual({ name: 'investigate', endpointId: null });
+  });
+
+  it('redirects /endpoint/<65-char-id> to /investigate (over length cap)', () => {
+    const tooLong = 'a'.repeat(65);
+    setPath(`/endpoint/${tooLong}`);
+    initRouter();
+    expect(currentRoute()).toEqual({ name: 'investigate', endpointId: null });
+  });
+
+  it('accepts /endpoint/<exactly-64-char-id> (boundary case)', () => {
+    const maxLen = 'a'.repeat(64);
+    setPath(`/endpoint/${maxLen}`);
+    initRouter();
+    expect(currentRoute()).toEqual({ name: 'endpoint', endpointId: maxLen });
+  });
+
+  it('redirects /unknown-path to / (overview)', () => {
+    setPath('/unknown-path');
+    initRouter();
+    expect(currentRoute()).toEqual({ name: 'overview', endpointId: null });
+    expect(window.location.pathname).toBe('/');
+  });
+});
+
+describe('navigateTo', () => {
+  beforeEach(() => initRouter());
+
+  it('pushes /endpoint/X and writes uiStore.focusedEndpointId', () => {
+    navigateTo({ name: 'endpoint', endpointId: 'aws' });
+    expect(window.location.pathname).toBe('/endpoint/aws');
+    expect(currentRoute()).toEqual({ name: 'endpoint', endpointId: 'aws' });
+    expect(get(uiStore).focusedEndpointId).toBe('aws');
+    expect(get(uiStore).activeView).toBe('diagnose');
+  });
+
+  it('navigating away from /endpoint/X does NOT clear focusedEndpointId', () => {
+    navigateTo({ name: 'endpoint', endpointId: 'aws' });
+    expect(get(uiStore).focusedEndpointId).toBe('aws');
+    navigateTo({ name: 'live', endpointId: null });
+    // Router does not own focus state; preserves prior value for in-page consumers.
+    expect(get(uiStore).focusedEndpointId).toBe('aws');
+  });
+
+  it('replace: true uses replaceState instead of pushState', () => {
+    const initialLength = window.history.length;
+    navigateTo({ name: 'live', endpointId: null });
+    const afterPush = window.history.length;
+    navigateTo({ name: 'report', endpointId: null }, { replace: true });
+    const afterReplace = window.history.length;
+    expect(afterPush).toBe(initialLength + 1);
+    expect(afterReplace).toBe(afterPush);
+  });
+
+  it('updates uiStore.activeView on every navigation', () => {
+    navigateTo({ name: 'live', endpointId: null });
+    expect(get(uiStore).activeView).toBe('live');
+    navigateTo({ name: 'investigate', endpointId: null });
+    expect(get(uiStore).activeView).toBe('diagnose');
+    navigateTo({ name: 'report', endpointId: null });
+    expect(get(uiStore).activeView).toBe('report');
+  });
+});
+
+describe('subscribeRoute', () => {
+  beforeEach(() => initRouter());
+
+  it('fires handler on every navigateTo call', () => {
+    const received: RouteState[] = [];
+    subscribeRoute((state) => received.push(state));
+    navigateTo({ name: 'live', endpointId: null });
+    navigateTo({ name: 'investigate', endpointId: null });
+    expect(received).toEqual([
+      { name: 'live', endpointId: null },
+      { name: 'investigate', endpointId: null },
+    ]);
+  });
+
+  it('unsubscribe stops further notifications', () => {
+    const received: RouteState[] = [];
+    const off = subscribeRoute((state) => received.push(state));
+    navigateTo({ name: 'live', endpointId: null });
+    off();
+    navigateTo({ name: 'investigate', endpointId: null });
+    expect(received).toHaveLength(1);
+  });
+
+  it('subscriber crash does not break navigation', () => {
+    subscribeRoute(() => { throw new Error('boom'); });
+    expect(() => navigateTo({ name: 'live', endpointId: null })).not.toThrow();
+    expect(currentRoute()).toEqual({ name: 'live', endpointId: null });
+  });
+});
+
+describe('popstate (browser back/forward)', () => {
+  beforeEach(() => initRouter());
+
+  it('updates currentRoute and uiStore on popstate', () => {
+    setPath('/live');
+    window.dispatchEvent(new PopStateEvent('popstate'));
+    expect(currentRoute()).toEqual({ name: 'live', endpointId: null });
+    expect(get(uiStore).activeView).toBe('live');
+  });
+
+  it('redirects to /investigate when back/forward lands on an invalid endpoint id', () => {
+    setPath('/endpoint/<script>');
+    window.dispatchEvent(new PopStateEvent('popstate'));
+    expect(currentRoute()).toEqual({ name: 'investigate', endpointId: null });
+    expect(window.location.pathname).toBe('/investigate');
+  });
+
+  it('fires subscribers on popstate', () => {
+    const received: RouteState[] = [];
+    subscribeRoute((state) => received.push(state));
+    setPath('/report');
+    window.dispatchEvent(new PopStateEvent('popstate'));
+    expect(received).toEqual([{ name: 'report', endpointId: null }]);
+  });
+});


### PR DESCRIPTION
## Summary

PR 4 of 9 in the synthesis arc per `docs/superpowers/specs/2026-05-17-synthesis-design-contract.md`. Lands the load-bearing routing infrastructure and the user-visible nav fixes. Defers the visual shell unification (single floating pill, Measuring counter format, settings cog overlay) to a follow-up — see "Deferred scope" below.

## What's in

- New `src/lib/router.ts` (198 lines) — hand-rolled `popstate`/`pushState` wrapper. RouteName + RouteState (discriminated union) + currentRoute/navigateTo/subscribeRoute/initRouter exports + private pathFor helper. endpointId validated against anchored `^[a-zA-Z0-9_-]{1,64}$`. RouteName ↔ ActiveView mapping including legacy `'strata'`/`'terminal'` coercion. focusedEndpointId weak-ownership contract preserved (router writes on endpoint route, never clears).
- 29 router unit tests covering URL parsing, validation, navigation, popstate, subscribe, vocabulary mapping, and the weak-ownership rule.
- `App.svelte` — `initRouter()` wired into bootstrap() as step 4 (after persistence settles, before engine creation).
- `public/_redirects` — adds SPA fallback for `/live`, `/investigate`, `/report`, `/endpoint/*`, plus `/diagnose → /investigate 301` for legacy bookmarks (handled at the Cloudflare edge before JS runs).
- `ViewSwitcher.svelte` — drops numeric tab-key suffixes (creeping into accessible names via WAI-ARIA name-from-content rules). Calls `navigateTo()` instead of writing `uiStore.activeView` directly. New mobile fade-affordance overlay at <420px when strip is clipped.
- `Topbar.svelte` — 3 raw-value violations tokenized (shell-backdrop var + 2 color-mix expressions).
- `.stylelintignore` — Topbar + ViewSwitcher removed (both clean now).

## Deferred to follow-up (intentionally not in this PR)

The contract's PR 4 scope also listed:

- Refactor Topbar + ViewSwitcher into a single floating sticky pill.
- Integrate Measuring pulse + T+MM:SS elapsed-time counter into the pill.
- Replace the three icon ovals (endpoints, share, run details) with a single settings cog opening an overlay sheet.

These are real UI design work that depends on overlay-sheet composition decisions not yet locked in. The router + nav-clipping fix here is the critical dependency for PRs 7-9 (router-based navigation) and addresses the user-visible mobile-nav bug. The visual shell unification can land in a follow-up commit on this branch, fold into PR 6 (which restructures the Overview shell), or be its own focused PR.

## Verification

- typecheck (tsc + svelte-check + functions): pass.
- lint (ESLint): pass.
- lint:css (stylelint): pass (Topbar + ViewSwitcher off the ignore list).
- test: 1190 / 1190 (was 1161; +29 router tests).
- build: pass.

## Test plan

- [ ] CI green across all gates.
- [ ] Direct browser load of `https://<preview>.chronoscope.pages.dev/live` mounts Live (verifies SPA fallback + initRouter reconciliation).
- [ ] Direct browser load of `/diagnose` hard-redirects to `/investigate` (verifies edge 301).
- [ ] Direct browser load of `/endpoint/abc@malicious` redirects to `/investigate` (verifies anchored regex).
- [ ] Mobile <420px nav strip shows fade affordance on the right when clipped; fade disappears when scrolled to end.
- [ ] No nav tab's accessible name contains "1"/"2"/"3"/"4" (verify via screen reader or accessibility inspector).