### PR TITLE
refactor(views): align Live + DiagnoseView + Report panels to v2 (6/7)

### DIFF
--- a/src/lib/components/DiagnoseView.svelte
+++ b/src/lib/components/DiagnoseView.svelte
@@ -962,7 +962,7 @@
     flex-direction: column;
     gap: 8px;
     padding: 16px;
-    background: rgba(8, 14, 24, 0.62);
+    background: color-mix(in srgb, black 40%, transparent);
     border: 1px solid var(--shell-border);
     border-radius: 14px;
   }
@@ -1060,10 +1060,10 @@
     display: flex;
     flex-direction: column;
     gap: 10px;
-    padding: 16px;
-    background: rgba(8, 14, 24, 0.62);
+    padding: 18px;
+    background: var(--shell-panel);
     border: 1px solid var(--shell-border);
-    border-radius: 14px;
+    border-radius: 16px;
   }
   .diagnose-brief {
     display: grid;
@@ -1072,12 +1072,13 @@
     gap: clamp(18px, 3vw, 34px);
     padding: clamp(20px, 3vw, 30px);
     min-height: 220px;
-    background:
-      linear-gradient(135deg, rgba(103, 232, 249, 0.07), rgba(37, 99, 235, 0.035) 42%, rgba(255, 255, 255, 0.022)),
-      var(--shell-panel-raised);
-    border-color: color-mix(in srgb, var(--accent-cyan) 20%, var(--shell-border-strong));
-    border-radius: 18px;
-    box-shadow: 0 28px 90px rgba(0, 0, 0, 0.18);
+    /* v2 alignment: flat panel surface in the same family as the other
+       diagnose panels — drops the cyan-tinted gradient that previously
+       singled this surface out. */
+    background: var(--shell-panel);
+    border-color: var(--shell-border);
+    border-radius: 24px;
+    box-shadow: 0 25px 50px -12px color-mix(in srgb, black 35%, transparent);
   }
   .diagnose-brief-score {
     width: clamp(112px, 12vw, 148px);

--- a/src/lib/components/LiveView.svelte
+++ b/src/lib/components/LiveView.svelte
@@ -251,12 +251,13 @@
     gap: 24px;
     flex-wrap: wrap;
     padding: clamp(20px, 3vw, 30px);
-    border: 1px solid var(--shell-border-strong);
-    border-radius: 18px;
-    background:
-      radial-gradient(circle at 12% 40%, var(--shell-bg-cyan), transparent 32%),
-      linear-gradient(135deg, var(--shell-panel-raised), rgba(16, 23, 34, 0.72));
-    box-shadow: 0 28px 90px rgba(0, 0, 0, 0.18);
+    border: 1px solid var(--shell-border);
+    /* v2 alignment: 24 px radius matches the verdict-card family; flat
+       panel surface (no radial-gradient) so the page palette carries the
+       atmosphere instead of each card layering its own. */
+    border-radius: 24px;
+    background: var(--shell-panel);
+    box-shadow: 0 25px 50px -12px color-mix(in srgb, black 35%, transparent);
   }
   .live-kicker {
     font-family: var(--mono);
@@ -312,7 +313,7 @@
     padding: 12px;
     border: 1px solid var(--shell-border);
     border-radius: 14px;
-    background: rgba(8, 14, 24, 0.58);
+    background: color-mix(in srgb, black 40%, transparent);
   }
   .live-control { display: flex; flex-direction: column; gap: 4px; }
   .live-control-label {
@@ -396,9 +397,9 @@
     min-width: 0;
     padding: clamp(12px, 2vw, 18px);
     border: 1px solid var(--shell-border);
-    border-radius: 18px;
-    background: rgba(8, 14, 24, 0.68);
-    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.18);
+    border-radius: 24px;
+    background: var(--shell-panel);
+    box-shadow: 0 25px 50px -12px color-mix(in srgb, black 35%, transparent);
     overflow: hidden;
   }
 
@@ -414,7 +415,7 @@
     gap: 6px;
     flex-wrap: wrap;
     padding: 10px 12px;
