### PR TITLE
fix(synthesis): Cloudflare deep-links, mobile hero-row, pulse animation, verdict copy

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,6 +1,4 @@
 /r/*           /index.html  200
 /endpoint/*    /index.html  200
-/live          /index.html  200
-/investigate   /index.html  200
-/report        /index.html  200
 /diagnose      /investigate 301
+/*             /index.html  200

--- a/src/lib/components/NetworkTopology.svelte
+++ b/src/lib/components/NetworkTopology.svelte
@@ -118,18 +118,23 @@
         />
       {/each}
 
-      <!-- Pulse packets — re-rendered when pulseKeys[ep.id] increments. -->
+      <!-- Pulse packets — re-rendered when pulseKeys[ep.id] increments.
+           cx/cy are set to the ORIGIN position; the animation translates the
+           element via CSS transform (which IS reliably animatable on SVG,
+           unlike CSS animation of SVG `cx`/`cy` attributes which silently
+           strands the element). The translate distance is the delta from
+           origin to endpoint, passed via --pulse-dx/--pulse-dy. -->
       {#each nodes as node (node.endpoint.id)}
         {#if pulseKeys[node.endpoint.id]}
           {#key pulseKeys[node.endpoint.id]}
             <circle
               class="topology-pulse"
               data-tone={node.tone}
-              r="3"
-              style:--pulse-x1="{ORIGIN_X}px"
-              style:--pulse-y1="{ORIGIN_Y}px"
-              style:--pulse-x2="{node.x}px"
-              style:--pulse-y2="{node.y}px"
+              cx={ORIGIN_X}
+              cy={ORIGIN_Y}
+              r="3.5"
+              style:--pulse-dx="{node.x - ORIGIN_X}px"
+              style:--pulse-dy="{node.y - ORIGIN_Y}px"
             />
           {/key}
         {/if}
@@ -208,30 +213,41 @@
     overflow: visible;
   }
 
+  /* Path lines — brighter than the prior shell-divider tone so the
+     spatial structure reads at a glance against the dark panel. */
   .topology-path {
-    stroke: var(--shell-divider);
+    stroke: var(--shell-border-strong);
     fill: none;
+    stroke-width: 1.2;
   }
 
+  /* Nodes — filled (slightly darker than the panel background so the
+     coloured stroke pops), thicker stroke, and a tone-coloured drop
+     shadow / glow halo so each endpoint has presence rather than reading
+     as a wireframe placeholder. */
   .topology-node {
-    fill: var(--shell-panel-raised);
-    stroke-width: 2;
+    fill: var(--shell-base);
+    stroke-width: 2.5;
     transition: stroke 200ms ease, fill 200ms ease;
   }
   [data-role='origin'] .topology-node {
-    stroke: var(--t3);
+    stroke: var(--t2);
   }
   [data-tone='good'] .topology-node {
     stroke: var(--accent-green);
+    filter: drop-shadow(0 0 6px var(--accent-green));
   }
   [data-tone='watch'] .topology-node {
     stroke: var(--accent-amber);
+    filter: drop-shadow(0 0 6px var(--accent-amber));
   }
   [data-tone='bad'] .topology-node {
     stroke: var(--accent-pink);
+    filter: drop-shadow(0 0 8px var(--accent-pink));
   }
   [data-tone='collecting'] .topology-node {
     stroke: var(--accent-cyan);
+    filter: drop-shadow(0 0 6px var(--accent-cyan));
   }
 
   .topology-node-clickable {
@@ -245,13 +261,16 @@
     outline: none;
   }
   .topology-node-clickable:focus-visible .topology-node {
-    stroke-width: 3;
+    stroke-width: 3.5;
   }
 
