### PR TITLE
refactor(shell): unify pill chrome and collapse icon trio to settings cog

### DIFF
--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -12,7 +12,6 @@
   import { uiStore } from '$lib/stores/ui';
   import { tokens } from '$lib/tokens';
   import Topbar from './Topbar.svelte';
-  import ViewSwitcher from './ViewSwitcher.svelte';
   import OverviewView from './OverviewView.svelte';
   import LiveView from './LiveView.svelte';
   import DiagnoseView from './DiagnoseView.svelte';
@@ -82,8 +81,6 @@
   {:else}
     <div class="shell-body">
       <div class="shell-main-wrap">
-        <ViewSwitcher />
-
         <main id="main-content" class="shell-main" tabindex="-1">
           {#if activeView === 'live'}
             <LiveView />

--- a/src/lib/components/SettingsDrawer.svelte
+++ b/src/lib/components/SettingsDrawer.svelte
@@ -90,6 +90,19 @@
     }, 150);
   }
 
+  // Quick-action openers — close this drawer first so only one overlay
+  // is open at a time. The animated close runs in parallel with the new
+  // overlay opening; that's intentional and matches existing popover
+  // open/close timing.
+  function openEndpoints(): void {
+    close();
+    if (!$uiStore.showEndpoints) uiStore.toggleEndpoints();
+  }
+  function openShare(): void {
+    close();
+    if (!$uiStore.showShare) uiStore.toggleShare();
+  }
+
   let drawerContentEl: HTMLDivElement;
 
   function handleBackdropClick(event: MouseEvent): void {
@@ -278,6 +291,40 @@
           Stop test to edit locked settings.
         </p>
       {/if}
+
+      <!-- Quick actions: replaces the prior trio of icon ovals
+           (endpoints/share/run-details) that the synthesis design contract
+           collapsed off the shell pill. Buttons open the corresponding
+           overlay and close this drawer so only one sheet is open at a
+           time. -->
+      <div class="quick-actions" role="group" aria-label="Quick actions">
+        <button
+          type="button"
+          class="quick-action-btn"
+          aria-label="Open endpoint management"
+          onclick={openEndpoints}
+        >
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <rect x="2" y="3" width="12" height="3" rx="0.5" stroke="currentColor" stroke-width="1.2"/>
+            <rect x="2" y="10" width="12" height="3" rx="0.5" stroke="currentColor" stroke-width="1.2"/>
+            <circle cx="4" cy="4.5" r="0.6" fill="currentColor"/>
+            <circle cx="4" cy="11.5" r="0.6" fill="currentColor"/>
+          </svg>
+          <span>Endpoints</span>
+        </button>
+        <button
+          type="button"
+          class="quick-action-btn"
+          aria-label="Open share results"
+          onclick={openShare}
+        >
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <path d="M4 10V12.5C4 13.052 4.448 13.5 5 13.5H11C11.552 13.5 12 13.052 12 12.5V10" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M8 2.5V10M8 2.5L5.5 5M8 2.5L10.5 5" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          <span>Share</span>
+        </button>
+      </div>
 
       <!-- Timing fields -->
       <div class="field">
@@ -632,6 +679,42 @@
     font-family: var(--sans);
     font-size: 12px;
     line-height: 1.4;
+  }
+
+  /* ── Quick actions ──────────────────────────────────────────────────────── */
+  .quick-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--spacing-xs);
+  }
+  .quick-action-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    min-height: 40px;
+    padding: 0 12px;
+    border-radius: var(--btn-radius);
+    border: 1px solid var(--shell-border);
+    background: var(--glass-bg);
+    color: var(--t2);
+    font-family: var(--sans);
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 160ms ease, color 160ms ease, border-color 160ms ease;
+  }
+  .quick-action-btn:hover {
+    background: var(--shell-panel-hover);
+    color: var(--t1);
+    border-color: var(--shell-border-strong);
+  }
+  .quick-action-btn:focus-visible {
+    outline: 2px solid var(--accent-cyan);
+    outline-offset: 2px;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .quick-action-btn { transition: none; }
   }
 
   /* ── Fields ──────────────────────────────────────────────────────────────── */

--- a/src/lib/components/Topbar.svelte
+++ b/src/lib/components/Topbar.svelte
@@ -1,14 +1,17 @@
 <!-- src/lib/components/Topbar.svelte -->