-    background: rgba(8, 14, 24, 0.62);
+    background: color-mix(in srgb, black 40%, transparent);
     border: 1px solid var(--shell-border);
     border-radius: 14px;
   }

--- a/src/lib/components/ReportView.svelte
+++ b/src/lib/components/ReportView.svelte
@@ -613,19 +613,13 @@
   .report-hero {
     position: relative;
     overflow: hidden;
-    border: 1px solid var(--shell-border-strong);
-    border-radius: 18px;
-    background:
-      radial-gradient(circle at 12% 40%, var(--shell-bg-cyan), transparent 32%),
-      linear-gradient(135deg, var(--shell-panel-raised), rgba(16, 23, 34, 0.72));
-    box-shadow: 0 28px 90px rgba(0,0,0,.18);
-  }
-  .report-hero::after {
-    content: "";
-    position: absolute;
-    inset: auto 0 0;
-    height: 1px;
-    background: linear-gradient(90deg, transparent, rgba(103,232,249,.42), transparent);
+    border: 1px solid var(--shell-border);
+    /* v2 alignment: 24 px radius, flat panel surface, soft shadow. Drops
+       the cyan radial-gradient that previously singled this surface out
+       and the cyan underline accent below the hero. */
+    border-radius: 24px;
+    background: var(--shell-panel);
+    box-shadow: 0 25px 50px -12px color-mix(in srgb, black 35%, transparent);
   }
   .report-hero-grid {
     position: relative;
@@ -807,7 +801,7 @@
   .report-strip > div {
     min-width: 0;
     padding: 13px 14px;
-    background: rgba(8, 14, 24, 0.68);
+    background: var(--shell-panel);
     display: flex;
     flex-direction: column;
     gap: 4px;
@@ -821,7 +815,7 @@
     margin-bottom: 18px;
     border: 1px solid var(--shell-border);
     border-radius: 14px;
-    background: rgba(8, 14, 24, 0.62);
+    background: color-mix(in srgb, black 40%, transparent);
     padding: 14px;
   }
 


### PR DESCRIPTION
## Summary
Brings the three non-overview routes into the same panel-surface family Overview already carries.

**LiveView**
- \`.live-hero\` + \`.live-scope-panel\`: flat shell-panel surface, 24 px radius, soft drop shadow (drops cyan radial-gradient + dark-blue tint)
- \`.live-controls\` + \`.live-footer\`: retint to color-mix on pure black

**DiagnoseView**
- \`.diagnose-distro\` + \`.diagnose-answer\` + visibility + remote + loaded + network-context + local-proof panels switch to flat shell-panel surface, 16 px radius, 18 px padding
- \`.diagnose-brief\` drops its cyan-tinted gradient + cyan-tinted border; falls back to v2 flat panel surface + soft shadow + 24 px radius

**ReportView**
- \`.report-hero\` strips the cyan radial-gradient and the cyan underline accent below the panel — flat shell-panel surface, 24 px radius, soft shadow
- \`.report-strip\` cells use shell-panel
- \`.evidence-trail\` retints to the neutral palette

InvestigateLandingView already received its v2 treatment in Arc C ε; no further changes needed there.

## Why
After PRs 1–5, every overview surface sits on v2's flat-panel family. PR 6 closes the loop so users don't experience a visual style break when they navigate to /live, /investigate, or /report. The focused-endpoint hero (\`.diagnose-brief\`) was particularly out of family — its cyan radial gradient made it look like an alert when it's just the hero of the route.

## Arc
PR 1/7 ✅ — verdict card
PR 2/7 ✅ — NetworkTopology
PR 3/7 ✅ — palette
PR 4/7 ✅ — topbar + nav
PR 5/7 ✅ — endpoint rows + event log
PR 6/7 — this PR
PR 7/7 — visual baselines + tokenisation sweep

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm run lint:css\` — clean
- [x] \`npm test\` — 1138 / 1138 passing
- [x] \`npm run build\` — succeeds