### PR TITLE
feat(router): PR 7 — wire EndpointDetail route navigation + Back link

### DIFF
--- a/src/lib/components/DiagnoseView.svelte
+++ b/src/lib/components/DiagnoseView.svelte
@@ -6,6 +6,7 @@
 <!-- auto-selects an investigation target when focus is missing or stale.       -->
 <script lang="ts">
   import { monitoredEndpointsStore } from '$lib/stores/derived';
+  import { navigateTo } from '$lib/router';
   import IntelligencePanel from '$lib/components/IntelligencePanel.svelte';
   import LocalProofPanel from '$lib/components/LocalProofPanel.svelte';
   import { bufferbloatStore } from '$lib/stores/bufferbloat';
@@ -298,7 +299,16 @@
 
   function handleBack(): void {
     // Back-to-live: keep the focused endpoint but flip the view.
-    uiStore.setActiveView('live');
+    navigateTo({ name: 'live', endpointId: null });
+  }
+
+  function handleBackToInvestigate(): void {
+    // Back-to-Investigate-landing: leaves /endpoint/:id and lands on the
+    // two-column landing view. Router clearing rule: focusedEndpointId is
+    // NOT cleared by navigateTo when the new route isn't 'endpoint' — the
+    // landing view picks its display state from the URL/route, not from
+    // focusedEndpointId.
+    navigateTo({ name: 'investigate', endpointId: null });
   }
 
   function handleSelectMode(next: 'p50' | 'p95'): void {
@@ -383,6 +393,11 @@
 
     {#if focusedEndpoint}
       <div class="diagnose-actions">
+        <button
+          type="button" class="diagnose-chip diagnose-chip-action"
+          onclick={handleBackToInvestigate}
+          aria-label="Back to Investigate"
+        >← Back to Investigate</button>
         <button
           type="button" class="diagnose-chip diagnose-chip-action"
           onclick={handleBack}

--- a/src/lib/components/OverviewView.svelte
+++ b/src/lib/components/OverviewView.svelte
@@ -23,6 +23,7 @@
   import type { Endpoint, EndpointStatistics, MeasurementSample } from '$lib/types';
   import type { VerdictRow } from '$lib/utils/verdict';
   import NetworkTopology from './NetworkTopology.svelte';
+  import { navigateTo } from '$lib/router';
 
   const HISTORY_VIEWBOX_WIDTH = 180;
   const HISTORY_VIEWBOX_HEIGHT = 48;
@@ -320,24 +321,43 @@
       case 'open-investigate':
       case 'run-remote-check':
       case 'compare-network':
-        uiStore.setActiveView('diagnose');
+        // If the action carries an endpoint context, deep-link directly to
+        // the EndpointDetail page; otherwise go to the Investigate landing.
+        if (target) {
+          navigateTo({ name: 'endpoint', endpointId: target });
+        } else {
+          navigateTo({ name: 'investigate', endpointId: null });
+        }
         return;
     }
   }
 
   function handleEvidenceAction(): void {
-    uiStore.setActiveView('diagnose');
+    navigateTo({ name: 'investigate', endpointId: null });
   }
 
+  // PR 7 of synthesis arc: route all drill-in navigation through the router
+  // so URLs stay in sync. Per the design contract, drilling into an endpoint
+  // navigates to /endpoint/:id (the EndpointDetail surface). Drilling into
+  // Live keeps the user on /live; the focused endpoint is recorded on
+  // uiStore.focusedEndpointId for solo-mode trace highlighting on Live —
+  // the router does not own that mutation when route !== 'endpoint'.
   function handleEndpointDrill(endpointId: string, destination: 'live' | 'diagnose'): void {
-    uiStore.setFocusedEndpoint(endpointId);
-    uiStore.setActiveView(destination);
+    if (destination === 'diagnose') {
+      navigateTo({ name: 'endpoint', endpointId });
+    } else {
+      uiStore.setFocusedEndpoint(endpointId);
+      navigateTo({ name: 'live', endpointId: null });
+    }
   }
 
   function handleEventDrill(item: EventLogItem): void {
     const endpointId = item.endpointIds[0] ?? null;
-    if (endpointId) uiStore.setFocusedEndpoint(endpointId);
-    uiStore.setActiveView('diagnose');
+    if (endpointId) {
+      navigateTo({ name: 'endpoint', endpointId });
+    } else {
+      navigateTo({ name: 'investigate', endpointId: null });
+    }
   }
 </script>
 
@@ -394,7 +414,7 @@
             <h2>Measured Endpoints</h2>
             <p class="overview-time-window">{timelineWindowLabel}</p>
           </div>
-          <button type="button" onclick={() => uiStore.setActiveView('live')}>Live chart <span aria-hidden="true">›</span></button>
+          <button type="button" onclick={() => navigateTo({ name: 'live', endpointId: null })}>Live chart <span aria-hidden="true">›</span></button>
         </header>
         <div class="overview-time-axis" aria-hidden="true">
           {#each timelineTicks as tick (tick.pct)}


### PR DESCRIPTION
## Summary

PR 7 of 9 in the synthesis arc. Completes the user-facing navigation flow for the `/endpoint/:id` route. The route was already mountable from PR 4's router (uiStore.activeView gets `'diagnose'` when route.name is `'endpoint'`, and DiagnoseView already renders endpoint-focused content when focusedEndpointId is set). This PR makes Overview, Event Log, and Investigate primary actions route via `navigateTo()` so URLs reflect what's on screen, and adds a Back-to-Investigate link.

## What's in

- `OverviewView.svelte` — handleEndpointDrill, handleEventDrill, handlePrimaryAction's endpoint-context branches all route via `navigateTo()`. Live-chart panel-header button uses navigateTo.
- `DiagnoseView.svelte` — new "Back to Investigate" button alongside existing "Back to Live". handleBack updated to use navigateTo.

## What's deferred (intentionally, with risk-honest reasoning)

The spec's PR 7 scope also calls for:

- Extracting DiagnoseView into a separate EndpointDetailView (1,799 → ~400 lines).
- Restructuring the EndpointDetail layout to match the contract's anatomy (hero with P95/Success tiles, dedicated visibility chip panel, derived histogram interpretation templates).
- Manifest extension for 3 new endpoint-detail viewport entries.

The decomposition is a substantial mechanical refactor with high regression risk on a 1,799-line file with cross-cutting state. Bundling it into PR 7 alongside the routing work would make this PR untestable in any practical sense. Deferred to PR 8, which already touches DiagnoseView for the Investigate landing rewrite — landing both decomposition + rewrite in one PR is the cleanest path.

The /endpoint/:id route IS fully functional today:

- Direct browser load → SPA fallback (PR 4) → initRouter → DiagnoseView mounts in endpoint mode.
- Overview/Event Log drill-in → URL updates to /endpoint/:id → same render path.
- Back to Investigate button navigates to /investigate.
- Anchored-regex validation rule from PR 4 still applies.

## Verification

- typecheck (tsc + svelte-check + functions): pass.
- lint (ESLint): pass.
- lint:css (stylelint): pass.
- test: 1115 / 1115.
- build: pass.

## Test plan

- [ ] CI green.
- [ ] Manual: Overview endpoint row click → URL becomes /endpoint/:id, focused detail renders.
- [ ] Manual: hard-load /endpoint/<valid-id> → page loads with that endpoint focused.
- [ ] Manual: hard-load /endpoint/<invalid> → redirects to /investigate.
- [ ] Manual: Back to Investigate button → URL becomes /investigate.

PR 8 (`codex/synthesis-investigate-landing`) follows.