-<!-- Figma-aligned top app bar. Brand left, primary run action right, compact  -->
-<!-- utility controls nearby. Detailed run state lives in the Overview card.   -->
+<!-- Single sticky shell pill. Brand row + nav row share a background and
+     border so they read as one floating element rather than two stacked
+     bars. Three icon ovals (endpoints/share/run-details) collapsed to a
+     single settings cog per synthesis design contract Section 1. Measuring
+     pulse + T+MM:SS elapsed counter integrated near the Stop button. -->
 <script lang="ts">
   import { measurementStore } from '$lib/stores/measurements';
   import { endpointStore } from '$lib/stores/endpoints';
   import { settingsStore } from '$lib/stores/settings';
   import { uiStore } from '$lib/stores/ui';
   import type { TestLifecycleState } from '$lib/types';
-  import { formatElapsed } from '$lib/utils/format';
   import { isStartLifecycle, runStatusText, startStopButtonLabel } from '$lib/utils/lifecycle-copy';
+  import ViewSwitcher from './ViewSwitcher.svelte';
 
   let { onStart, onStop }: {
     onStart?: () => void;
@@ -16,59 +19,56 @@
   } = $props();
 
   const lifecycle: TestLifecycleState = $derived($measurementStore.lifecycle);
-  const roundCounter: number = $derived($measurementStore.roundCounter);
   const isSharedView: boolean = $derived($uiStore.isSharedView);
   const enabledEndpointCount = $derived($endpointStore.filter((ep) => ep.enabled).length);
   const cap = $derived($settingsStore.cap);
-  const burstRounds = $derived($settingsStore.burstRounds);
-  const monitorDelay = $derived($settingsStore.monitorDelay);
   const timeout = $derived($settingsStore.timeout);
   const startedAt = $derived($measurementStore.startedAt);
-  const errorCount = $derived($measurementStore.errorCount);
-  const timeoutCount = $derived($measurementStore.timeoutCount);
 
-  let detailsOpen = $state(false);
   let now = $state(Date.now());
 
   const isRunning = $derived(lifecycle === 'running');
   const isTransitioning = $derived(lifecycle === 'starting' || lifecycle === 'stopping');
+  const isMeasuring = $derived(isRunning || lifecycle === 'starting');
 
   const runText = $derived(runStatusText(lifecycle));
-
-  const tickText = $derived(`T+${String(roundCounter).padStart(4, '0')}`);
   const endpointText = $derived(`${enabledEndpointCount} endpoint${enabledEndpointCount === 1 ? '' : 's'}`);
   const timeoutText = $derived(`${Math.round(timeout / 1000)}s timeout`);
-  const progressText = $derived(`${roundCounter} of ${cap} samples`);
-  const elapsedText = $derived(startedAt === null ? 'Not started' : `${formatElapsed(Math.max(0, now - startedAt))} elapsed`);
-  const cadenceText = $derived(
-    roundCounter < burstRounds
-      ? `Burst ${Math.min(roundCounter, burstRounds)}/${burstRounds}`
-      : `${Math.round(monitorDelay / 1000)}s interval`
-  );
-  const issueText = $derived(
-    errorCount === 0 && timeoutCount === 0
-      ? 'No request errors'
-      : `${errorCount} error${errorCount === 1 ? '' : 's'} · ${timeoutCount} timeout${timeoutCount === 1 ? '' : 's'}`
-  );
-  const runSummaryText = $derived(`Browser test · ${endpointText} · ${timeoutText}`);
+  const runSummaryText = $derived(`${endpointText} · ${timeoutText} · cap ${cap}`);
 
