### PR TITLE
feat(overview): specific verdict headline with inline endpoint chip

### DIFF
--- a/src/lib/components/OverviewView.svelte
+++ b/src/lib/components/OverviewView.svelte
@@ -184,6 +184,28 @@
     })
   ));
 
+  // Per synthesis design contract Section 2 / Arc C C4: when the verdict
+  // implicates a single endpoint, render its label as a tone-coloured chip
+  // inline within the headline. Splits the headline on the label so the chip
+  // can be styled while still being readable as a sentence.
+  const highlightedEndpoint = $derived(diagnosticNarrative.highlightedEndpoint);
+  const highlightedTone = $derived.by(() => {
+    if (highlightedEndpoint === undefined) return null;
+    const row = endpointRows.find((r) => r.endpoint.id === highlightedEndpoint.id);
+    return row?.tone ?? null;
+  });
+  const headlineSegments = $derived.by(() => {
+    if (highlightedEndpoint === undefined) return null;
+    const label = highlightedEndpoint.label;
+    const index = headline.indexOf(label);
+    if (index < 0) return null;
+    return {
+      before: headline.slice(0, index),
+      chip: label,
+      after: headline.slice(index + label.length),
+    };
+  });
+
   const eventRows: readonly EventLogItem[] = $derived.by(() => {
     const beats = runStoryline.beats.slice(-5);
     if (beats.length === 0) {
@@ -380,7 +402,16 @@
             <span class="measuring-pill"><span aria-hidden="true"></span>Measuring</span>
           {/if}
         </div>
-        <h1>{headline}</h1>
+        <h1>
+          {#if headlineSegments !== null}
+            {headlineSegments.before}<span
+              class="headline-endpoint-chip"
+              data-tone={highlightedTone ?? 'collecting'}
+            >{headlineSegments.chip}</span>{headlineSegments.after}
+          {:else}
+            {headline}
+          {/if}
+        </h1>
         <p><strong>Measured Fact:</strong> {measuredFact}</p>
         <p class="interpretation"><strong>Interpretation:</strong> {interpretation}</p>
         <div class="verdict-actions">
@@ -688,6 +719,46 @@
     line-height: 1.08;
     letter-spacing: var(--tr-tight);
     color: var(--t1);
+  }
+
+  /* Inline endpoint chip embedded in the verdict headline (Arc C C4 /
+     synthesis design contract Section 2). Tone mirrors the endpoint-row tone
+     vocabulary (good / warn / bad / collecting) so the chip reads the same
+     across surfaces. Sized down relative to the h1 so it doesn't overpower
+     the surrounding sentence — still tabular-numeric-aligned to the headline
+     baseline. */
+  .headline-endpoint-chip {
+    display: inline-block;
+    padding: 0 0.4em;
+    margin: 0 0.05em;
+    border-radius: 0.32em;
+    font-weight: 800;
+    line-height: 1.15;
+    vertical-align: baseline;
+    color: var(--t1);
+    background: color-mix(in srgb, var(--accent-cyan) 14%, transparent);
+    border: 1px solid color-mix(in srgb, var(--accent-cyan) 28%, transparent);
+  }
+  .headline-endpoint-chip[data-tone='good'] {
+    color: var(--accent-green);
+    background: color-mix(in srgb, var(--accent-green) 12%, transparent);
+    border-color: color-mix(in srgb, var(--accent-green) 28%, transparent);
+  }
+  .headline-endpoint-chip[data-tone='warn'],
+  .headline-endpoint-chip[data-tone='watch'] {
+    color: var(--accent-amber);
+    background: color-mix(in srgb, var(--accent-amber) 14%, transparent);
+    border-color: color-mix(in srgb, var(--accent-amber) 32%, transparent);
+  }
+  .headline-endpoint-chip[data-tone='bad'] {
+    color: var(--accent-pink);
+    background: color-mix(in srgb, var(--accent-pink) 14%, transparent);
+    border-color: color-mix(in srgb, var(--accent-pink) 32%, transparent);
+  }
+  .headline-endpoint-chip[data-tone='collecting'] {
+    color: var(--accent-cyan);
+    background: color-mix(in srgb, var(--accent-cyan) 12%, transparent);
+    border-color: color-mix(in srgb, var(--accent-cyan) 28%, transparent);
   }
 
   p {

--- a/src/lib/utils/diagnostic-narrative.ts
+++ b/src/lib/utils/diagnostic-narrative.ts
@@ -126,6 +126,11 @@ export interface DiagnosticNarrative {
   readonly triageActions: readonly DiagnosticTriageAction[];
   readonly nextSteps: readonly string[];
   readonly timingVisibility: TimingVisibility;
+  // Surface-side helper: when the verdict implicates a single endpoint, this
+  // exposes its id + label so the view can render the headline with the
+  // endpoint name highlighted inline (the view derives tone from its own
+  // endpoint-tone lookup). Undefined when no single endpoint is implicated.
+  readonly highlightedEndpoint?: { readonly id: string; readonly label: string };
 }
 
 interface DiagnosticInput {
@@ -314,6 +319,39 @@ function confidenceReason(
   return `Based on ${minSamples}+ successful checks across ${rows.length} ${plural(rows.length, 'site')}.`;
 }
 
+// Returns the endpoint clearly implicated by the diagnosis when one stands
+// out — and nothing otherwise. For latency-dominated kinds the verdict
+// already exposes this via worstEpId; for loss/jitter the verdict does not,
+// so we look at per-row stats. "Clearly implicated" means the worst row's
+// signal exceeds the warn threshold and is at least 2× any other row's
+// signal — otherwise the verdict treats the problem as broad, not isolated.
+function implicatedEndpointRow(
+  kind: DiagnosticKind,
+  rows: readonly VerdictRow[],
+  verdict: Verdict,
+): VerdictRow | undefined {
+  if (verdict.worstEpId !== undefined) {
+    const row = rows.find((candidate) => candidate.ep.id === verdict.worstEpId);
+    if (row !== undefined) return row;
+  }
+  const dominant = (extract: (row: VerdictRow) => number, warnAt: number): VerdictRow | undefined => {
+    if (rows.length < 2) return rows[0];
+    const sorted = [...rows].sort((a, b) => extract(b) - extract(a));
+    const [top, runnerUp] = sorted;
+    if (extract(top) < warnAt) return undefined;
+    if (extract(runnerUp) === 0) return top;
+    return extract(top) >= extract(runnerUp) * 2 ? top : undefined;
+  };
+  switch (kind) {
+    case 'packet-loss':
+      return dominant((row) => row.stats.lossPercent, LOSS_WARN_PERCENT);
+    case 'jitter':
+      return dominant((row) => row.stats.stddev, JITTER_WARN_MS);
+    default:
+      return undefined;
+  }
+}
+
 function explanationFor(
   kind: DiagnosticKind,
   rows: readonly VerdictRow[],
@@ -337,10 +375,19 @@ function explanationFor(
     }
     case 'shared-network':
       return 'Several sites are slow in the same test window.';
-    case 'packet-loss':
-      return 'Some requests are failing.';
-    case 'jitter':
-      return 'Latency is jumping around.';
+    case 'packet-loss': {
+      // Name the failing endpoint when one clearly dominates the loss
+      // signal — keeps the headline specific per the synthesis design
+      // contract Section 2 state table ("<endpoint> failed from your
+      // browser."). Falls back to the generic phrasing when failures are
+      // spread across endpoints.
+      const worst = implicatedEndpointRow(kind, rows, verdict);
+      return worst ? `${worst.ep.label} is failing from your browser.` : 'Some requests are failing.';
+    }
+    case 'jitter': {
+      const worst = implicatedEndpointRow(kind, rows, verdict);
+      return worst ? `${worst.ep.label}'s latency is jumping around.` : 'Latency is jumping around.';
+    }
     case 'multiple-slow':
       return 'Several sites are slower than your threshold.';
   }
@@ -1155,6 +1202,11 @@ export function buildDiagnosticNarrative(input: DiagnosticInput): DiagnosticNarr
     primaryAnswer,
   });
 
+  const implicatedRow = implicatedEndpointRow(kind, input.rows, verdict);
+  const highlightedEndpoint = implicatedRow !== undefined
+    ? { id: implicatedRow.ep.id, label: implicatedRow.ep.label }
+    : undefined;
+
   return {
     verdict,
     kind,
@@ -1182,5 +1234,6 @@ export function buildDiagnosticNarrative(input: DiagnosticInput): DiagnosticNarr
     triageActions,
     nextSteps: nextStepsFor(kind, verdict, input.rows),
     timingVisibility,
+    ...(highlightedEndpoint !== undefined ? { highlightedEndpoint } : {}),
   };
 }

--- a/tests/unit/utils/diagnostic-narrative.test.ts
+++ b/tests/unit/utils/diagnostic-narrative.test.ts
@@ -445,6 +445,88 @@ describe('buildDiagnosticNarrative', () => {
     ).not.toMatch(/elevated|browser-visible|root-cause|likely/i);
   });
 
+  it('names the implicated endpoint in packet-loss and jitter headlines when one dominates', () => {
+    // When a single endpoint clearly dominates the failure or jitter signal,
+    // computeCausalVerdict sets worstEpId and the headline names that
+    // endpoint per the synthesis design contract Section 2 ("specific verdict
+    // headline" + inline highlighting). This is the spec-table failure copy
+    // rendered as a real measured fact.
+    const packetLoss = buildDiagnosticNarrative({
+      rows: [
+        row('api', { lossPercent: 8, sampleCount: 18 }, 'API'),
+        row('google', { lossPercent: 0, sampleCount: 18 }, 'Google'),
+        row('cloudflare', { lossPercent: 0, sampleCount: 18 }, 'Cloudflare'),
+      ],
+      threshold: 120,
+      corsMode: 'no-cors',
+      samplesByEndpoint: {
+        api: samples(18, 60),
+        google: samples(18, 45),
+        cloudflare: samples(18, 38),
+      },
+      monitoredEndpointCount: 3,
+    });
+    expect(packetLoss.kind).toBe('packet-loss');
+    expect(packetLoss.primaryAnswer.text).toBe('API is failing from your browser.');
+    expect(packetLoss.highlightedEndpoint).toEqual({ id: 'api', label: 'API' });
+
+    const jitter = buildDiagnosticNarrative({
+      rows: [
+        row('api', { stddev: 80, sampleCount: 18 }, 'API'),
+        row('google', { stddev: 6, sampleCount: 18 }, 'Google'),
+        row('cloudflare', { stddev: 5, sampleCount: 18 }, 'Cloudflare'),
+      ],
+      threshold: 120,
+      corsMode: 'no-cors',
+      samplesByEndpoint: {
+        api: samples(18, 70),
+        google: samples(18, 50),
+        cloudflare: samples(18, 45),
+      },
+      monitoredEndpointCount: 3,
+    });
+    expect(jitter.kind).toBe('jitter');
+    expect(jitter.primaryAnswer.text).toBe("API's latency is jumping around.");
+    expect(jitter.highlightedEndpoint).toEqual({ id: 'api', label: 'API' });
+  });
+
+  it('exposes highlightedEndpoint for isolated-endpoint and omits it when no single endpoint is implicated', () => {
+    const isolated = buildDiagnosticNarrative({
+      rows: [
+        row('api', { p50: 240, sampleCount: 18 }, 'API'),
+        row('google', { p50: 45, sampleCount: 18 }, 'Google'),
+        row('cloudflare', { p50: 38, sampleCount: 18 }, 'Cloudflare'),
+      ],
+      threshold: 120,
+      corsMode: 'no-cors',
+      samplesByEndpoint: {
+        api: samples(18, 240),
+        google: samples(18, 45),
+        cloudflare: samples(18, 38),
+      },
+      monitoredEndpointCount: 3,
+    });
+    expect(isolated.kind).toBe('isolated-endpoint');
+    expect(isolated.highlightedEndpoint).toEqual({ id: 'api', label: 'API' });
+    expect(isolated.primaryAnswer.text).toContain('API');
+
+    const healthy = buildDiagnosticNarrative({
+      rows: [
+        row('google', { p50: 45, sampleCount: 30 }),
+        row('cloudflare', { p50: 38, sampleCount: 30 }),
+      ],
+      threshold: 120,
+      corsMode: 'no-cors',
+      samplesByEndpoint: {
+        google: samples(30, 45),
+        cloudflare: samples(30, 38),
+      },
+      monitoredEndpointCount: 2,
+    });
+    expect(healthy.kind).toBe('healthy');
+    expect(healthy.highlightedEndpoint).toBeUndefined();
+  });
+
   it('keeps the trust matrix concise and evidence-scoped across common scenarios', () => {
     const scenarios = [
       buildDiagnosticNarrative({


### PR DESCRIPTION
## Summary
- Verdict-card headline now names the implicated endpoint for packet-loss and jitter when one clearly dominates (≥ warn threshold AND ≥ 2× the runner-up) — matches the synthesis design contract Section 2 state table (closes C3)
- The implicated endpoint label renders as a tone-coloured inline chip inside the headline, sharing the endpoint-row tone vocabulary (good / warn / bad / collecting) so the chip reads the same across surfaces (closes C4)
- DiagnosticNarrative gains a \`highlightedEndpoint\` field driven by a new \`implicatedEndpointRow\` helper shared between headline copy and the chip — so the chip's label always matches the substring it replaces, even if the headline copy changes later
- Two new unit tests cover the specific copy and the \`highlightedEndpoint\` field for both packet-loss and isolated-endpoint kinds

## Why
Second PR in Arc C, addressing cohesiveness gaps C3 (generic headline) and C4 (no inline endpoint highlighting) surfaced by the post-merge UX review. Keeps the original copy intact for genuinely broad failures so we don't fabricate a culprit when none stands out.

## Test plan
- [x] \`npm run typecheck\` — clean (tsc + svelte-check + functions)
- [x] \`npm run lint\` — clean
- [x] \`npm run lint:css\` — clean
- [x] \`npm test\` — 1117 / 1117 passing (+2 new narrative tests)
- [x] \`npm run build\` — succeeds
- [ ] Visual check at 1440px and 375px viewports — chip should fit in the headline at both