### PR TITLE
feat(topology): rounded-square nodes, side-anchor labels, +N overflow chip

### DIFF
--- a/src/lib/components/NetworkTopology.svelte
+++ b/src/lib/components/NetworkTopology.svelte
@@ -4,6 +4,11 @@
 <!-- on the left, one endpoint node per monitored endpoint on the right,        -->
 <!-- connecting path lines, animated pulse packets driven by REAL measurement   -->
 <!-- round events (not setInterval(Math.random) like the v2 prototype).         -->
+<!--                                                                            -->
+<!-- Glyphs are rounded squares (not circles) per the Arc C cohesiveness pass.  -->
+<!-- Labels switch to a right-side anchor when ≥5 endpoints share the column    -->
+<!-- so they can't collide with adjacent nodes. >8 endpoints collapse the last  -->
+<!-- slot to a "+N more" chip so the visual cap stays at 8 glyphs.              -->
 <script lang="ts">
   import { measurementStore } from '$lib/stores/measurements';
   import { monitoredEndpointsStore } from '$lib/stores/derived';
@@ -12,14 +17,20 @@
   import { uiStore } from '$lib/stores/ui';
   import { navigateTo } from '$lib/router';
   import { deriveEndpointTone, type EndpointTone } from '$lib/utils/endpoint-tone';
+  import {
+    layoutTopologyNodes,
+    TOPOLOGY_VISIBLE_LIMIT,
+  } from '$lib/utils/network-topology-layout';
 
   // Layout grid (SVG viewBox is unitless — these are abstract design units).
   const VIEWBOX_WIDTH = 320;
   const VIEWBOX_HEIGHT = 260;
   const ORIGIN_X = 50;
   const ORIGIN_Y = VIEWBOX_HEIGHT / 2;
-  const ENDPOINT_X = 250;
-  const NODE_RADIUS = 14;
+  const ENDPOINT_X = 240;
+  const NODE_HALF = 14;
+  const NODE_SIZE = NODE_HALF * 2;
+  const NODE_RADIUS = NODE_HALF; // legacy alias retained for the origin glyph
 
   const monitored = $derived($monitoredEndpointsStore);
   const stats = $derived($statisticsStore);
@@ -48,44 +59,68 @@
     }
   });
 
