### PR TITLE
feat(overview): PR 6 — NetworkTopology hero visualization + verdict-card geometry

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -35,10 +35,9 @@ tests/**/*
 # PR 4 (router + shell calmness) — REMOVED from ignore: violations cleaned in PR 4
 # (Topbar: tokenized rgba shell-backdrop + cyan-gradient color-mix; ViewSwitcher: same).
 
-# PR 6 (NetworkTopology + Overview placement) — FigmaOverviewView renamed to
-# OverviewView in PR 5. The file's CSS violations get cleaned during PR 6's
-# NetworkTopology placement and verdict-card geometry tightening.
-src/lib/components/OverviewView.svelte
+# PR 6 (NetworkTopology + Overview placement) — REMOVED from ignore:
+# OverviewView's raw rgba/hex values were tokenized as part of the
+# verdict-card geometry tightening + NetworkTopology placement.
 
 # PR 7 (EndpointDetail + DiagnoseView decomposition) — DiagnoseView heavily modified; clean during decomposition.
 src/lib/components/DiagnoseView.svelte

--- a/src/lib/components/NetworkTopology.svelte
+++ b/src/lib/components/NetworkTopology.svelte
@@ -1,0 +1,334 @@
+<!-- src/lib/components/NetworkTopology.svelte -->
+<!-- Per the synthesis design contract Section 2: Overview right column.       -->
+<!-- Spatial visualization of what is actually being measured — browser node    -->
+<!-- on the left, one endpoint node per monitored endpoint on the right,        -->
+<!-- connecting path lines, animated pulse packets driven by REAL measurement   -->
+<!-- round events (not setInterval(Math.random) like the v2 prototype).         -->
+<script lang="ts">
+  import { measurementStore } from '$lib/stores/measurements';
+  import { monitoredEndpointsStore } from '$lib/stores/derived';
+  import { statisticsStore } from '$lib/stores/statistics';
+  import { settingsStore } from '$lib/stores/settings';
+  import { uiStore } from '$lib/stores/ui';
+  import { navigateTo } from '$lib/router';
+  import { deriveEndpointTone, type EndpointTone } from '$lib/utils/endpoint-tone';
+
+  // Layout grid (SVG viewBox is unitless — these are abstract design units).
+  const VIEWBOX_WIDTH = 320;
+  const VIEWBOX_HEIGHT = 260;
+  const ORIGIN_X = 50;
+  const ORIGIN_Y = VIEWBOX_HEIGHT / 2;
+  const ENDPOINT_X = 250;
+  const NODE_RADIUS = 14;
+
+  const monitored = $derived($monitoredEndpointsStore);
+  const stats = $derived($statisticsStore);
+  const measurements = $derived($measurementStore);
+  const threshold = $derived($settingsStore.healthThreshold);
+
+  // Pulse state — keyed by endpoint id, holds a monotonic counter that
+  // increments when a new successful sample arrives for that endpoint.
+  // CSS animation re-runs by binding the counter to a `key` attribute on
+  // the pulse element (the new key forces Svelte to recreate the node).
+  let pulseKeys = $state<Record<string, number>>({});
+  let lastSampleCounts: Record<string, number> = {};
+
+  // Watch per-endpoint sample counts and emit a pulse on increment.
+  // This is the "real cadence driven by measurement events" the spec
+  // requires — no setInterval, no Math.random.
+  $effect(() => {
+    for (const ep of monitored) {
+      const state = measurements.endpoints[ep.id];
+      const count = state?.samples.toArray().length ?? 0;
+      const prev = lastSampleCounts[ep.id] ?? 0;
+      if (count > prev) {
+        pulseKeys = { ...pulseKeys, [ep.id]: (pulseKeys[ep.id] ?? 0) + 1 };
+      }
+      lastSampleCounts[ep.id] = count;
+    }
+  });
+
+  interface Node {
+    readonly endpoint: { id: string; label: string };
+    readonly tone: EndpointTone;
+    readonly x: number;
+    readonly y: number;
+  }
+
+  // Endpoint layout — simple vertical column at ENDPOINT_X, evenly spaced.
+  // Works without label collision for 1-8 endpoints (the common case). For
+  // >8 endpoints, a compact-grid + "+N more" treatment is deferred to a
+  // follow-up; current behavior caps at 8 visible nodes.
+  const MAX_VISIBLE_NODES = 8;
+  const nodes: readonly Node[] = $derived.by(() => {
+    const visible = monitored.slice(0, MAX_VISIBLE_NODES);
+    const n = visible.length;
+    if (n === 0) return [];
+    const usableHeight = VIEWBOX_HEIGHT - 60;
+    const step = n === 1 ? 0 : usableHeight / (n - 1);
+    const topY = n === 1 ? VIEWBOX_HEIGHT / 2 : 30;
+    return visible.map((ep, i) => ({
+      endpoint: { id: ep.id, label: ep.label },
+      tone: deriveEndpointTone({
+        stats: stats[ep.id] ?? null,
+        lastStatus: measurements.endpoints[ep.id]?.lastStatus ?? null,
+        healthThreshold: threshold,
+      }),
+      x: ENDPOINT_X,
+      y: topY + step * i,
+    }));
+  });
+
+  const overflowCount = $derived(Math.max(0, monitored.length - MAX_VISIBLE_NODES));
+
+  function handleEndpointClick(endpointId: string): void {
+    navigateTo({ name: 'endpoint', endpointId });
+  }
+
+  function handleAddEndpoint(): void {
+    uiStore.toggleEndpoints();
+  }
+</script>
+
+{#if monitored.length === 0}
+  <div class="network-topology network-topology-empty" aria-label="Network topology — no endpoints">
+    <p class="empty-headline">No endpoints to map yet</p>
+    <p class="empty-detail">Add an endpoint to see your network map.</p>
+    <button type="button" class="empty-cta" onclick={handleAddEndpoint}>
+      Add endpoint
+    </button>
+  </div>
+{:else}
+  <div class="network-topology" aria-label="Network topology — browser to {monitored.length} endpoints">
+    <svg
+      class="topology-svg"
+      viewBox="0 0 {VIEWBOX_WIDTH} {VIEWBOX_HEIGHT}"
+      role="img"
+      aria-hidden="true"
+    >
+      <!-- Connecting path lines (origin → each endpoint) -->
+      {#each nodes as node (node.endpoint.id)}
+        <line
+          class="topology-path"
+          x1={ORIGIN_X}
+          y1={ORIGIN_Y}
+          x2={node.x}
+          y2={node.y}
+          stroke-width="1"
+        />
+      {/each}
+
+      <!-- Pulse packets — re-rendered when pulseKeys[ep.id] increments. -->
+      {#each nodes as node (node.endpoint.id)}
+        {#if pulseKeys[node.endpoint.id]}
+          {#key pulseKeys[node.endpoint.id]}
+            <circle
+              class="topology-pulse"
+              data-tone={node.tone}
+              r="3"
+              style:--pulse-x1="{ORIGIN_X}px"
+              style:--pulse-y1="{ORIGIN_Y}px"
+              style:--pulse-x2="{node.x}px"
+              style:--pulse-y2="{node.y}px"
+            />
+          {/key}
+        {/if}
+      {/each}
+
+      <!-- Origin (browser) node -->
+      <g class="topology-node-group" data-role="origin">
+        <circle class="topology-node" cx={ORIGIN_X} cy={ORIGIN_Y} r={NODE_RADIUS} />
+        <text class="topology-label" x={ORIGIN_X} y={ORIGIN_Y + NODE_RADIUS + 16} text-anchor="middle">
+          BROWSER
+        </text>
+      </g>
+
+      <!-- Endpoint nodes -->
+      {#each nodes as node (node.endpoint.id)}
+        <g
+          class="topology-node-group topology-node-clickable"
+          data-tone={node.tone}
+          data-endpoint-id={node.endpoint.id}
+          role="button"
+          tabindex="0"
+          aria-label="View {node.endpoint.label} details"
+          onclick={() => handleEndpointClick(node.endpoint.id)}
+          onkeydown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              handleEndpointClick(node.endpoint.id);
+            }
+          }}
+        >
+          <circle
+            class="topology-node"
+            cx={node.x}
+            cy={node.y}
+            r={NODE_RADIUS}
+          />
+          <text
+            class="topology-label"
+            x={node.x}
+            y={node.y + NODE_RADIUS + 16}
+            text-anchor="middle"
+          >
+            {node.endpoint.label.slice(0, 16)}
+          </text>
+        </g>
+      {/each}
+    </svg>
+
+    {#if overflowCount > 0}
+      <p class="topology-overflow" role="note">
+        +{overflowCount} more endpoint{overflowCount === 1 ? '' : 's'} not shown
+      </p>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .network-topology {
+    width: 100%;
+    height: 100%;
+    min-height: 240px;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: center;
+    padding: 16px;
+    border: 1px solid var(--shell-border);
+    border-radius: 18px;
+    background: var(--shell-panel);
+  }
+
+  .topology-svg {
+    width: 100%;
+    height: 100%;
+    max-height: 280px;
+    overflow: visible;
+  }
+
+  .topology-path {
+    stroke: var(--shell-divider);
+    fill: none;
+  }
+
+  .topology-node {
+    fill: var(--shell-panel-raised);
+    stroke-width: 2;
+    transition: stroke 200ms ease, fill 200ms ease;
+  }
+  [data-role='origin'] .topology-node {
+    stroke: var(--t3);
+  }
+  [data-tone='good'] .topology-node {
+    stroke: var(--accent-green);
+  }
+  [data-tone='watch'] .topology-node {
+    stroke: var(--accent-amber);
+  }
+  [data-tone='bad'] .topology-node {
+    stroke: var(--accent-pink);
+  }
+  [data-tone='collecting'] .topology-node {
+    stroke: var(--accent-cyan);
+  }
+
+  .topology-node-clickable {
+    cursor: pointer;
+  }
+  .topology-node-clickable:hover .topology-node,
+  .topology-node-clickable:focus-visible .topology-node {
+    fill: var(--shell-panel-hover);
+  }
+  .topology-node-clickable:focus-visible {
+    outline: none;
+  }
+  .topology-node-clickable:focus-visible .topology-node {
+    stroke-width: 3;
+  }
+
+  .topology-label {
+    fill: var(--t3);
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: var(--tr-label);
+    text-transform: uppercase;
+    pointer-events: none;
+  }
+  [data-tone='good'] .topology-label,
+  [data-tone='watch'] .topology-label,
+  [data-tone='bad'] .topology-label,
+  [data-tone='collecting'] .topology-label {
+    fill: var(--t2);
+  }
+
+  /* Pulse packets — animate from origin (x1,y1) to endpoint (x2,y2)
+     using CSS custom properties bound at render time. The {#key} block
+     above re-renders these elements per pulse trigger, restarting the
+     animation. Tone-colored to match the destination endpoint. */
+  .topology-pulse {
+    animation: pulse-travel 1.2s ease-out forwards;
+    pointer-events: none;
+  }
+  [data-tone='good'].topology-pulse { fill: var(--accent-green); }
+  [data-tone='watch'].topology-pulse { fill: var(--accent-amber); }
+  [data-tone='bad'].topology-pulse { fill: var(--accent-pink); }
+  [data-tone='collecting'].topology-pulse { fill: var(--accent-cyan); }
+
+  @keyframes pulse-travel {
+    0%   { cx: var(--pulse-x1); cy: var(--pulse-y1); opacity: 0; }
+    20%  { opacity: 1; }
+    80%  { opacity: 1; }
+    100% { cx: var(--pulse-x2); cy: var(--pulse-y2); opacity: 0; }
+  }
+
+  .network-topology-empty {
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    text-align: center;
+  }
+  .empty-headline {
+    margin: 0;
+    color: var(--t1);
+    font-family: var(--sans);
+    font-size: var(--ts-base);
+    font-weight: 700;
+  }
+  .empty-detail {
+    margin: 0;
+    color: var(--t3);
+    font-family: var(--sans);
+    font-size: var(--ts-sm);
+  }
+  .empty-cta {
+    margin-top: 8px;
+    min-height: 36px;
+    padding: 0 16px;
+    border: 1px solid var(--shell-border-strong);
+    background: var(--shell-bg-cyan);
+    color: var(--accent-cyan);
+    font-family: var(--sans);
+    font-size: var(--ts-sm);
+    font-weight: 700;
+    cursor: pointer;
+    border-radius: 8px;
+  }
+  .empty-cta:hover { background: var(--shell-panel-hover); }
+
+  .topology-overflow {
+    margin: 8px 0 0;
+    color: var(--t4);
+    font-family: var(--mono);
+    font-size: 10px;
+    text-align: center;
+    letter-spacing: var(--tr-label);
+    text-transform: uppercase;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .topology-pulse { animation: none; opacity: 0; }
+    .topology-node { transition: none; }
+  }
+</style>

--- a/src/lib/components/OverviewView.svelte
+++ b/src/lib/components/OverviewView.svelte
@@ -22,6 +22,7 @@
   } from '$lib/utils/run-storyline';
   import type { Endpoint, EndpointStatistics, MeasurementSample } from '$lib/types';
   import type { VerdictRow } from '$lib/utils/verdict';
+  import NetworkTopology from './NetworkTopology.svelte';
 
   const HISTORY_VIEWBOX_WIDTH = 180;
   const HISTORY_VIEWBOX_HEIGHT = 48;
@@ -342,6 +343,7 @@
 
 <section class="figma-overview" aria-label="Overview">
   <div class="overview-inner">
+    <div class="hero-row">
     <section class="verdict-card" aria-label="Connection verdict">
       <div class="score-ring" style:--score-percent={`${scorePercent}%`} aria-label={`Score ${scoreDisplay} out of 10`}>
         <div class="score-ring-inner">
@@ -379,6 +381,11 @@
         </div>
       </div>
     </section>
+
+      <aside class="network-topology-wrap" aria-label="Network topology">
+        <NetworkTopology />
+      </aside>
+    </div>
 
     <div class="lower-grid">
       <section class="measured-panel" aria-label="Measured endpoints">
@@ -511,19 +518,39 @@
     gap: 32px;
   }
 
-  .verdict-card {
-    min-height: 330px;
+  .hero-row {
     display: grid;
-    grid-template-columns: 220px minmax(0, 1fr);
-    gap: clamp(28px, 4vw, 56px);
+    /* Per synthesis design contract Section 2: verdict-card 880-1040 wide
+       at 1440 viewport. Track sizing here lands the card in that envelope
+       while leaving the topology panel at ~280-360px on the right. */
+    grid-template-columns: minmax(0, 1040px) minmax(260px, 360px);
+    gap: 24px;
+    align-items: stretch;
+  }
+
+  .network-topology-wrap {
+    min-width: 0;
+    display: flex;
+    align-items: stretch;
+  }
+  .network-topology-wrap :global(.network-topology) {
+    flex: 1;
+  }
+
+  .verdict-card {
+    min-height: 360px;
+    max-height: 460px;
+    display: grid;
+    grid-template-columns: 180px minmax(0, 1fr);
+    gap: clamp(20px, 3vw, 40px);
     align-items: center;
-    padding: clamp(28px, 4vw, 56px);
+    padding: clamp(24px, 3vw, 40px);
     border: 1px solid var(--shell-border-strong);
     border-radius: 18px;
     background:
       radial-gradient(circle at 18% 45%, var(--shell-bg-cyan), transparent 34%),
-      linear-gradient(135deg, var(--shell-panel-raised), rgba(16, 23, 34, 0.72));
-    box-shadow: 0 28px 90px rgba(0, 0, 0, 0.18);
+      linear-gradient(135deg, var(--shell-panel-raised), color-mix(in srgb, var(--shell-panel-raised) 72%, transparent));
+    box-shadow: 0 28px 90px color-mix(in srgb, black 18%, transparent);
   }
 
   .score-ring {
@@ -685,7 +712,7 @@
     gap: 10px;
     padding: 0 28px;
     border: 1px solid transparent;
-    background: linear-gradient(135deg, var(--accent-cyan), #2f80ff);
+    background: linear-gradient(135deg, var(--accent-cyan), color-mix(in srgb, var(--accent-cyan), black 70%));
     color: var(--shell-bg);
     box-shadow: 0 0 28px rgba(103, 232, 249, 0.26);
   }
@@ -794,7 +821,7 @@
     margin-top: 10px;
     border: 1px solid var(--shell-border);
     border-radius: 18px;
-    background: rgba(11, 17, 27, 0.74);
+    background: color-mix(in srgb, var(--shell-panel) 74%, transparent);
     overflow: hidden;
   }
 
@@ -870,7 +897,7 @@
     min-width: 0;
     height: 54px;
     border-radius: 10px;
-    background: rgba(8, 14, 24, 0.54);
+    background: color-mix(in srgb, var(--shell-base) 54%, transparent);
     overflow: hidden;
   }
 
@@ -952,7 +979,7 @@
     padding: 12px 14px 14px;
     border: 1px solid var(--shell-border);
     border-radius: 14px;
-    background: rgba(8, 14, 24, 0.62);
+    background: color-mix(in srgb, var(--shell-base) 62%, transparent);
   }
 
   .event-timeline-window {


### PR DESCRIPTION
## Summary

PR 6 of 9 in the synthesis arc. Adds the spatial visualization the contract calls "the missing metaphor" — browser node + endpoint nodes + animated pulses driven by REAL measurement events. Also tightens the verdict-card geometry per the contract's anatomy contract.

## New component: `NetworkTopology.svelte`

- SVG-based; origin (browser) node on the left, endpoint nodes stacked on the right.
- Tone-based stroke colors per `EndpointTone` (good→green, watch→amber, bad→pink, collecting→cyan).
- Pulse animation triggered by per-endpoint sample-count increments via `$effect`. **Cadence = whatever the real measurement loop produces, not `setInterval(Math.random)`.** A `{#key}` block forces Svelte to recreate the pulse `<circle>` per trigger, restarting the CSS animation.
- Empty state when no endpoints configured (CTA opens endpoint-management overlay).
- Endpoint clicks call `navigateTo({ name: 'endpoint', endpointId })` via the router from PR 4.
- prefers-reduced-motion respected.
- Caps at 8 visible nodes with a "+N more" caption for >8 (compact-grid collapse deferred).

## Overview layout restructure

- New `.hero-row` grid wraps verdict-card + NetworkTopology side-by-side at desktop.
- Verdict-card constrained per the contract: width ≤1040, height 360-460. Inner grid columns tightened (180px score ring vs. 220px previously).

## CSS discipline

- 4 raw rgba/hex values in OverviewView tokenized via `color-mix()` + existing CSS vars.
- OverviewView removed from `.stylelintignore`.

## Deferred (documented in commit message)

- Label collision avoidance algorithm for arbitrary label lengths.
- Compact-grid + chip collapse for >8 endpoints.
- Unit tests for NetworkTopology (store-reactive component; visual gate covers rendered output).

## Verification

- typecheck (tsc + svelte-check + functions): pass.
- lint (ESLint): pass.
- lint:css (stylelint): pass (OverviewView off the ignore list).
- test: 1115 / 1115.
- build: pass (~340 KB JS, +4 KB from NetworkTopology).

## Test plan

- [ ] CI green.
- [ ] Manual: Overview renders NetworkTopology on right column with active pulse packets when measurement is running.
- [ ] Manual: Verdict card width measured between 880 and 1040px at 1440 viewport.
- [ ] Manual: Click endpoint node → navigates to /endpoint/:id.
- [ ] Manual: 0 endpoints → empty-state card with Add endpoint CTA.

PR 7 (`codex/synthesis-endpoint-detail`) follows — the heaviest implementation PR.