### PR TITLE
feat(diagnose): five-template distribution interpretation on EndpointDetail

### DIFF
--- a/src/lib/components/DiagnoseView.svelte
+++ b/src/lib/components/DiagnoseView.svelte
@@ -22,6 +22,7 @@
   import { describeTimingVisibility, type DiagnosticConfidence } from '$lib/utils/diagnostic-narrative';
   import { phaseHypothesis, PHASE_LABELS, type PhaseBreakdown, type Tier2Phase } from '$lib/utils/verdict';
   import { buildDistributionEmptyMessage, buildHistogram, buildCorrelation } from '$lib/utils/diagnose-stats';
+  import { interpretDistribution } from '$lib/utils/distribution-interpretation';
   import { fmt, compactUrlLabel, axisEdgeLabel, binLabel } from '$lib/utils/format';
   import { selectInvestigationEndpointId } from '$lib/utils/status-intent';
   import { tokens } from '$lib/tokens';
@@ -238,6 +239,17 @@
     return m.samples.toArray().slice(-50);
   });
   const histogram = $derived(buildHistogram(focusedAllSamples));
+  // Per Arc C C5 / synthesis design contract: the distribution panel now
+  // surfaces a five-template plain-English interpretation alongside the
+  // histogram. Helper lives in `distribution-interpretation.ts` and is
+  // fully covered by `distribution-interpretation.test.ts`.
+  const distributionInterpretation = $derived(interpretDistribution({
+    endpointLabel: focusedEndpoint?.label ?? 'This endpoint',
+    samples: focusedAllSamples,
+  }));
+  // Kept as a fallback for the rare 2-7 OK sample case where the histogram
+  // collapses to an empty bin set; the interpretation supersedes the prior
+  // empty-state copy for ≥ 8 OK samples.
   const distributionEmptyMessage = $derived(buildDistributionEmptyMessage(
     focusedAllSamples,
     settings.healthThreshold,
@@ -681,6 +693,19 @@
           {:else}
             <p class="distro-empty">{distributionEmptyMessage}</p>
           {/if}
+
+          <!-- Distribution interpretation (Arc C C5): plain-English shape
+               read-out attached to the chart so users don't need to infer
+               distribution character from histogram bars. Always renders so
+               the headline + detail are present even when the chart isn't. -->
+          <div
+            class="distro-interpretation"
+            data-kind={distributionInterpretation.kind}
+            role="note"
+          >
+            <p class="distro-interpretation-headline">{distributionInterpretation.headline}</p>
+            <p class="distro-interpretation-detail">{distributionInterpretation.detail}</p>
+          </div>
         </section>
 
         <section class="diagnose-visibility" aria-label="Browser visibility">
@@ -1140,6 +1165,34 @@
     margin: 0;
     padding: 8px 0;
   }
+
+  /* Distribution interpretation — Arc C C5. Headline + one detail line in
+     a quietly-emphasized block under the chart. data-kind hooks per-shape
+     accent colour without changing layout. */
+  .distro-interpretation {
+    margin-top: 12px;
+    padding: 10px 12px;
+    border: 1px solid var(--shell-border);
+    border-radius: 10px;
+    background: var(--shell-panel-hover);
+  }
+  .distro-interpretation-headline {
+    margin: 0;
+    color: var(--t1);
+    font-family: var(--sans);
+    font-size: var(--ts-sm);
+    font-weight: 700;
+  }
+  .distro-interpretation-detail {
+    margin: 4px 0 0;
+    color: var(--t3);
+    font-family: var(--sans);
+    font-size: var(--ts-xs);
+    line-height: 1.45;
+  }
+  .distro-interpretation[data-kind='bimodal'] { border-color: var(--shell-stop-border); }
+  .distro-interpretation[data-kind='tail-spikes'] { border-color: var(--shell-stop-border); }
+  .distro-interpretation[data-kind='unimodal-tight'] { border-color: var(--shell-success-border); }
 
   /* ── Diagnostic answer + browser visibility ───────────────────────────── */
   .diagnose-answer,

--- a/src/lib/utils/distribution-interpretation.ts
+++ b/src/lib/utils/distribution-interpretation.ts
@@ -1,0 +1,137 @@
+// src/lib/utils/distribution-interpretation.ts
+// Pure helper that turns a focused endpoint's recent OK latency samples into
+// a plain-English interpretation of the distribution shape. The synthesis
+// design contract requires this as the "what does the histogram actually
+// mean" copy on the EndpointDetail surface (Arc C C5 / cohesiveness gap B7).
+//
+// The interpretation is intentionally narrow — five buckets, each with copy
+// that names the endpoint (so the same module powers headline highlighting
+// downstream) and quotes real measurements rather than hand-waved adjectives.
+//
+// All thresholds are explicit and documented inline; do not adjust without
+// re-running the unit-test suite (`distribution-interpretation.test.ts`).
+
+import type { MeasurementSample } from '../types';
+
+export type DistributionInterpretationKind =
+  | 'insufficient-data'
+  | 'unimodal-tight'
+  | 'unimodal-wide'
+  | 'bimodal'
+  | 'tail-spikes';
+
+export interface DistributionInterpretation {
+  readonly kind: DistributionInterpretationKind;
+  readonly headline: string;
+  readonly detail: string;
+}
+
+export interface DistributionInterpretationInput {
+  readonly endpointLabel: string;
+  readonly samples: readonly MeasurementSample[];
+}
+
+// Distribution-shape thresholds. Tuned for the typical 8-50 sample window the
+// focused-endpoint panel surfaces; values are documented so the interpretation
+// boundaries are reviewable without spelunking through git blame.
+const MIN_SAMPLES = 8;
+const TIGHT_SPREAD_RATIO = 0.25; // spreadDelta / p50 — below ⇒ clustered tightly
+const WIDE_SPREAD_RATIO = 0.60;  // spreadDelta / p50 — above ⇒ wide spread (bimodal candidate)
+const TAIL_SPIKE_FACTOR = 3;     // outlier ≥ TAIL_SPIKE_FACTOR × p50
+const TAIL_SPIKE_MAX_SHARE = 0.20; // outliers must be ≤ 20 % of samples to count as tail (not a true second mode)
+
+function okLatencies(samples: readonly MeasurementSample[]): number[] {
+  const oks: number[] = [];
+  for (const sample of samples) {
+    if (sample.status !== 'ok') continue;
+    if (!Number.isFinite(sample.latency) || sample.latency < 0) continue;
+    oks.push(sample.latency);
+  }
+  return oks;
+}
+
+function percentile(sorted: readonly number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  if (sorted.length === 1) return sorted[0] as number;
+  const clamped = Math.max(0, Math.min(1, p));
+  const idx = clamped * (sorted.length - 1);
+  const low = Math.floor(idx);
+  const high = Math.ceil(idx);
+  if (low === high) return sorted[low] as number;
+  const frac = idx - low;
+  return (sorted[low] as number) * (1 - frac) + (sorted[high] as number) * frac;
+}
+
+function round(value: number): number {
+  return Math.round(value);
+}
+
+export function interpretDistribution(
+  input: DistributionInterpretationInput,
+): DistributionInterpretation {
+  const { endpointLabel, samples } = input;
+  const oks = okLatencies(samples);
+
+  if (oks.length < MIN_SAMPLES) {
+    return {
+      kind: 'insufficient-data',
+      headline: 'Not enough successful checks to characterize the distribution.',
+      detail: `Collect at least ${MIN_SAMPLES} successful checks (currently ${oks.length}) to see this endpoint's typical spread.`,
+    };
+  }
+
+  const sorted = [...oks].sort((a, b) => a - b);
+  const p50 = percentile(sorted, 0.5);
+  const p95 = percentile(sorted, 0.95);
+  const max = sorted[sorted.length - 1] as number;
+
+  // Tail detection — large outliers above ≥ TAIL_SPIKE_FACTOR × p50 but only
+  // a small share of the samples. A true second mode (bimodal) needs more
+  // than TAIL_SPIKE_MAX_SHARE of samples in the upper cluster.
+  const tailThreshold = p50 * TAIL_SPIKE_FACTOR;
+  const tailSamples = sorted.filter((value) => value >= tailThreshold);
+  const tailShare = tailSamples.length / sorted.length;
+
+  // Spread ratio guards the "tight" / "wide" branching. Using p50 in the
+  // denominator means a 5 ms median + 1 ms tail difference is "tight"
+  // while a 200 ms median + 60 ms tail difference is "wide" — the ratio
+  // matches what users perceive at very different latency scales.
+  const spreadDelta = p95 - p50;
+  const spreadRatio = p50 > 0 ? spreadDelta / p50 : 0;
+
+  if (tailSamples.length > 0 && tailShare <= TAIL_SPIKE_MAX_SHARE) {
+    const sharePercent = Math.round(tailShare * 100);
+    return {
+      kind: 'tail-spikes',
+      headline: `${endpointLabel} mostly runs fast, with occasional spikes.`,
+      detail: `${sharePercent}% of checks spike to ${round(tailThreshold)} ms or higher (max ${round(max)} ms); the rest cluster near ${round(p50)} ms.`,
+    };
+  }
+
+  if (spreadRatio > WIDE_SPREAD_RATIO) {
+    // Wide enough that the distribution is split rather than one fuzzy peak.
+    const lowerHalf = sorted.slice(0, Math.floor(sorted.length / 2));
+    const upperHalf = sorted.slice(Math.floor(sorted.length / 2));
+    const lowerCenter = percentile(lowerHalf, 0.5);
+    const upperCenter = percentile(upperHalf, 0.5);
+    return {
+      kind: 'bimodal',
+      headline: `${endpointLabel}'s latency is split between two response times.`,
+      detail: `Two clusters: one near ${round(lowerCenter)} ms and another near ${round(upperCenter)} ms — investigate what conditions trigger each.`,
+    };
+  }
+
+  if (spreadRatio < TIGHT_SPREAD_RATIO) {
+    return {
+      kind: 'unimodal-tight',
+      headline: `${endpointLabel}'s latency is consistent.`,
+      detail: `Most checks land near ${round(p50)} ms (p95 ${round(p95)} ms) with little spread.`,
+    };
+  }
+
+  return {
+    kind: 'unimodal-wide',
+    headline: `${endpointLabel}'s latency varies but stays unimodal.`,
+    detail: `Spread is wider than typical (p50 ${round(p50)} ms, p95 ${round(p95)} ms) but there is a single broad cluster, not two distinct ones.`,
+  };
+}

--- a/tests/unit/utils/distribution-interpretation.test.ts
+++ b/tests/unit/utils/distribution-interpretation.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { interpretDistribution } from '../../../src/lib/utils/distribution-interpretation';
+import type { MeasurementSample } from '../../../src/lib/types';
+
+function ok(round: number, latency: number): MeasurementSample {
+  return { round, latency, status: 'ok', timestamp: round * 1000 };
+}
+
+function failed(round: number): MeasurementSample {
+  return { round, latency: 0, status: 'timeout', timestamp: round * 1000 };
+}
+
+describe('interpretDistribution', () => {
+  it('returns insufficient-data below 8 successful samples', () => {
+    const samples = [ok(1, 50), ok(2, 52), ok(3, 48), ok(4, 51), failed(5)];
+    const interpretation = interpretDistribution({ endpointLabel: 'API', samples });
+    expect(interpretation.kind).toBe('insufficient-data');
+    expect(interpretation.headline).toContain('Not enough');
+    expect(interpretation.detail).toContain('currently 4');
+  });
+
+  it('returns unimodal-tight when samples cluster within ~25% of the median', () => {
+    // 10 samples between 48 and 56 ms — (p95 - p50) / p50 should be well
+    // under TIGHT_SPREAD_RATIO (0.25).
+    const samples = Array.from({ length: 10 }, (_, i) => ok(i + 1, 50 + i % 4));
+    const interpretation = interpretDistribution({ endpointLabel: 'Google', samples });
+    expect(interpretation.kind).toBe('unimodal-tight');
+    expect(interpretation.headline).toBe("Google's latency is consistent.");
+    expect(interpretation.detail).toMatch(/p95 \d+ ms/);
+  });
+
+  it('returns unimodal-wide when spread is moderate but no second cluster forms', () => {
+    // p50 ≈ 60ms, p95 ≈ 90ms → spread ratio ≈ 0.5 (above tight, below wide).
+    const samples: MeasurementSample[] = [];
+    let r = 1;
+    for (const latency of [45, 50, 55, 58, 60, 62, 65, 70, 80, 90]) {
+      samples.push(ok(r++, latency));
+    }
+    const interpretation = interpretDistribution({ endpointLabel: 'API', samples });
+    expect(interpretation.kind).toBe('unimodal-wide');
+    expect(interpretation.headline).toBe("API's latency varies but stays unimodal.");
+  });
+
+  it('returns bimodal when samples form two clearly separated groups', () => {
+    // Half clustered around 50 ms, half around 250 ms — spread ratio is huge
+    // and the upper cluster is larger than 20 % of samples.
+    const samples: MeasurementSample[] = [];
+    let r = 1;
+    for (const latency of [48, 50, 52, 50, 49, 51, 250, 245, 252, 248, 251, 250]) {
+      samples.push(ok(r++, latency));
+    }
+    const interpretation = interpretDistribution({ endpointLabel: 'Cloudflare', samples });
+    expect(interpretation.kind).toBe('bimodal');
+    expect(interpretation.headline).toBe("Cloudflare's latency is split between two response times.");
+    expect(interpretation.detail).toMatch(/two clusters/i);
+  });
+
+  it('returns tail-spikes when most samples cluster tight but a small fraction is much slower', () => {
+    // 9 fast samples around 50ms, 1 outlier at 400ms — outlier is 8× p50 but
+    // only 10 % of the sample count (≤ TAIL_SPIKE_MAX_SHARE of 20 %).
+    const samples: MeasurementSample[] = [];
+    let r = 1;
+    for (const latency of [48, 50, 52, 49, 51, 50, 47, 53, 50, 400]) {
+      samples.push(ok(r++, latency));
+    }
+    const interpretation = interpretDistribution({ endpointLabel: 'API', samples });
+    expect(interpretation.kind).toBe('tail-spikes');
+    expect(interpretation.headline).toBe('API mostly runs fast, with occasional spikes.');
+    expect(interpretation.detail).toMatch(/max 400 ms/);
+  });
+
+  it('excludes failed samples from the OK count for the insufficient-data threshold', () => {
+    // 7 OK + 4 failed = 7 successful. Should still be insufficient-data.
+    const samples: MeasurementSample[] = [];
+    let r = 1;
+    for (let i = 0; i < 7; i++) samples.push(ok(r++, 50));
+    for (let i = 0; i < 4; i++) samples.push(failed(r++));
+    const interpretation = interpretDistribution({ endpointLabel: 'API', samples });
+    expect(interpretation.kind).toBe('insufficient-data');
+  });
+
+  it('always names the focused endpoint in the headline', () => {
+    const samples = Array.from({ length: 12 }, (_, i) => ok(i + 1, 50));
+    const interpretation = interpretDistribution({ endpointLabel: 'My Custom Endpoint', samples });
+    expect(interpretation.headline).toContain('My Custom Endpoint');
+  });
+});


### PR DESCRIPTION
## Summary
- New plain-English read-out of the focused endpoint's latency distribution shape, surfaced alongside the histogram so users don't need to infer character from bar heights (closes B7)
- Five templates: \`insufficient-data\`, \`unimodal-tight\`, \`unimodal-wide\`, \`bimodal\`, \`tail-spikes\` — each headline names the endpoint and the detail line quotes real measurements (p50, p95, max, share)
- Detection lives in a new pure helper (\`src/lib/utils/distribution-interpretation.ts\`) — explicit, documented thresholds in one module so the boundaries are reviewable
- Seven unit tests cover each template, threshold edges (insufficient-data cutoff at 8 OK samples, failed-sample exclusion, tail-share cap at 20%), and endpoint-label substitution

## Why
Fourth PR in Arc C, closing cohesiveness gap B7 (the histogram bars alone don't tell the user whether they're looking at a tight cluster, a wide-but-unimodal spread, two modes, or a tail). Specific, evidence-backed copy matching the spec's Measured Fact discipline.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm run lint:css\` — clean
- [x] \`npm test\` — 1133 / 1133 passing (+7 interpretation tests)
- [x] \`npm run build\` — succeeds
- [ ] Visual check of distribution panel on EndpointDetail across each shape