+  // T+MM:SS elapsed counter per the synthesis design contract Section 1.
+  // Format mm:ss when under an hour, hh:mm:ss otherwise. Shows "T+00:00"
+  // during the brief "starting" lifecycle before the first round lands so
+  // the live affordance never blinks out.
+  const elapsedTickText = $derived.by(() => {
+    if (startedAt === null) return 'T+00:00';
+    const ms = Math.max(0, now - startedAt);
+    const totalSeconds = Math.floor(ms / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    const hours = Math.floor(minutes / 60);
+    if (hours > 0) {
+      const m = minutes % 60;
+      return `T+${String(hours).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+    }
+    return `T+${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+  });
+
+  // Single Stop/Start label per spec — drops the "Test" suffix.
   const startStopLabel = $derived(startStopButtonLabel(lifecycle));
   const isStartButton = $derived(isStartLifecycle(lifecycle));
   const startStopText = $derived.by(() => {
-    if (lifecycle === 'starting') return 'Starting...';
-    if (lifecycle === 'stopping') return 'Stopping...';
-    return isStartButton ? 'Start Test' : 'Stop Test';
+    if (lifecycle === 'starting') return 'Starting…';
+    if (lifecycle === 'stopping') return 'Stopping…';
+    return isStartButton ? 'Start' : 'Stop';
   });
 
   $effect(() => {
-    if (lifecycle !== 'running') return;
+    if (lifecycle !== 'running' && lifecycle !== 'starting') return;
     const id = setInterval(() => { now = Date.now(); }, 1000);
     return () => clearInterval(id);
   });
 
-  function handleRunDetails(): void {
-    detailsOpen = !detailsOpen;
-  }
   function handleStartStop(): void {
     if (lifecycle === 'running') onStop?.();
     else if (isStartButton) onStart?.();
@@ -78,159 +78,100 @@
     uiStore.setAutoStartSuppressionReason(null);
     measurementStore.reset();
   }
-  function handleSettings():  void { uiStore.toggleSettings();  }
-  function handleShare():     void { uiStore.toggleShare();     }
-  function handleEndpoints(): void { uiStore.toggleEndpoints(); }
+  function handleSettings(): void { uiStore.toggleSettings(); }
+  function handleShare(): void { uiStore.toggleShare(); }
 </script>
 
-<header class="topbar">
-  <div class="brand">
-    <div class="brand-mark" aria-hidden="true">
-      <svg viewBox="0 0 24 24" width="22" height="22">
-        <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="1.2" />
-        <circle cx="12" cy="12" r="1.4" fill="currentColor" />
-        <line x1="12" y1="12" x2="12" y2="4.5"  stroke="currentColor" stroke-width="1.2" stroke-linecap="round" />
-        <line x1="12" y1="12" x2="17" y2="15"   stroke="currentColor" stroke-width="1"   stroke-linecap="round" opacity="0.7" />
-      </svg>
-    </div>
-    <div class="brand-meta">
+<header class="shell-pill">
+  <!-- Brand + run-state + actions row -->
+  <div class="shell-row pill-row">
+    <div class="brand">
+      <div class="brand-mark" aria-hidden="true">
+        <svg viewBox="0 0 24 24" width="22" height="22">
+          <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="1.2" />
+          <circle cx="12" cy="12" r="1.4" fill="currentColor" />
+          <line x1="12" y1="12" x2="12" y2="4.5"  stroke="currentColor" stroke-width="1.2" stroke-linecap="round" />
+          <line x1="12" y1="12" x2="17" y2="15"   stroke="currentColor" stroke-width="1"   stroke-linecap="round" opacity="0.7" />
+        </svg>
+      </div>
       <div class="brand-name">Chronoscope</div>
-      <div class="brand-sub">HTTP latency monitor · multi-site</div>
     </div>
-  </div>
 
-  <div class="topbar-divider" aria-hidden="true"></div>
-
-  <div class="run-status" role="status" aria-live="polite" aria-label={runText}>
-    <span class="run-dot" class:on={isRunning} aria-hidden="true"></span>
-    <span class="run-label">{runText}</span>
-    <span class="run-tick" aria-hidden="true">{tickText}</span>
-  </div>
-  <span class="run-summary">{runSummaryText}</span>
-
-  <div class="spacer"></div>
-
-  <nav class="actions" aria-label="Test controls">
-    <div class="run-details">
-      <button
-        type="button"
-        class="icon-btn run-details-btn"
-        aria-label="Run details"
-        aria-expanded={detailsOpen}
-        aria-controls="run-details-popover"
-        onclick={handleRunDetails}
-      >
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-          <circle cx="8" cy="8" r="6.5" stroke="currentColor" stroke-width="1.3"/>
-          <path d="M8 7.25V11" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
-          <circle cx="8" cy="4.75" r=".75" fill="currentColor"/>
-        </svg>
-      </button>
-      {#if detailsOpen}
-        <div id="run-details-popover" class="run-details-popover" role="dialog" aria-label="Run details">
-          <p class="run-details-title">Browser test</p>
-          <dl class="run-details-list">
-            <div>
-              <dt>Endpoints</dt>
-              <dd>{endpointText}</dd>
-            </div>
-            <div>
-              <dt>Progress</dt>
-              <dd>{progressText}</dd>
-            </div>
-            <div>
-              <dt>Cadence</dt>
-              <dd>{cadenceText}</dd>
-            </div>
-            <div>
-              <dt>Timeout</dt>
-              <dd>{timeoutText}</dd>
-            </div>
-            <div>
-              <dt>Elapsed</dt>
-              <dd>{elapsedText}</dd>
-            </div>
-            <div>
-              <dt>Requests</dt>
-              <dd>{issueText}</dd>
-            </div>
-          </dl>
-        </div>
-      {/if}
-    </div>
-    {#if isSharedView}
-      <button
-        type="button" class="icon-btn"
-        aria-label="Share results" aria-expanded={$uiStore.showShare} aria-controls="share-popover"
-        onclick={handleShare}
-      >
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-          <path d="M4 10V12.5C4 13.052 4.448 13.5 5 13.5H11C11.552 13.5 12 13.052 12 12.5V10" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
-          <path d="M8 2.5V10M8 2.5L5.5 5M8 2.5L10.5 5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
-      </button>
-      <button type="button" class="run-btn start run-own" aria-label="Run your own test" onclick={handleRunOwn}>
-        Run Your Own Test
-      </button>
-    {:else}
-      <button
-        type="button" class="icon-btn"
-        aria-label="Add or remove endpoints" aria-expanded={$uiStore.showEndpoints} aria-controls="endpoint-drawer"
-        onclick={handleEndpoints}
-      >
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-          <circle cx="8" cy="8" r="6.5" stroke="currentColor" stroke-width="1.3"/>
-          <path d="M8 5V11M5 8H11" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
-        </svg>
-      </button>
-      <button
-        type="button" class="icon-btn"
-        aria-label="Open settings" aria-expanded={$uiStore.showSettings} aria-controls="settings-drawer"
-        onclick={handleSettings}
-      >
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-          <path d="M2 4H10.5M13.5 4H14M2 8H5M8 8H14M2 12H8M11 12H14" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
-          <circle cx="12"  cy="4"  r="1.5" stroke="currentColor" stroke-width="1.3"/>
-          <circle cx="6.5" cy="8"  r="1.5" stroke="currentColor" stroke-width="1.3"/>
-          <circle cx="9.5" cy="12" r="1.5" stroke="currentColor" stroke-width="1.3"/>
-        </svg>
-      </button>
-      <button
-        type="button" class="icon-btn"
-        aria-label="Share results" aria-expanded={$uiStore.showShare} aria-controls="share-popover"
-        onclick={handleShare}
-      >
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-          <path d="M4 10V12.5C4 13.052 4.448 13.5 5 13.5H11C11.552 13.5 12 13.052 12 12.5V10" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
-          <path d="M8 2.5V10M8 2.5L5.5 5M8 2.5L10.5 5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
-      </button>
-      <button
-        type="button"
-        class="run-btn"
-        class:start={isStartButton}
-        class:stop={isRunning}
-        disabled={isTransitioning}
-        aria-disabled={isTransitioning}
-        aria-label={startStopLabel}
-        onclick={handleStartStop}
-      >
-        <span class="run-btn-icon" aria-hidden="true">{isRunning ? '■' : '▶'}</span>
-        <span>{startStopText}</span>
-      </button>
+    <!-- Measuring affordance integrated into the pill: cyan pulsing dot +
+         T+MM:SS elapsed counter near the Stop button. Renders only while
+         a run is active. -->
+    {#if isMeasuring}
+      <div class="run-status" role="status" aria-live="polite" aria-label={runText}>
+        <span class="measuring-dot" aria-hidden="true"></span>
+        <span class="measuring-label">Measuring</span>
+        <span class="measuring-tick" aria-hidden="true">{elapsedTickText}</span>
+      </div>
     {/if}
-  </nav>
+
+    <span class="spacer"></span>
+
+    <span class="run-summary" aria-hidden="true">{runSummaryText}</span>
+
+    <nav class="actions" aria-label="Test controls">
+      {#if isSharedView}
+        <button
+          type="button" class="icon-btn"
+          aria-label="Share results" aria-expanded={$uiStore.showShare} aria-controls="share-popover"
+          onclick={handleShare}
+        >
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <path d="M4 10V12.5C4 13.052 4.448 13.5 5 13.5H11C11.552 13.5 12 13.052 12 12.5V10" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M8 2.5V10M8 2.5L5.5 5M8 2.5L10.5 5" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+        </button>
+        <button type="button" class="run-btn start run-own" aria-label="Run your own test" onclick={handleRunOwn}>
+          Run your own test
+        </button>
+      {:else}
+        <!-- Single settings cog replaces the prior three icon ovals
+             (endpoints / settings / share / run-details). SettingsDrawer
+             provides the consolidated overlay sheet with Quick actions
+             section linking to endpoint management, share, and run
+             details — see synthesis design contract Section 1. -->
+        <button
+          type="button" class="icon-btn"
+          aria-label="Open settings" aria-expanded={$uiStore.showSettings} aria-controls="settings-drawer"
+          onclick={handleSettings}
+        >
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <circle cx="8" cy="8" r="2.2" stroke="currentColor" stroke-width="1.3"/>
+            <path d="M8 1.5V3M8 13V14.5M14.5 8H13M3 8H1.5M12.6 3.4L11.5 4.5M4.5 11.5L3.4 12.6M12.6 12.6L11.5 11.5M4.5 4.5L3.4 3.4" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
+          </svg>
+        </button>
+        <button
+          type="button"
+          class="run-btn"
+          class:start={isStartButton}
+          class:stop={isRunning}
+          disabled={isTransitioning}
+          aria-disabled={isTransitioning}
+          aria-label={startStopLabel}
+          onclick={handleStartStop}
+        >
+          <span class="run-btn-icon" aria-hidden="true">{isRunning ? '■' : '▶'}</span>
+          <span>{startStopText}</span>
+        </button>
+      {/if}
+    </nav>
+  </div>
+
+  <!-- ViewSwitcher renders as the second row of the same pill. Shared
+       background + no internal divider so the two rows read as one
+       floating element. The pill itself sits sticky-top via .shell-pill. -->
+  <ViewSwitcher />
 </header>
 
 <style>
-  .topbar {
+  .shell-pill {
     position: relative;
     z-index: 50;
-    height: var(--shell-topbar-height, var(--topbar-height));
-    padding: 0 18px;
     display: flex;
-    align-items: center;
-    gap: 14px;
+    flex-direction: column;
     flex-shrink: 0;
     background: var(--shell-backdrop);
     backdrop-filter: var(--shell-topbar-backdrop);
@@ -239,10 +180,18 @@
     color: var(--t1);
   }
 
-  .brand { display: flex; align-items: center; gap: 14px; min-width: 0; }
+  .pill-row {
+    min-height: var(--shell-topbar-height, 60px);
+    padding: 0 18px;
+    display: flex;
+    align-items: center;
+    gap: 14px;
+  }
+
+  .brand { display: flex; align-items: center; gap: 12px; min-width: 0; }
   .brand-mark {
-    width: 32px; height: 32px;
-    border-radius: 8px;
+    width: 36px; height: 36px;
+    border-radius: 10px;
     background: linear-gradient(135deg, var(--accent-cyan), color-mix(in srgb, var(--accent-cyan), black 40%));
     border: 0;
     display: grid; place-items: center;
@@ -251,131 +200,86 @@
     box-shadow: 0 0 24px color-mix(in srgb, var(--accent-cyan) 22%, transparent);
   }
   .brand-mark svg circle { display: none; }
-  .brand-meta { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
   .brand-name {
     font-family: var(--sans);
-    font-weight: 900;
-    font-size: 18px;
+    font-weight: 800;
+    font-size: 17px;
+    letter-spacing: var(--tr-tight);
+    color: var(--t1);
+    text-transform: none;
+  }
+
+  /* Measuring affordance — cyan pulsing dot + T+MM:SS counter. Integrated
+     into the pill row near the Stop button per synthesis design contract. */
+  .run-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 12px;
+    border-radius: 999px;
+    background: var(--shell-bg-cyan);
+    border: 1px solid var(--shell-border-strong);
+    color: var(--accent-cyan);
+    font-family: var(--mono);
+    font-size: var(--ts-xs);
+    font-weight: 700;
     letter-spacing: var(--tr-label);
     text-transform: uppercase;
-    color: var(--t1);
+    line-height: 1;
   }
-  .brand-sub {
-    display: none;
-  }
-
-  .topbar-divider {
-    display: none;
-  }
-
-  .run-status {
-    display: none;
-    align-items: center;
-    gap: 10px;
-    min-width: 0;
-  }
-  .run-dot {
-    width: 7px; height: 7px;
+  .measuring-dot {
+    width: 8px;
+    height: 8px;
     border-radius: 50%;
-    background: var(--t4);
-    transition: background 200ms ease, box-shadow 200ms ease;
-    flex-shrink: 0;
+    background: var(--accent-cyan);
+    box-shadow: 0 0 12px var(--accent-cyan);
+    animation: measuring-pulse 1.4s ease-in-out infinite;
   }
-  .run-dot.on {
-    background: var(--accent-green);
-    box-shadow: 0 0 10px var(--green-glow);
-    animation: pulse 1.8s ease-in-out infinite;
-  }
-  @keyframes pulse {
+  @keyframes measuring-pulse {
     0%, 100% { opacity: 1; }
     50% { opacity: 0.45; }
   }
-  .run-label {
-    font-family: var(--mono);
-    font-size: var(--ts-sm);
-    color: var(--t2);
-    letter-spacing: var(--tr-label);
-    text-transform: uppercase;
-  }
-  .run-tick {
-    font-family: var(--mono);
-    font-size: var(--ts-sm);
-    color: var(--t3);
+  .measuring-label { color: var(--accent-cyan); }
+  .measuring-tick {
+    margin-left: 4px;
+    padding-left: 10px;
+    border-left: 1px solid var(--shell-border-strong);
+    color: var(--t1);
     font-variant-numeric: tabular-nums;
-    margin-left: 2px;
-  }
-  .run-summary {
-    display: none;
   }
 
   .spacer { flex: 1; }
 
-  .actions { display: flex; align-items: center; gap: 10px; }
-  .run-details {
-    display: none;
-  }
-  .run-details-popover {
-    position: absolute;
-    right: 0;
-    top: calc(100% + 8px);
-    z-index: 80;
-    width: var(--shell-popover-width);
-    padding: 12px;
-    border-radius: var(--radius-md);
-    border: 1px solid var(--shell-border-strong);
-    background: var(--shell-popover);
-    box-shadow: var(--shadow-popover);
-    backdrop-filter: var(--shell-popover-backdrop);
-    -webkit-backdrop-filter: var(--shell-popover-backdrop);
-  }
-  .run-details-title {
-    margin: 0 0 9px;
-    font-family: var(--sans);
-    font-size: var(--ts-md);
-    font-weight: 600;
-    color: var(--t1);
-  }
-  .run-details-list {
-    margin: 0;
-    display: grid;
-    gap: 7px;
+  .run-summary {
     font-family: var(--mono);
     font-size: var(--ts-xs);
-    font-variant-numeric: tabular-nums;
-  }
-  .run-details-list div {
-    display: flex;
-    justify-content: space-between;
-    gap: 14px;
-  }
-  .run-details-list dt {
-    color: var(--t3);
+    color: var(--t4);
+    letter-spacing: var(--tr-label);
     text-transform: uppercase;
-    letter-spacing: var(--tr-kicker);
   }
-  .run-details-list dd {
-    margin: 0;
-    color: var(--t1);
-    text-align: right;
+
+  .actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
   }
 
   .icon-btn {
-    width: var(--shell-control-size);
-    height: var(--shell-control-size);
-    min-width: var(--shell-control-size);
-    min-height: var(--shell-control-size);
-    border-radius: var(--radius-sm);
-    background: var(--shell-panel);
+    width: 36px;
+    height: 36px;
+    border-radius: 10px;
     border: 1px solid var(--shell-border);
+    background: transparent;
     color: var(--t2);
-    display: grid; place-items: center;
     cursor: pointer;
-    transition: color 160ms ease, border-color 160ms ease, background 160ms ease;
+    display: grid;
+    place-items: center;
+    transition: background 160ms ease, color 160ms ease, border-color 160ms ease;
   }
   .icon-btn:hover {
+    background: var(--shell-panel-hover);
     color: var(--t1);
     border-color: var(--shell-border-strong);
-    background: var(--shell-panel-hover);
   }
   .icon-btn:focus-visible {
     outline: 2px solid var(--accent-cyan);
@@ -383,68 +287,62 @@
   }
 
   .run-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 36px;
+    padding: 0 16px;
+    border-radius: 999px;
+    border: 1px solid transparent;
     font-family: var(--sans);
-    font-size: 15px;
-    font-weight: 900;
-    letter-spacing: var(--tr-label);
-    text-transform: uppercase;
-    min-height: 44px;
-    padding: 0 28px;
-    border-radius: 8px;
-    background: var(--accent-cyan);
-    border: 1px solid var(--accent-cyan);
-    color: var(--shell-bg);
-    display: inline-flex; align-items: center; gap: 6px;
+    font-weight: 700;
+    font-size: var(--ts-sm);
     cursor: pointer;
-    white-space: nowrap;
-    transition: background 160ms ease, border-color 160ms ease, color 160ms ease, filter 160ms ease;
+    transition: background 160ms ease, color 160ms ease;
+    line-height: 1;
+  }
+  .run-btn.start {
+    background: var(--t1);
+    color: var(--shell-bg);
+  }
+  .run-btn.start:hover {
+    background: color-mix(in srgb, var(--t1) 92%, transparent);
   }
   .run-btn.stop {
     background: var(--shell-stop-bg);
-    border-color: var(--shell-stop-border);
     color: var(--accent-pink);
+    border-color: var(--shell-stop-border);
   }
-  .run-btn:hover:not(:disabled) { filter: brightness(1.15); }
-  .run-btn:disabled { opacity: 0.55; cursor: not-allowed; }
+  .run-btn.stop:hover {
+    background: color-mix(in srgb, var(--accent-pink) 18%, transparent);
+  }
+  .run-btn.run-own {
+    background: var(--t1);
+    color: var(--shell-bg);
+  }
+  .run-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  .run-btn-icon {
+    font-size: 11px;
+    line-height: 1;
+  }
   .run-btn:focus-visible {
     outline: 2px solid var(--accent-cyan);
     outline-offset: 2px;
   }
-  .run-btn-icon { font-size: var(--ts-xs); }
 
   @media (prefers-reduced-motion: reduce) {
-    .run-dot, .icon-btn, .run-btn { animation: none !important; transition: none !important; }
+    .measuring-dot { animation: none; }
+    .icon-btn, .run-btn { transition: none; }
   }
 
   @media (max-width: 767px) {
-    .brand-name { font-size: 14px; }
-    .topbar { gap: 8px; padding: 0 12px; }
-    .actions { gap: 6px; }
-    .icon-btn {
-      width: var(--shell-mobile-control-size);
-      height: var(--shell-mobile-control-size);
-      min-width: var(--shell-mobile-control-size);
-      min-height: var(--shell-mobile-control-size);
-      padding: 0;
-    }
-    .actions .run-btn:not(.run-own) {
-      justify-content: center;
-      min-width: 44px;
-      width: 44px;
-      min-height: var(--shell-mobile-control-size);
-      padding: 0;
-    }
-    .actions .run-btn:not(.run-own) span:not(.run-btn-icon) { display: none; }
-  }
-
-  @media (max-width: 420px) {
-    .brand { gap: 6px; }
-    .brand-mark { width: 28px; height: 28px; }
-    .run-btn { padding: 0 10px; }
-  }
-
-  @media (max-width: 374px) {
-    .brand-meta { display: none; }
-    .brand { gap: 0; }
+    .pill-row { padding: 0 12px; gap: 10px; min-height: 54px; }
+    .brand-name { font-size: 15px; }
+    .brand-mark { width: 32px; height: 32px; border-radius: 8px; }
+    .run-summary { display: none; }
+    .measuring-label { display: none; }
   }
 </style>

--- a/tests/unit/components/topbar.test.ts
+++ b/tests/unit/components/topbar.test.ts
@@ -4,7 +4,7 @@
 // lifecycle label expectations compact and explicit.
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { fireEvent, render, within } from '@testing-library/svelte';
+import { render } from '@testing-library/svelte';
 import { measurementStore } from '../../../src/lib/stores/measurements';
 import { endpointStore } from '../../../src/lib/stores/endpoints';
 import { settingsStore } from '../../../src/lib/stores/settings';
@@ -150,13 +150,17 @@ describe('Topbar', () => {
   });
 
   it('renders the shared chrome controls with accessible names', () => {
-    const { getByRole } = render(Topbar, { props: {} });
+    // Synthesis design contract Section 1 collapsed the prior trio of icon
+    // ovals (endpoints / share / run-details) into the SettingsDrawer's
+    // Quick actions section. Only the settings cog + Start/Stop button
+    // remain on the pill in the non-shared view.
+    const { getByRole, queryByRole } = render(Topbar, { props: {} });
 
-    expect(getByRole('button', { name: /run details/i })).toBeTruthy();
-    expect(getByRole('button', { name: /add or remove endpoints/i })).toBeTruthy();
     expect(getByRole('button', { name: /open settings/i })).toBeTruthy();
-    expect(getByRole('button', { name: /share results/i })).toBeTruthy();
     expect(getByRole('button', { name: /^start$/i })).toBeTruthy();
+    expect(queryByRole('button', { name: /run details/i })).toBeNull();
+    expect(queryByRole('button', { name: /add or remove endpoints/i })).toBeNull();
+    expect(queryByRole('button', { name: /share results/i })).toBeNull();
   });
 
   // statTransition / dotEntrance / dotExit removed in Phase 7 — the surviving
@@ -166,18 +170,13 @@ describe('Topbar', () => {
     expect(tokens.timing.btnHover).toBeGreaterThanOrEqual(100);
   });
 
-  it('keeps run mechanics behind a compact Run details disclosure', async () => {
-    const { getByRole, queryByText } = render(Topbar, { props: {} });
+  it('hides the measuring affordance when no run is active', () => {
+    // The Measuring pulse + T+MM:SS counter only renders during a run.
+    // While stopped/completed/idle the pill stays quiet — verifying this
+    // prevents the affordance from leaking into the brand-row layout.
+    const { queryByText, queryByLabelText } = render(Topbar, { props: {} });
 
-    expect(queryByText(/Measuring from your browser/i)).toBeNull();
-    const detailsButton = getByRole('button', { name: /run details/i });
-    expect(detailsButton).toBeTruthy();
-
-    await fireEvent.click(detailsButton);
-
-    const dialog = getByRole('dialog', { name: /run details/i });
-    expect(within(dialog).getByText('Browser test')).toBeTruthy();
-    expect(within(dialog).getByText(/0 of \d+ samples/i)).toBeTruthy();
-    expect(within(dialog).getByText(/\d+s timeout/i)).toBeTruthy();
+    expect(queryByLabelText(/^measuring$/i)).toBeNull();
+    expect(queryByText(/^T\+\d{2}:\d{2}$/)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Merges ViewSwitcher into Topbar — brand row and nav row share one sticky background so they read as a single floating pill instead of two stacked bars (closes cohesiveness gap C1)
- Collapses the endpoints / share / run-details icon trio into a single settings cog; SettingsDrawer gains a Quick actions section so neither overlay loses discoverability (closes C2)
- Adds an integrated Measuring affordance — cyan pulsing dot + \`T+MM:SS\` elapsed counter — that only renders during an active run
- Shortens Start / Stop labels to drop the "Test" suffix; lifecycle states "Starting…" / "Stopping…" preserved

## Why
First PR in Arc C, addressing the synthesis design contract's Section 1 (Shell Pill) gaps surfaced by the post-merge UX review. Restores discoverability for Endpoints and Share via the SettingsDrawer rather than dropping them.

## Test plan
- [x] \`npm run typecheck\` — clean (tsc + svelte-check + functions)
- [x] \`npm run lint\` — clean
- [x] \`npm run lint:css\` — clean
- [x] \`npm test\` — 1115 / 1115 passing (topbar.test.ts updated for new shape)
- [x] \`npm run build\` — succeeds, no regressions in bundle size
- [ ] Manual visual review of new pill at 1440px and 375px viewports
- [ ] Verify Quick actions buttons in SettingsDrawer open the correct overlays