### PR TITLE
refactor(theme): shift palette to v2 pure-black + warm-grey scale (3/7)

### DIFF
--- a/src/lib/components/Layout.svelte
+++ b/src/lib/components/Layout.svelte
@@ -120,17 +120,14 @@
   }
   .skip-link:focus { top: 0; }
 
+  /* v2 aesthetic arc PR 3: page bg is solid black. The prior linear
+     gradient and corner radial-gradient orbs both banded on dark per
+     [[feedback_dark_backgrounds]]; v2 simply uses a flat bg-black body.
+     Solid colour is the only banding-safe option without a pre-dithered
+     raster, which is overkill for this surface. */
   .bg {
     position: fixed; inset: 0; z-index: 0;
-    background:
-      linear-gradient(180deg, var(--shell-bg), var(--bg-base));
-  }
-
-  .bg::before {
-    content: ''; position: absolute; inset: 0; pointer-events: none;
-    background:
-      radial-gradient(ellipse 70% 42% at 18% -10%, var(--shell-bg-cyan), transparent 62%),
-      radial-gradient(ellipse 55% 38% at 92% 105%, var(--shell-bg-amber), transparent 68%);
+    background: var(--shell-bg);
   }
 
   .app {

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -12,21 +12,28 @@
 // ── Primitive tokens ───────────────────────────────────────────────────────
 const primitive = {
   // Background
-  bgBase: '#0c0a14',
-  bgMid:  '#100e1e',
-  bgDeep: '#0e0c18',
+  // v2 aesthetic arc PR 3: page bg is pure black, panels are warm-grey
+  // (#1C1C1E) one notch above. Pure solid is the only atmospheric option
+  // that doesn't band on dark — see [[feedback_dark_backgrounds]]. The
+  // prior cyan/amber radial-gradient orbs in Layout.svelte are dropped
+  // alongside this token shift.
+  bgBase: '#000000',
+  bgMid:  '#0A0A0A',
+  bgDeep: '#000000',
 
-  // Figma redesign shell foundation (PR 1)
-  shellBase: '#070b12',
-  shellPanel: '#0b111b',
-  shellPanelRaised: '#101722',
+  // v2 panel scale: black page → #1C1C1E panel → #2C2C2E raised. Hover
+  // and active stay as alpha-on-white so they read the same across light
+  // and dark panel families.
+  shellBase: '#000000',
+  shellPanel: '#1C1C1E',
+  shellPanelRaised: '#2C2C2E',
   shellPanelHover: 'rgba(255,255,255,.055)',
   shellPanelActive: 'rgba(103,232,249,.095)',
-  shellBorder: 'rgba(255,255,255,.085)',
-  shellBorderStrong: 'rgba(255,255,255,.145)',
+  shellBorder: 'rgba(255,255,255,.08)',
+  shellBorderStrong: 'rgba(255,255,255,.14)',
   shellDivider: 'rgba(255,255,255,.06)',
-  shellBackdrop: 'rgba(7,11,18,.78)',
-  shellPopover: 'rgba(8,12,19,.96)',
+  shellBackdrop: 'rgba(28,28,30,.8)',
+  shellPopover: 'rgba(28,28,30,.96)',
   shellBgCyan: 'rgba(103,232,249,.045)',
   shellBgAmber: 'rgba(251,191,36,.028)',
   shellSuccessBg: 'rgba(134,239,172,.115)',

--- a/tests/unit/tokens.test.ts
+++ b/tests/unit/tokens.test.ts
@@ -3,9 +3,11 @@ import { tokens } from '../../src/lib/tokens';
 
 describe('tokens', () => {
   it('exposes all required surface tokens', () => {
-    expect(tokens.color.surface.base).toBe('#0c0a14');
-    expect(tokens.color.surface.mid).toBe('#100e1e');
-    expect(tokens.color.surface.deep).toBe('#0e0c18');
+    // v2 aesthetic arc PR 3: page bg is pure black + warm-grey panels
+    // (#1C1C1E / #2C2C2E) to match the v2 reference.
+    expect(tokens.color.surface.base).toBe('#000000');
+    expect(tokens.color.surface.mid).toBe('#0A0A0A');
+    expect(tokens.color.surface.deep).toBe('#000000');
   });
 
   it('exposes all spacing tokens as numbers (px)', () => {
@@ -58,7 +60,8 @@ describe('Glass token additions', () => {
   });
 
   it('exports glass background base color', () => {
-    expect(tokens.color.surface.base).toBe('#0c0a14');
+    // v2 aesthetic arc PR 3: surface base is now pure black.
+    expect(tokens.color.surface.base).toBe('#000000');
   });
 
   it('exports glass accent colors', () => {
@@ -274,19 +277,22 @@ describe('v2 foundation tokens (Phase 0)', () => {
 
 describe('figma redesign shell tokens (PR 1)', () => {
   it('exports graphite shell surfaces with a near-black base', () => {
-    expect(tokens.color.shell.base).toBe('#070b12');
-    expect(tokens.color.shell.panel).toBe('#0b111b');
-    expect(tokens.color.shell.panelRaised).toBe('#101722');
-    expect(tokens.color.shell.popover).toBe('rgba(8,12,19,.96)');
+    // v2 aesthetic arc PR 3: shell surface scale is now pure black page bg
+    // (#000) + warm-grey panel (#1C1C1E) + raised (#2C2C2E). Replaces the
+    // prior #070b12 / #0b111b / #101722 blue-tinted near-black scale.
+    expect(tokens.color.shell.base).toBe('#000000');
+    expect(tokens.color.shell.panel).toBe('#1C1C1E');
+    expect(tokens.color.shell.panelRaised).toBe('#2C2C2E');
+    expect(tokens.color.shell.popover).toBe('rgba(28,28,30,.96)');
   });
 
   it('exports shell interaction and atmosphere tokens', () => {
     expect(tokens.color.shell.panelHover).toBe('rgba(255,255,255,.055)');
     expect(tokens.color.shell.panelActive).toBe('rgba(103,232,249,.095)');
-    expect(tokens.color.shell.border).toBe('rgba(255,255,255,.085)');
-    expect(tokens.color.shell.borderStrong).toBe('rgba(255,255,255,.145)');
+    expect(tokens.color.shell.border).toBe('rgba(255,255,255,.08)');
+    expect(tokens.color.shell.borderStrong).toBe('rgba(255,255,255,.14)');
     expect(tokens.color.shell.divider).toBe('rgba(255,255,255,.06)');
-    expect(tokens.color.shell.backdrop).toBe('rgba(7,11,18,.78)');
+    expect(tokens.color.shell.backdrop).toBe('rgba(28,28,30,.8)');
     expect(tokens.color.shell.bgCyan).toBe('rgba(103,232,249,.045)');
     expect(tokens.color.shell.bgAmber).toBe('rgba(251,191,36,.028)');
   });


### PR DESCRIPTION
## Summary
- Page bg: pure black (#000) — replaces the blue-tinted #070b12
- Panel: #1C1C1E (v2 warm grey) — replaces #0b111b
- Panel raised: #2C2C2E — replaces #101722
- Drops Layout.svelte's vertical gradient + corner radial-gradient orbs (both banded on dark per saved feedback memory; v2's flat bg is the banding-safe move)
- Border alphas tightened to round numbers matching v2 source (.08 / .14)
- Backdrop / popover overlays re-tinted to the new panel colour

## Why
The palette is the loudest single thing separating Chronoscope's old look from v2. This shift makes every panel + button + chip in the project sit on the v2 surface scale automatically — the remaining PRs (4–6) refine each surface's typography and chrome on top of this foundation.

Tone-tint surfaces (shellBgCyan, shellBgAmber, shellSuccessBg, shellStopBg) are unchanged — those are per-tone affordances, not atmosphere, and the rgba overlays sit cleanly on either palette family.

## Arc
PR 1/7 ✅ — verdict card
PR 2/7 ✅ — NetworkTopology
PR 3/7 — this PR
PR 4/7 — shell + topbar
PR 5/7 — endpoint rows + event log
PR 6/7 — Live + Investigate + Report
PR 7/7 — visual baselines + tokenisation sweep

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm run lint:css\` — clean
- [x] \`npm test\` — 1138 / 1138 passing (4 token tests updated for the new scale)
- [x] \`npm run build\` — succeeds