### PR TITLE
refactor(topology): align NetworkTopology to v2 aesthetic (2/7)

### DIFF
--- a/src/lib/components/NetworkTopology.svelte
+++ b/src/lib/components/NetworkTopology.svelte
@@ -23,14 +23,15 @@
   } from '$lib/utils/network-topology-layout';
 
   // Layout grid (SVG viewBox is unitless — these are abstract design units).
+  // v2 alignment: bigger glyphs (40 px vs 28 px), tighter horizontal travel
+  // so the panel doesn't feel sparse with only 3 endpoints.
   const VIEWBOX_WIDTH = 320;
   const VIEWBOX_HEIGHT = 260;
-  const ORIGIN_X = 50;
+  const ORIGIN_X = 56;
   const ORIGIN_Y = VIEWBOX_HEIGHT / 2;
-  const ENDPOINT_X = 240;
-  const NODE_HALF = 14;
+  const ENDPOINT_X = 230;
+  const NODE_HALF = 20;
   const NODE_SIZE = NODE_HALF * 2;
-  const NODE_RADIUS = NODE_HALF; // legacy alias retained for the origin glyph
 
   const monitored = $derived($monitoredEndpointsStore);
   const stats = $derived($statisticsStore);
@@ -185,13 +186,24 @@
         {/if}
       {/each}
 
-      <!-- Origin (browser) node — kept circular to read as "you" / device. -->
+      <!-- Origin (browser) node — v2 alignment: same rounded-square family
+           as endpoint glyphs so the whole topology reads as one visual
+           system. The label stays below the glyph since the origin is
+           always centred vertically and never collides with siblings. -->
       <g class="topology-node-group" data-role="origin">
-        <circle class="topology-node-circle" cx={ORIGIN_X} cy={ORIGIN_Y} r={NODE_RADIUS} />
+        <rect
+          class="topology-node-circle"
+          x={ORIGIN_X - NODE_HALF}
+          y={ORIGIN_Y - NODE_HALF}
+          width={NODE_SIZE}
+          height={NODE_SIZE}
+          rx="8"
+          ry="8"
+        />
         <text
           class="topology-label"
           x={ORIGIN_X}
-          y={ORIGIN_Y + NODE_HALF + 16}
+          y={ORIGIN_Y + NODE_HALF + 18}
           text-anchor="middle"
         >
           BROWSER
@@ -222,8 +234,8 @@
             y={node.y - NODE_HALF}
             width={NODE_SIZE}
             height={NODE_SIZE}
-            rx="6"
-            ry="6"
+            rx="8"
+            ry="8"
           />
           <text
             class="topology-label"
@@ -261,8 +273,8 @@
             y={overflowSlot.y - NODE_HALF}
             width={NODE_SIZE}
             height={NODE_SIZE}
-            rx="6"
-            ry="6"
+            rx="8"
+            ry="8"
           />
           <text
             class="topology-overflow-count"
@@ -293,10 +305,13 @@
     flex-direction: column;
     align-items: stretch;
     justify-content: center;
-    padding: 16px;
+    padding: 24px;
     border: 1px solid var(--shell-border);
-    border-radius: 18px;
+    /* v2 alignment: larger 24px radius matches the verdict card panel so
+       the hero row reads as two surfaces in the same family. */
+    border-radius: 24px;
     background: var(--shell-panel);
+    box-shadow: 0 25px 50px -12px color-mix(in srgb, black 35%, transparent);
   }
 
   .topology-svg {
@@ -306,45 +321,47 @@
     overflow: visible;
   }
 
-  /* Path lines — brighter than the prior shell-divider tone so the
-     spatial structure reads at a glance against the dark panel. */
+  /* Path lines — v2 alignment. Nearly invisible thin lines that suggest
+     connection without competing with the glyphs. v2 uses h-px bg-white/
+     [0.03]; we approximate with the lightest border token at 1px stroke. */
   .topology-path {
-    stroke: var(--shell-border-strong);
+    stroke: color-mix(in srgb, var(--t1) 6%, transparent);
     fill: none;
-    stroke-width: 1.2;
+    stroke-width: 1;
   }
   .topology-path-overflow {
     stroke-dasharray: 3 4;
     opacity: 0.7;
   }
 
-  /* Endpoint glyphs — rounded squares per Arc C synthesis. Coloured stroke
-     pops against the slightly darker fill; tone-coloured drop-shadow / glow
-     gives each endpoint presence rather than reading as a wireframe. */
+  /* Endpoint glyphs — v2 alignment. Tinted panel fill (subtle tone-coloured
+     background) + matching tinted border (no heavy stroke), no drop-shadow
+     glow halo. The glyph reads as a calm coloured panel, not a glowing
+     wireframe. Origin keeps the same family. */
   .topology-node-rect,
   .topology-node-circle {
-    fill: var(--shell-base);
-    stroke-width: 2.5;
+    stroke-width: 1;
     transition: stroke 200ms ease, fill 200ms ease;
   }
   [data-role='origin'] .topology-node-circle {
-    stroke: var(--t2);
+    fill: color-mix(in srgb, var(--t1) 6%, transparent);
+    stroke: color-mix(in srgb, var(--t1) 12%, transparent);
   }
   [data-tone='good'] .topology-node-rect {
-    stroke: var(--accent-green);
-    filter: drop-shadow(0 0 6px var(--accent-green));
+    fill: color-mix(in srgb, var(--accent-green) 10%, transparent);
+    stroke: color-mix(in srgb, var(--accent-green) 24%, transparent);
   }
   [data-tone='watch'] .topology-node-rect {
-    stroke: var(--accent-amber);
-    filter: drop-shadow(0 0 6px var(--accent-amber));
+    fill: color-mix(in srgb, var(--accent-amber) 10%, transparent);
+    stroke: color-mix(in srgb, var(--accent-amber) 24%, transparent);
   }
   [data-tone='bad'] .topology-node-rect {
-    stroke: var(--accent-pink);
-    filter: drop-shadow(0 0 8px var(--accent-pink));
+    fill: color-mix(in srgb, var(--accent-pink) 10%, transparent);
+    stroke: color-mix(in srgb, var(--accent-pink) 24%, transparent);
   }
   [data-tone='collecting'] .topology-node-rect {
-    stroke: var(--accent-cyan);
-    filter: drop-shadow(0 0 6px var(--accent-cyan));
+    fill: color-mix(in srgb, var(--accent-cyan) 10%, transparent);
+    stroke: color-mix(in srgb, var(--accent-cyan) 24%, transparent);
   }
 
   .topology-node-clickable,