-  interface Node {
+  interface EndpointNode {
     readonly endpoint: { id: string; label: string };
     readonly tone: EndpointTone;
     readonly x: number;
     readonly y: number;
   }
 
-  // Endpoint layout — simple vertical column at ENDPOINT_X, evenly spaced.
-  // Works without label collision for 1-8 endpoints (the common case). For
-  // >8 endpoints, a compact-grid + "+N more" treatment is deferred to a
-  // follow-up; current behavior caps at 8 visible nodes.
-  const MAX_VISIBLE_NODES = 8;
-  const nodes: readonly Node[] = $derived.by(() => {
-    const visible = monitored.slice(0, MAX_VISIBLE_NODES);
-    const n = visible.length;
-    if (n === 0) return [];
-    const usableHeight = VIEWBOX_HEIGHT - 60;
-    const step = n === 1 ? 0 : usableHeight / (n - 1);
-    const topY = n === 1 ? VIEWBOX_HEIGHT / 2 : 30;
-    return visible.map((ep, i) => ({
-      endpoint: { id: ep.id, label: ep.label },
-      tone: deriveEndpointTone({
-        stats: stats[ep.id] ?? null,
-        lastStatus: measurements.endpoints[ep.id]?.lastStatus ?? null,
-        healthThreshold: threshold,
-      }),
-      x: ENDPOINT_X,
-      y: topY + step * i,
-    }));
+  const layout = $derived(layoutTopologyNodes({
+    endpointCount: monitored.length,
+    viewboxHeight: VIEWBOX_HEIGHT,
+    endpointX: ENDPOINT_X,
+  }));
+
+  // Visible endpoint slice: when overflow kicks in we keep the first 7
+  // endpoints and use the last slot for the "+N more" chip.
+  const visibleEndpoints = $derived.by(() => {
+    const cap = layout.hasOverflowSlot
+      ? TOPOLOGY_VISIBLE_LIMIT - 1
+      : monitored.length;
+    return monitored.slice(0, cap);
   });
 
-  const overflowCount = $derived(Math.max(0, monitored.length - MAX_VISIBLE_NODES));
+  const endpointNodes: readonly EndpointNode[] = $derived.by(() => (
+    visibleEndpoints.map((ep, i) => {
+      const slot = layout.slots[i];
+      return {
+        endpoint: { id: ep.id, label: ep.label },
+        tone: deriveEndpointTone({
+          stats: stats[ep.id] ?? null,
+          lastStatus: measurements.endpoints[ep.id]?.lastStatus ?? null,
+          healthThreshold: threshold,
+        }),
+        x: slot.x,
+        y: slot.y,
+      };
+    })
+  ));
+
+  const overflowSlot = $derived(
+    layout.hasOverflowSlot ? layout.slots[layout.slots.length - 1] : null,
+  );
+
+  const labelAnchorMode = $derived(layout.labelAnchor);
+
+  // Label-position helper. "below": centered under the node. "right":
+  // anchored to the right of the node (start-anchored, vertically centered).
+  function labelPosition(node: { x: number; y: number }): { x: number; y: number; anchor: 'middle' | 'start' } {
+    if (labelAnchorMode === 'below') {
+      return { x: node.x, y: node.y + NODE_HALF + 16, anchor: 'middle' };
+    }
+    return { x: node.x + NODE_HALF + 6, y: node.y + 4, anchor: 'start' };
+  }
 
   function handleEndpointClick(endpointId: string): void {
     navigateTo({ name: 'endpoint', endpointId });
   }
 
   function handleAddEndpoint(): void {
+    uiStore.toggleEndpoints();
+  }
+
+  function handleOverflowClick(): void {
     uiStore.toggleEndpoints();
   }
 </script>
@@ -106,8 +141,8 @@
       role="img"
       aria-hidden="true"
     >
-      <!-- Connecting path lines (origin → each endpoint) -->
-      {#each nodes as node (node.endpoint.id)}
+      <!-- Connecting path lines (origin → each endpoint, plus overflow slot) -->
+      {#each endpointNodes as node (node.endpoint.id)}
         <line
           class="topology-path"
           x1={ORIGIN_X}
@@ -117,6 +152,16 @@
           stroke-width="1"
         />
       {/each}
+      {#if overflowSlot !== null}
+        <line
+          class="topology-path topology-path-overflow"
+          x1={ORIGIN_X}
+          y1={ORIGIN_Y}
+          x2={overflowSlot.x}
+          y2={overflowSlot.y}
+          stroke-width="1"
+        />
+      {/if}
 
       <!-- Pulse packets — re-rendered when pulseKeys[ep.id] increments.
            cx/cy are set to the ORIGIN position; the animation translates the
@@ -124,7 +169,7 @@
            unlike CSS animation of SVG `cx`/`cy` attributes which silently
            strands the element). The translate distance is the delta from
            origin to endpoint, passed via --pulse-dx/--pulse-dy. -->
-      {#each nodes as node (node.endpoint.id)}
+      {#each endpointNodes as node (node.endpoint.id)}
         {#if pulseKeys[node.endpoint.id]}
           {#key pulseKeys[node.endpoint.id]}
             <circle
@@ -140,16 +185,22 @@
         {/if}
       {/each}
 
-      <!-- Origin (browser) node -->
+      <!-- Origin (browser) node — kept circular to read as "you" / device. -->
       <g class="topology-node-group" data-role="origin">
-        <circle class="topology-node" cx={ORIGIN_X} cy={ORIGIN_Y} r={NODE_RADIUS} />
-        <text class="topology-label" x={ORIGIN_X} y={ORIGIN_Y + NODE_RADIUS + 16} text-anchor="middle">
+        <circle class="topology-node-circle" cx={ORIGIN_X} cy={ORIGIN_Y} r={NODE_RADIUS} />
+        <text
+          class="topology-label"
+          x={ORIGIN_X}
+          y={ORIGIN_Y + NODE_HALF + 16}
+          text-anchor="middle"
+        >
           BROWSER
         </text>
       </g>
 
-      <!-- Endpoint nodes -->
-      {#each nodes as node (node.endpoint.id)}
+      <!-- Endpoint nodes — rounded squares per Arc C cohesiveness pass. -->
+      {#each endpointNodes as node (node.endpoint.id)}
+        {@const lp = labelPosition(node)}
         <g
           class="topology-node-group topology-node-clickable"
           data-tone={node.tone}
@@ -165,29 +216,71 @@
             }
           }}
         >
-          <circle
-            class="topology-node"
-            cx={node.x}
-            cy={node.y}
-            r={NODE_RADIUS}
+          <rect
+            class="topology-node-rect"
+            x={node.x - NODE_HALF}
+            y={node.y - NODE_HALF}
+            width={NODE_SIZE}
+            height={NODE_SIZE}
+            rx="6"
+            ry="6"
           />
           <text
             class="topology-label"
-            x={node.x}
-            y={node.y + NODE_RADIUS + 16}
-            text-anchor="middle"
+            x={lp.x}
+            y={lp.y}
+            text-anchor={lp.anchor}
           >
             {node.endpoint.label.slice(0, 16)}
           </text>
         </g>
       {/each}
-    </svg>
 
-    {#if overflowCount > 0}
-      <p class="topology-overflow" role="note">
-        +{overflowCount} more endpoint{overflowCount === 1 ? '' : 's'} not shown
-      </p>
-    {/if}
+      <!-- Overflow chip (+N more) — claims the last slot when the monitored
+           list exceeds the 8-glyph visual cap. Opens the endpoints overlay
+           on click so all endpoints stay reachable. -->
+      {#if overflowSlot !== null}
+        {@const overflowLabel = labelPosition(overflowSlot)}
+        <g
+          class="topology-node-group topology-overflow-chip"
+          data-role="overflow"
+          role="button"
+          tabindex="0"
+          aria-label="Show all {monitored.length} endpoints"
+          onclick={handleOverflowClick}
+          onkeydown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              handleOverflowClick();
+            }
+          }}
+        >
+          <rect
+            class="topology-node-rect topology-overflow-rect"
+            x={overflowSlot.x - NODE_HALF}
+            y={overflowSlot.y - NODE_HALF}
+            width={NODE_SIZE}
+            height={NODE_SIZE}
+            rx="6"
+            ry="6"
+          />
+          <text
+            class="topology-overflow-count"
+            x={overflowSlot.x}
+            y={overflowSlot.y + 4}
+            text-anchor="middle"
+          >+{layout.overflowCount}</text>
+          <text
+            class="topology-label"
+            x={overflowLabel.x}
+            y={overflowLabel.y}
+            text-anchor={overflowLabel.anchor}
+          >
+            MORE
+          </text>
+        </g>
+      {/if}
+    </svg>
   </div>
 {/if}
 
@@ -220,48 +313,69 @@
     fill: none;
     stroke-width: 1.2;
   }
+  .topology-path-overflow {
+    stroke-dasharray: 3 4;
+    opacity: 0.7;
+  }
 
-  /* Nodes — filled (slightly darker than the panel background so the
-     coloured stroke pops), thicker stroke, and a tone-coloured drop
-     shadow / glow halo so each endpoint has presence rather than reading
-     as a wireframe placeholder. */
-  .topology-node {
+  /* Endpoint glyphs — rounded squares per Arc C synthesis. Coloured stroke
+     pops against the slightly darker fill; tone-coloured drop-shadow / glow
+     gives each endpoint presence rather than reading as a wireframe. */
+  .topology-node-rect,
+  .topology-node-circle {
     fill: var(--shell-base);
     stroke-width: 2.5;
     transition: stroke 200ms ease, fill 200ms ease;
   }
-  [data-role='origin'] .topology-node {
+  [data-role='origin'] .topology-node-circle {
     stroke: var(--t2);
   }
-  [data-tone='good'] .topology-node {
+  [data-tone='good'] .topology-node-rect {
     stroke: var(--accent-green);
     filter: drop-shadow(0 0 6px var(--accent-green));
   }
-  [data-tone='watch'] .topology-node {
+  [data-tone='watch'] .topology-node-rect {
     stroke: var(--accent-amber);
     filter: drop-shadow(0 0 6px var(--accent-amber));
   }
-  [data-tone='bad'] .topology-node {
+  [data-tone='bad'] .topology-node-rect {
     stroke: var(--accent-pink);
     filter: drop-shadow(0 0 8px var(--accent-pink));
   }
-  [data-tone='collecting'] .topology-node {
+  [data-tone='collecting'] .topology-node-rect {
     stroke: var(--accent-cyan);
     filter: drop-shadow(0 0 6px var(--accent-cyan));
   }
 
-  .topology-node-clickable {
+  .topology-node-clickable,
+  .topology-overflow-chip {
     cursor: pointer;
   }
-  .topology-node-clickable:hover .topology-node,
-  .topology-node-clickable:focus-visible .topology-node {
+  .topology-node-clickable:hover .topology-node-rect,
+  .topology-node-clickable:focus-visible .topology-node-rect,
+  .topology-overflow-chip:hover .topology-node-rect,
+  .topology-overflow-chip:focus-visible .topology-node-rect {
     fill: var(--shell-panel-hover);
   }
-  .topology-node-clickable:focus-visible {
+  .topology-node-clickable:focus-visible,
+  .topology-overflow-chip:focus-visible {
     outline: none;
   }
-  .topology-node-clickable:focus-visible .topology-node {
+  .topology-node-clickable:focus-visible .topology-node-rect,
+  .topology-overflow-chip:focus-visible .topology-node-rect {
     stroke-width: 3.5;
+  }
+
+  .topology-overflow-rect {
+    stroke: var(--shell-border-strong);
+    fill: var(--shell-panel-hover);
+  }
+  .topology-overflow-count {
+    fill: var(--t1);
+    font-family: var(--mono);
+    font-size: 11px;
+    font-weight: 800;
+    pointer-events: none;
   }
 
   /* Labels — bumped contrast (was --t3 = .5 alpha, barely readable;
@@ -340,18 +454,9 @@
   }
   .empty-cta:hover { background: var(--shell-panel-hover); }
 
-  .topology-overflow {
-    margin: 8px 0 0;
-    color: var(--t4);
-    font-family: var(--mono);
-    font-size: 10px;
-    text-align: center;
-    letter-spacing: var(--tr-label);
-    text-transform: uppercase;
-  }
-
   @media (prefers-reduced-motion: reduce) {
     .topology-pulse { animation: none; opacity: 0; }
-    .topology-node { transition: none; }
+    .topology-node-rect,
+    .topology-node-circle { transition: none; }
   }
 </style>

--- a/src/lib/utils/network-topology-layout.ts
+++ b/src/lib/utils/network-topology-layout.ts
@@ -1,0 +1,82 @@
+// src/lib/utils/network-topology-layout.ts
+// Pure layout math for the NetworkTopology component. Extracted so the
+// collision-avoidance and overflow-collapse rules can be exercised by unit
+// tests without rendering an SVG.
+//
+// Layout rules (synthesis design contract Section 2):
+//
+// - Up to TOPOLOGY_VISIBLE_LIMIT (8) endpoint slots are visible at once.
+// - When the monitored-endpoint count exceeds the limit, the last slot is
+//   replaced with a "+N more" chip so the topology never renders more than
+//   8 visible glyphs (the spec's "mobile chip cap of 8" rule).
+// - Labels render below nodes when there's enough vertical room. Above a
+//   density threshold the labels switch to a side anchor (right of the node)
+//   to avoid colliding with the next node's glyph.
+
+export const TOPOLOGY_VISIBLE_LIMIT = 8;
+
+// At >= this many endpoints, labels can't fit below nodes without
+// colliding with the next node's glyph — switch to right-anchored labels.
+const SIDE_LABEL_THRESHOLD = 5;
+
+export type TopologyLabelAnchor = 'below' | 'right';
+
+export interface TopologyLayoutInput {
+  readonly endpointCount: number;
+  readonly viewboxHeight: number;
+  readonly endpointX: number;
+  readonly verticalPadding?: number;
+}
+
+export interface TopologySlot {
+  readonly index: number;
+  readonly x: number;
+  readonly y: number;
+}
+
+export interface TopologyLayout {
+  readonly slots: readonly TopologySlot[];
+  readonly overflowCount: number;
+  readonly hasOverflowSlot: boolean;
+  readonly labelAnchor: TopologyLabelAnchor;
+}
+
+export function layoutTopologyNodes(input: TopologyLayoutInput): TopologyLayout {
+  const { endpointCount, viewboxHeight, endpointX } = input;
+  const verticalPadding = input.verticalPadding ?? 30;
+
+  if (endpointCount <= 0) {
+    return {
+      slots: [],
+      overflowCount: 0,
+      hasOverflowSlot: false,
+      labelAnchor: 'below',
+    };
+  }
+
+  const overflows = endpointCount > TOPOLOGY_VISIBLE_LIMIT;
+  const endpointSlots = overflows ? TOPOLOGY_VISIBLE_LIMIT - 1 : endpointCount;
+  const totalSlots = overflows ? TOPOLOGY_VISIBLE_LIMIT : endpointCount;
+  const overflowCount = overflows ? endpointCount - endpointSlots : 0;
+
+  const usableHeight = Math.max(0, viewboxHeight - verticalPadding * 2);
+  const slots: TopologySlot[] = [];
+
+  for (let i = 0; i < totalSlots; i += 1) {
+    let y: number;
+    if (totalSlots === 1) {
+      y = viewboxHeight / 2;
+    } else {
+      const step = usableHeight / (totalSlots - 1);
+      y = verticalPadding + step * i;
+    }
+    slots.push({ index: i, x: endpointX, y });
+  }
+
+  return {
+    slots,
+    overflowCount,
+    hasOverflowSlot: overflows,
+    labelAnchor: totalSlots >= SIDE_LABEL_THRESHOLD ? 'right' : 'below',
+  };
+}

--- a/tests/unit/utils/network-topology-layout.test.ts
+++ b/tests/unit/utils/network-topology-layout.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import {
+  layoutTopologyNodes,
+  TOPOLOGY_VISIBLE_LIMIT,
+} from '../../../src/lib/utils/network-topology-layout';
+
+const VIEWBOX_HEIGHT = 260;
+const ENDPOINT_X = 240;
+
+describe('layoutTopologyNodes', () => {
+  it('returns no slots for zero endpoints', () => {
+    const result = layoutTopologyNodes({
+      endpointCount: 0,
+      viewboxHeight: VIEWBOX_HEIGHT,
+      endpointX: ENDPOINT_X,
+    });
+    expect(result.slots).toEqual([]);
+    expect(result.overflowCount).toBe(0);
+    expect(result.hasOverflowSlot).toBe(false);
+  });
+
+  it('centers a single endpoint vertically', () => {
+    const result = layoutTopologyNodes({
+      endpointCount: 1,
+      viewboxHeight: VIEWBOX_HEIGHT,
+      endpointX: ENDPOINT_X,
+    });
+    expect(result.slots).toHaveLength(1);
+    expect(result.slots[0]).toEqual({ index: 0, x: ENDPOINT_X, y: VIEWBOX_HEIGHT / 2 });
+    expect(result.labelAnchor).toBe('below');
+  });
+
+  it('uses below-anchor labels for 2-4 endpoints (no crowding)', () => {
+    for (const n of [2, 3, 4]) {
+      const result = layoutTopologyNodes({
+        endpointCount: n,
+        viewboxHeight: VIEWBOX_HEIGHT,
+        endpointX: ENDPOINT_X,
+      });
+      expect(result.labelAnchor, `n=${n}`).toBe('below');
+      expect(result.slots, `n=${n}`).toHaveLength(n);
+    }
+  });
+
+  it('switches to right-anchor labels when endpoints crowd the column', () => {
+    // The vertical spacing at n=5 is tight enough that a below-anchor label
+    // for one node would collide with the next node's glyph. The layout
+    // helper must switch to a right-anchor at that density to honour the
+    // spec's "labels never overlap nodes" rule.
+    for (const n of [5, 6, 7, 8]) {
+      const result = layoutTopologyNodes({
+        endpointCount: n,
+        viewboxHeight: VIEWBOX_HEIGHT,
+        endpointX: ENDPOINT_X,
+      });
+      expect(result.labelAnchor, `n=${n}`).toBe('right');
+    }
+  });
+
+  it('distributes slots evenly between the vertical padding bounds', () => {
+    const result = layoutTopologyNodes({
+      endpointCount: 4,
+      viewboxHeight: VIEWBOX_HEIGHT,
+      endpointX: ENDPOINT_X,
+    });
+    expect(result.slots[0].y).toBe(30);
+    expect(result.slots[result.slots.length - 1].y).toBe(VIEWBOX_HEIGHT - 30);
+    // Each step should be equal.
+    const gaps = result.slots
+      .slice(1)
+      .map((slot, i) => slot.y - result.slots[i].y);
+    const first = gaps[0];
+    for (const gap of gaps) {
+      expect(Math.abs(gap - first)).toBeLessThan(0.001);
+    }
+  });
+
+  it('caps the visible glyphs at the visible limit', () => {
+    const result = layoutTopologyNodes({
+      endpointCount: TOPOLOGY_VISIBLE_LIMIT,
+      viewboxHeight: VIEWBOX_HEIGHT,
+      endpointX: ENDPOINT_X,
+    });
+    expect(result.slots).toHaveLength(TOPOLOGY_VISIBLE_LIMIT);
+    expect(result.hasOverflowSlot).toBe(false);
+    expect(result.overflowCount).toBe(0);
+  });
+
+  it('reserves the last slot for the +N more chip when endpoints exceed the visible limit', () => {
+    // 12 endpoints: 7 endpoint slots + 1 overflow chip slot, overflowCount=5.
+    // Total visible glyphs still equals the visible limit so the mobile cap
+    // of 8 is preserved.
+    const result = layoutTopologyNodes({
+      endpointCount: 12,
+      viewboxHeight: VIEWBOX_HEIGHT,
+      endpointX: ENDPOINT_X,
+    });
+    expect(result.slots).toHaveLength(TOPOLOGY_VISIBLE_LIMIT);
+    expect(result.hasOverflowSlot).toBe(true);
+    expect(result.overflowCount).toBe(12 - (TOPOLOGY_VISIBLE_LIMIT - 1));
+  });
+
+  it('reports zero overflow when endpointCount equals exactly the visible limit', () => {
+    const result = layoutTopologyNodes({
+      endpointCount: TOPOLOGY_VISIBLE_LIMIT,
+      viewboxHeight: VIEWBOX_HEIGHT,
+      endpointX: ENDPOINT_X,
+    });
+    expect(result.hasOverflowSlot).toBe(false);
+    expect(result.overflowCount).toBe(0);
+  });
+
+  it('keeps slot x equal to endpointX for every slot', () => {
+    const result = layoutTopologyNodes({
+      endpointCount: 6,
+      viewboxHeight: VIEWBOX_HEIGHT,
+      endpointX: ENDPOINT_X,
+    });
+    for (const slot of result.slots) {
+      expect(slot.x).toBe(ENDPOINT_X);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Endpoint glyphs now render as rounded squares per the Arc C cohesiveness pass; origin "browser" node stays circular to read as device vs endpoint
- Layout math extracted to a pure helper (\`layoutTopologyNodes\`) covering collision avoidance, overflow collapse, and slot positioning
- Labels switch from below-anchor to right-anchor at ≥ 5 endpoints so they don't collide with adjacent nodes (synthesis design contract Section 2: "labels never overlap nodes")
- Monitored.length > 8 collapses the last slot to a "+N more" chip that opens the endpoints overlay on click — preserves the 8-glyph visual cap
- Nine new unit tests cover empty state, single-endpoint centering, anchor-mode thresholds, even spacing, the visible cap, and overflow accounting

## Why
Third PR in Arc C, closing cohesiveness gaps B4 (uniform geometry across topology + cards), B5 (>8 endpoint behaviour), and B8 (testable layout). The pure helper makes the spec's layout rules a property of math rather than a property of the rendered SVG.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm run lint:css\` — clean
- [x] \`npm test\` — 1126 / 1126 passing (+9 layout tests)
- [x] \`npm run build\` — succeeds
- [ ] Visual check with 3, 5, 8, and 12 endpoints across 1440px and 375px viewports