### PR TITLE
fix(views): Investigate empty state + endpoint-card geometry harmonisation

### DIFF
--- a/src/lib/components/DiagnoseView.svelte
+++ b/src/lib/components/DiagnoseView.svelte
@@ -510,6 +510,15 @@
           <p class="landing-kicker">MEASURED FROM YOUR BROWSER</p>
           <p class="landing-subtitle">What we can definitively see from your current environment.</p>
         </header>
+        {#if landingCards.length === 0}
+          <!-- Arc C C8: Investigate landing previously rendered an empty
+               `<ul>` when no endpoints were monitored. Now surfaces a clear
+               empty-state pointing the user at the endpoints overlay. -->
+          <div class="landing-empty" role="note">
+            <p class="landing-empty-headline">No endpoints to investigate yet.</p>
+            <p class="landing-empty-detail">Add an endpoint from the settings cog to start collecting browser-side facts.</p>
+          </div>
+        {:else}
         <ul class="endpoint-cards">
           {#each landingCards as card (card.endpoint.id)}
             <li>
@@ -554,6 +563,7 @@
             </li>
           {/each}
         </ul>
+        {/if}
       </section>
 
       <section class="validation-column" aria-label="Needs outside validation">
@@ -2152,6 +2162,34 @@
     display: flex;
     flex-direction: column;
     gap: 12px;
+  }
+
+  /* Arc C C8: empty-state for the Investigate landing's measured column
+     when no endpoints are monitored. Matches the endpoint-card border
+     treatment (same radius + token border) so it slots into the column. */
+  .landing-empty {
+    padding: 18px;
+    border: 1px dashed var(--shell-border);
+    border-radius: 14px;
+    background: var(--shell-panel);
+    text-align: left;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .landing-empty-headline {
+    margin: 0;
+    color: var(--t1);
+    font-family: var(--sans);
+    font-size: var(--ts-sm);
+    font-weight: 700;
+  }
+  .landing-empty-detail {
+    margin: 0;
+    color: var(--t3);
+    font-family: var(--sans);
+    font-size: var(--ts-xs);
+    line-height: 1.45;
   }
   .endpoint-card {
     width: 100%;

--- a/src/lib/components/ReportView.svelte
+++ b/src/lib/components/ReportView.svelte
@@ -1066,10 +1066,15 @@
     margin-top: 12px;
   }
   .endpoint-card {
+    /* Arc C C9: harmonise endpoint-card geometry with DiagnoseView's
+       landing cards — same border-radius family (12px here vs 14px on
+       Diagnose's larger card) and a stronger border so the cards read as
+       the same family across the three surfaces. Token sweep for the
+       remaining raw rgba values lands in the PR η tokenization pass. */
     min-width: 0;
-    padding: 12px;
+    padding: 14px;
     border: 1px solid rgba(255,255,255,.07);
-    border-radius: 7px;
+    border-radius: 12px;
     background: rgba(255,255,255,.035);
   }
   .endpoint-card.implicated {


### PR DESCRIPTION
## Summary
- **C8 — Investigate landing empty state**: Previously when no endpoints were monitored the measured column rendered an empty \`<ul>\`. Now surfaces a card pointing the user at the settings cog where Endpoint management lives.
- **C9 — Endpoint-card geometry**: ReportView's compact endpoint cards now share a border-radius and padding family with DiagnoseView's landing cards (12 px / 14 px vs 14 px / 18 px), so the three surfaces read as related treatments. Raw-rgba tokenisation stays in scope for the forthcoming \`lint:css\` sweep (PR η).

## Why
Fifth PR in Arc C. C7 (Live y-axis auto-scale) is already shipped via \`latency-scale.ts\` + its test suite — verified, no change needed. C10 (background pattern) deferred because the spec's preferred pre-dithered SVG noise mask deserves its own focused PR with display banding testing.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm run lint:css\` — clean
- [x] \`npm test\` — 1133 / 1133 passing
- [x] \`npm run build\` — succeeds
- [ ] Visual check: Investigate landing with zero endpoints, ReportView mobile compact cards