@@ -378,35 +395,40 @@
     pointer-events: none;
   }
 
-  /* Labels — bumped contrast (was --t3 = .5 alpha, barely readable;
-     --t2 = .58 still calm but legible). */
+  /* Labels — v2 alignment: a half-step quieter than before, with sans-serif
+     rather than mono for the endpoint labels (the BROWSER kicker stays
+     uppercase tracked-out so it reads as a label, not a value). */
   .topology-label {
-    fill: var(--t2);
-    font-family: var(--mono);
+    fill: var(--t3);
+    font-family: var(--sans);
     font-size: 10px;
+    font-weight: 500;
+    letter-spacing: -0.005em;
+    pointer-events: none;
+  }
+  [data-role='origin'] .topology-label {
+    fill: var(--t4);
+    font-family: var(--mono);
     font-weight: 600;
     letter-spacing: var(--tr-label);
     text-transform: uppercase;
-    pointer-events: none;
   }
   [data-tone='good'] .topology-label,
   [data-tone='watch'] .topology-label,
   [data-tone='bad'] .topology-label,
   [data-tone='collecting'] .topology-label {
-    fill: var(--t1);
+    fill: var(--t2);
   }
 
-  /* Pulse packets — animate via CSS transform: translate (which IS
-     reliably animatable on SVG elements). The earlier implementation used
-     CSS keyframes on the SVG `cx`/`cy` attributes, which Chrome accepts
-     syntactically but renders inconsistently and frequently strands the
-     element mid-path. The new approach: render the circle at the origin
-     coordinates (cx=ORIGIN_X, cy=ORIGIN_Y) and animate transform: translate
-     by --pulse-dx / --pulse-dy (the delta to the endpoint). */
+  /* Pulse packets — v2 alignment: smaller circle, lower peak opacity so
+     the pulses read as quiet evidence of ongoing measurement rather than
+     attention-grabbing decoration. Animation timing matches v2's 1.5s ease
+     -in-out which feels less mechanical than the previous 1.2s ease-out. */
   .topology-pulse {
-    animation: pulse-travel 1.2s ease-out forwards;
+    animation: pulse-travel 1.5s ease-in-out forwards;
     pointer-events: none;
     transform-box: fill-box;
+    r: 2.5;
   }
   [data-tone='good'].topology-pulse { fill: var(--accent-green); }
   [data-tone='watch'].topology-pulse { fill: var(--accent-amber); }
@@ -415,8 +437,8 @@
 
   @keyframes pulse-travel {
     0%   { transform: translate(0, 0);                            opacity: 0; }
-    20%  { transform: translate(calc(var(--pulse-dx) * 0.2), calc(var(--pulse-dy) * 0.2)); opacity: 1; }
-    80%  { transform: translate(calc(var(--pulse-dx) * 0.8), calc(var(--pulse-dy) * 0.8)); opacity: 1; }
+    25%  { transform: translate(calc(var(--pulse-dx) * 0.25), calc(var(--pulse-dy) * 0.25)); opacity: 0.7; }
+    75%  { transform: translate(calc(var(--pulse-dx) * 0.75), calc(var(--pulse-dy) * 0.75)); opacity: 0.7; }
     100% { transform: translate(var(--pulse-dx), var(--pulse-dy));  opacity: 0; }
   }
 


### PR DESCRIPTION
## Summary
- Endpoint glyphs: tinted fill + subtle border, no drop-shadow halo, no heavy stroke
- Origin: rounded-square (same family as endpoints), bigger (40 px), label demotes to a quieter kicker
- Path lines: nearly-invisible white/6% — pulses carry the live signal
- Pulse animation: smaller radius, softer easing, lower peak opacity (quiet measurement, not decoration)
- Endpoint labels: sans-serif, lighter weight, quieter colour
- Panel: 24 px radius + soft drop shadow to match the verdict card from PR 1/7

## Why
Continues the v2 aesthetic arc. The topology was the second-loudest surface on the overview hero (the glow halos + heavy stroke read as "instrument"). v2's treatment reads as "system map." Layout-logic unchanged — \`layoutTopologyNodes\` and the overflow-chip behaviour from Arc C γ carry through.

## Arc
PR 1/7 ✅ — verdict card (#183)
PR 2/7 — this PR
PR 3/7 — background + atmospheric
PR 4/7 — shell + topbar
PR 5/7 — endpoint rows + event log
PR 6/7 — Live + Investigate + Report
PR 7/7 — visual baselines + tokenisation sweep

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm run lint:css\` — clean
- [x] \`npm test\` — 1138 / 1138 passing
- [x] \`npm run build\` — succeeds