+  /* Labels — bumped contrast (was --t3 = .5 alpha, barely readable;
+     --t2 = .58 still calm but legible). */
   .topology-label {
-    fill: var(--t3);
+    fill: var(--t2);
     font-family: var(--mono);
     font-size: 10px;
+    font-weight: 600;
     letter-spacing: var(--tr-label);
     text-transform: uppercase;
     pointer-events: none;
@@ -260,16 +279,20 @@
   [data-tone='watch'] .topology-label,
   [data-tone='bad'] .topology-label,
   [data-tone='collecting'] .topology-label {
-    fill: var(--t2);
+    fill: var(--t1);
   }
 
-  /* Pulse packets — animate from origin (x1,y1) to endpoint (x2,y2)
-     using CSS custom properties bound at render time. The {#key} block
-     above re-renders these elements per pulse trigger, restarting the
-     animation. Tone-colored to match the destination endpoint. */
+  /* Pulse packets — animate via CSS transform: translate (which IS
+     reliably animatable on SVG elements). The earlier implementation used
+     CSS keyframes on the SVG `cx`/`cy` attributes, which Chrome accepts
+     syntactically but renders inconsistently and frequently strands the
+     element mid-path. The new approach: render the circle at the origin
+     coordinates (cx=ORIGIN_X, cy=ORIGIN_Y) and animate transform: translate
+     by --pulse-dx / --pulse-dy (the delta to the endpoint). */
   .topology-pulse {
     animation: pulse-travel 1.2s ease-out forwards;
     pointer-events: none;
+    transform-box: fill-box;
   }
   [data-tone='good'].topology-pulse { fill: var(--accent-green); }
   [data-tone='watch'].topology-pulse { fill: var(--accent-amber); }
@@ -277,10 +300,10 @@
   [data-tone='collecting'].topology-pulse { fill: var(--accent-cyan); }
 
   @keyframes pulse-travel {
-    0%   { cx: var(--pulse-x1); cy: var(--pulse-y1); opacity: 0; }
-    20%  { opacity: 1; }
-    80%  { opacity: 1; }
-    100% { cx: var(--pulse-x2); cy: var(--pulse-y2); opacity: 0; }
+    0%   { transform: translate(0, 0);                            opacity: 0; }
+    20%  { transform: translate(calc(var(--pulse-dx) * 0.2), calc(var(--pulse-dy) * 0.2)); opacity: 1; }
+    80%  { transform: translate(calc(var(--pulse-dx) * 0.8), calc(var(--pulse-dy) * 0.8)); opacity: 1; }
+    100% { transform: translate(var(--pulse-dx), var(--pulse-dy));  opacity: 0; }
   }
 
   .network-topology-empty {

--- a/src/lib/components/OverviewView.svelte
+++ b/src/lib/components/OverviewView.svelte
@@ -1140,6 +1140,13 @@
   }
 
   @media (max-width: 1100px) {
+    .hero-row {
+      /* Collapse to single column below ~tablet width. The synthesis arc's
+         desktop 2-col verdict + topology layout squashes the verdict card
+         to almost nothing without this — verified at 600px viewport
+         post-PR 6 deploy: verdict-card was 184px wide. */
+      grid-template-columns: 1fr;
+    }
     .verdict-card {
       grid-template-columns: 170px minmax(0, 1fr);
       gap: 28px;

--- a/src/lib/utils/diagnostic-narrative.ts
+++ b/src/lib/utils/diagnostic-narrative.ts
@@ -963,8 +963,18 @@ function primaryValidationFor(input: {
   };
 }
 
-function safeSummaryFor(claim: DiagnosticClaim, confidenceReasonText: string): string {
-  return `This browser test: ${claim.text} (${claim.strength} confidence; ${confidenceReasonText})`;
+function safeSummaryFor(claim: DiagnosticClaim): string {
+  // Drops the "(${strength} confidence; ${reason})" parenthetical that the
+  // synthesis design contract Section 2 "Disallowed" list explicitly forbids
+  // ("duplicates the measured fact and reads as marketing"). Confidence and
+  // its reason are still exposed on the DiagnoseNarrative via the
+  // `confidence`, `confidenceLabel`, and `confidenceReason` fields — surfaces
+  // that want to render them can compose them explicitly. The parenthetical
+  // also caused the Interpretation in the Overview verdict card to repeat the
+  // headline verbatim with a marketing-style suffix (verified in production
+  // 2026-05-17), which undermines the fact-vs-interpretation discipline the
+  // verdict card was designed to demonstrate.
+  return `This browser test: ${claim.text}`;
 }
 
 function timingSummaryFor(timingVisibility: TimingVisibility): string {
@@ -1022,6 +1032,57 @@ function supportingSummaryFor(input: {
     return `Clean browser-visible run: ${sampleScope}.`;
   }
 
+  // Substantive Measured Fact for the degraded kinds (jitter, isolated-
+  // endpoint, shared-network, multiple-slow, packet-loss). The prior
+  // fallback ("Evidence: ${sampleScope}; ${timingSummary}.") was meta-count,
+  // not a fact about WHAT was measured — the synthesis design contract
+  // calls for the Measured Fact slot to carry the actual measurement.
+  if (rows.length > 0) {
+    const medians = rows.map((r) => r.stats.p50).filter((v) => Number.isFinite(v)).sort((a, b) => a - b);
+    const median = medians.length > 0 ? Math.round(medians[Math.floor(medians.length / 2)] ?? 0) : null;
+    const p95s = rows.map((r) => r.stats.p95).filter((v) => Number.isFinite(v));
+    const peakP95 = p95s.length > 0 ? Math.round(Math.max(...p95s)) : null;
+    const peakRow = peakP95 !== null ? rows.find((r) => Math.round(r.stats.p95) === peakP95) : null;
+    const peakName = peakRow?.ep.label ?? null;
+
+    if (kind === 'isolated-endpoint') {
+      // The slow endpoint is the one with the highest p95 — peakRow above
+      // already identifies it. Surface its name and p95 explicitly so the
+      // Measured Fact carries the actual measurement, not just a count.
+      const slowName = peakName ?? 'one site';
+      return median !== null && peakP95 !== null
+        ? `Median latency is ${median} ms across ${rows.length} ${plural(rows.length, 'site')}; ${slowName} is the slowest at p95 ${peakP95} ms.`
+        : `${slowName} is the slowest site in this window.`;
+    }
+
+    if (kind === 'jitter') {
+      return median !== null && peakP95 !== null
+        ? `p50 is ${median} ms across ${rows.length} ${plural(rows.length, 'site')}, but p95 reaches ${peakP95} ms — latency is varying widely.`
+        : `Latencies are varying widely across ${rows.length} ${plural(rows.length, 'site')}.`;
+    }
+
+    if (kind === 'shared-network') {
+      return median !== null
+        ? `All ${rows.length} measured ${plural(rows.length, 'site')} are elevated: median is ${median} ms (threshold ${threshold} ms).`
+        : `All ${rows.length} measured ${plural(rows.length, 'site')} are over threshold.`;
+    }
+
+    if (kind === 'multiple-slow') {
+      const over = rows.filter((r) => r.stats.p50 > threshold).length;
+      return median !== null
+        ? `${over} of ${rows.length} ${plural(rows.length, 'site')} are over the ${threshold} ms threshold; overall median is ${median} ms.`
+        : `${over} of ${rows.length} ${plural(rows.length, 'site')} are over the ${threshold} ms threshold.`;
+    }
+
+    if (kind === 'packet-loss') {
+      const totalLoss = rows.reduce((sum, r) => sum + (r.stats.lossPercent ?? 0), 0) / rows.length;
+      return Number.isFinite(totalLoss)
+        ? `Some requests are failing — average loss across ${rows.length} ${plural(rows.length, 'site')} is ${totalLoss.toFixed(1)}%.`
+        : `Some requests are failing across ${rows.length} ${plural(rows.length, 'site')}.`;
+    }
+  }
+
+  // Final fallback (rare — handles edge cases where no rows are ready).
   return `Evidence: ${sampleScope}; ${timingSummaryFor(timingVisibility)}.`;
 }
 
@@ -1104,7 +1165,7 @@ export function buildDiagnosticNarrative(input: DiagnosticInput): DiagnosticNarr
     primaryAnswer,
     claims: [primaryAnswer, ...registryClaims],
     primaryValidation,
-    safeSummary: safeSummaryFor(primaryAnswer, confidenceReasonText),
+    safeSummary: safeSummaryFor(primaryAnswer),
     supportingSummary: supportingSummaryFor({
       kind,
       confidence,

--- a/tests/unit/utils/diagnostic-narrative.test.ts
+++ b/tests/unit/utils/diagnostic-narrative.test.ts
@@ -224,7 +224,14 @@ describe('buildDiagnosticNarrative', () => {
     );
     expect(narrative.evidence.some((item) => item.label === 'Site to inspect' && item.value === 'API')).toBe(true);
     expect(narrative.safeSummary).not.toMatch(/likely (source|site|network|your network)/i);
-    expect(narrative.supportingSummary).toBe('Evidence: 18+ successful checks across 3 sites; total timing only.');
+    // Post-hotfix (fix/synthesis-arc-hotfixes) the Measured Fact slot
+    // surfaces actual measurements per kind rather than the prior generic
+    // "Evidence: N+ successful checks across N sites; total timing only."
+    // meta-count. For the isolated-endpoint kind, it now names the slowest
+    // site by label and includes its p95.
+    expect(narrative.supportingSummary).toBe(
+      'Median latency is 45 ms across 3 sites; API is the slowest at p95 70 ms.',
+    );
     expect(narrative.nextSteps.join(' ')).toContain('Open Investigate');
     expect(narrative.triageActions.map((action) => action.id)).toEqual([
       'review-browser-visibility',

--- a/tests/unit/utils/diagnostic-report.test.ts
+++ b/tests/unit/utils/diagnostic-report.test.ts
@@ -152,7 +152,15 @@ describe('buildDiagnosticReport', () => {
     expect(report.copySummary).not.toMatch(/likely (affected|source|site|network|your network)/i);
     expect(report.copySummary).not.toContain(report.diagnosis.verdict.headline);
     expect(report.copySummary).toContain(report.diagnosis.primaryAnswer.text);
-    expect(report.copySummary).toContain('Trust: Evidence: 30+ successful checks across 3 sites; total timing only.');
+    // Post-hotfix (fix/synthesis-arc-hotfixes) the report's Trust slot
+    // surfaces actual measurements per kind rather than the prior generic
+    // "Evidence: N+ successful checks across N sites; total timing only."
+    // meta-count, matching the synthesis design contract's Measured Fact
+    // anatomy. For isolated-endpoint kind it names the slowest site by
+    // label and includes its p95.
+    expect(report.copySummary).toContain(
+      'Trust: Median latency is 45 ms across 3 sites; API is the slowest at p95 280 ms.',
+    );
     expect(report.copySummary).toContain(`Next validation: ${report.diagnosis.primaryValidation.claim.text}`);
     expect(report.copySummary).toContain('Watch for: If detailed timing appears');
     expect(report.copySummary.match(new RegExp(report.diagnosis.primaryAnswer.text, 'g'))).toHaveLength(1);


### PR DESCRIPTION
## Summary

Hotfix for four production regressions surfaced during live review of `chronoscope.dev` on 2026-05-17 (review compared deployed shell against both the synthesis design contract and the Figma `chrono-redesign-v2` prototype).

## Fixes

### 1. Cloudflare deep-link 308 redirects → use catch-all SPA fallback

Verified via curl: bare `/live`, `/investigate`, `/report` returned **HTTP 308 redirect to `/`** instead of serving the SPA. Only wildcard rules (`/endpoint/*`, `/r/*`) worked. Cloudflare's matcher silently default-redirects unmatched paths to root, taking precedence over my exact-match rules.

Standard SPA fix: specific rules first, then `/* /index.html 200` catch-all. The router parses `pathname` after JS loads and handles validation / redirects from there.

```
/r/*           /index.html  200
/endpoint/*    /index.html  200
/diagnose      /investigate 301
/*             /index.html  200
```

### 2. Mobile hero-row collapse

PR 6's `.hero-row { grid-template-columns: minmax(0, 1040px) minmax(260px, 360px); }` had no media query. Verdict card collapsed to **92px wide** at 500px viewport in production. Added a `@media (max-width: 1100px)` rule that collapses the grid to a single column.

### 3. NetworkTopology pulse animation

Pulse packets rendered as **static dots permanently stranded along each path** in production. CSS keyframes on SVG `cx`/`cy` attributes are accepted syntactically but render inconsistently. Replaced with `transform: translate()` keyframes (reliably animatable on SVG when `transform-box: fill-box` is set), parameterised on `--pulse-dx` / `--pulse-dy`.

Also boosted the topology's visual weight per the v2 prototype reference: filled nodes against the panel base, thicker tone-colored stroke with `drop-shadow(0 0 6-8px <tone>)` halo, brighter path lines (`shell-border-strong` instead of `shell-divider`, 1.2px stroke), and higher-contrast labels (`t2` → `t1` for tone-active nodes). Before this the topology read as wireframe sketching; now each endpoint has presence.

### 4. Verdict body copy

Two violations of the synthesis design contract caught by both the review and direct comparison against the Figma prototype's substantive copy:

- **Interpretation ended with** `(high confidence; Based on N+ successful checks across N sites.)` — the exact marketing-style suffix the spec's Section 2 "Disallowed" list calls out. Dropped from `safeSummaryFor`. Confidence + reason remain available on the narrative via `.confidence`, `.confidenceLabel`, `.confidenceReason` for surfaces that want them.
- **Measured Fact rendered as** `Evidence: 48+ successful checks across 4 sites; 48/192 checks show detailed timing.` — that's meta-count, not measurement. Rewrote `supportingSummaryFor` so each diagnostic kind surfaces a real measurement:

| Kind | New Measured Fact copy |
|---|---|
| `isolated-endpoint` | "Median latency is N ms across M sites; `<slowest>` is the slowest at p95 N ms." |
| `jitter` | "p50 is N ms across M sites, but p95 reaches N ms — latency is varying widely." |
| `shared-network` | "All M measured sites are elevated: median is N ms (threshold T ms)." |
| `multiple-slow` | "K of M sites are over the T ms threshold; overall median is N ms." |
| `packet-loss` | "Some requests are failing — average loss across M sites is N%." |

Healthy / collecting branches keep their existing copy (already substantive). Generic fallback survives for rare edge cases.

## Tests updated

Two exact-string assertions of the old "Evidence: N+ successful checks" copy in `diagnostic-narrative.test.ts` and `diagnostic-report.test.ts` are now asserting the substantive isolated-endpoint copy. Both have comments referencing this branch.

## Verification

- typecheck (tsc + svelte-check + functions): pass.
- lint (ESLint): pass.
- lint:css (stylelint): pass.
- test: 1115 / 1115.
- build: pass (~347 KB JS).

## Test plan post-deploy

- [ ] `curl -I https://chronoscope.dev/live` returns 200 not 308.
- [ ] `curl -I https://chronoscope.dev/investigate` returns 200 not 308.
- [ ] Browser load of `/endpoint/<id>` renders endpoint detail directly.
- [ ] Mobile viewport (375 / 390 / 430): hero-row stacks; verdict card fills width; NetworkTopology renders below.
- [ ] NetworkTopology pulses visibly travel from BROWSER node to each endpoint node and fade.
- [ ] Overview verdict card: Interpretation no longer contains `(<...>confidence; Based on ...)` parenthetical.
- [ ] Overview verdict card on a degraded run: Measured Fact contains real median/p95 numbers and names the slowest endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved network topology visualization with enhanced pulse animations, stronger line styling, and updated node rendering
  
* **Bug Fixes**
  * Fixed responsive layout behavior on smaller screens (≤1100px) for better single-column display
  
* **New Features**
  * Enhanced diagnostic reports with detailed measurement-specific data, including endpoint performance metrics and latency information
  * Updated routing for `/diagnose` redirect

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xaedyn/chronoscope/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->