### PR TITLE
docs: v2 aesthetic arc handoff + tokenise two stylelint-ignored files (7/7)

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -54,11 +54,14 @@ src/lib/components/SettingsDrawer.svelte
 src/lib/components/CompanionPanel.svelte
 src/lib/components/ConfigStagingBanner.svelte
 src/lib/components/LiveView.svelte
-src/lib/components/SharedResultsBanner.svelte
 src/lib/components/IntelligencePanel.svelte
 src/lib/components/EndpointDrawer.svelte
 src/lib/components/EndpointRow.svelte
-src/lib/components/KeyboardOverlay.svelte
 src/lib/components/ScopeCanvas.svelte
 src/lib/components/LocalProofPanel.svelte
 src/app.css
+
+# v2 aesthetic arc PR 7 — REMOVED from ignore (raw values tokenised to
+# the v2 neutral palette):
+# - SharedResultsBanner.svelte (1 raw rgba → shell-panel color-mix)
+# - KeyboardOverlay.svelte (3 raw rgba → shell-panel + t1 + black color-mix)

--- a/docs/v2-aesthetic-arc-handoff.md
+++ b/docs/v2-aesthetic-arc-handoff.md
@@ -1,0 +1,85 @@
+# v2 Aesthetic Arc — Handoff
+
+Status: 7/7 PRs merged. The Chronoscope visual system now sits in v2's
+calm-product posture across every route.
+
+## What shipped
+
+| PR | Surface | Visible change |
+|----|---------|----------------|
+| 1  | Overview verdict card | Score ring dropped, MF/I labels dropped, two-paragraph body, white-on-black primary, quieter pills, pinging-dot live indicator, inline endpoint name highlight |
+| 2  | NetworkTopology      | Rounded-square glyphs in same family across origin + endpoints, tinted fill instead of glow halos, nearly-invisible path lines, softer pulse animation |
+| 3  | Background palette   | Pure-black page bg + `#1C1C1E`/`#2C2C2E` panels (replaces blue-tinted near-black); drops Layout.svelte gradient + corner orbs |
+| 4  | Shell + Topbar       | Centred floating pill at desktop, v2 segmented control nav inside the pill, white-on-black Start button, rose-tinted Stop, quiet settings cog, mobile-only separate nav row |
+| 5  | Endpoint rows + event log | Stacked rounded-cards instead of border-bottom rows; tinted status circle; sans-serif body; quieter sparkline |
+| 6  | Live + Investigate + Report | Every panel surface aligns to flat shell-panel + 16/24 px radius + soft shadow family; drops the cyan radial gradients on hero surfaces |
+| 7  | Baselines + tokenisation | Two more files removed from `.stylelintignore` (SharedResultsBanner, KeyboardOverlay); this document |
+
+## Remaining work for you to do
+
+### 1. Regenerate Playwright visual baselines
+
+Every surface changed visually. The PNG baselines under
+`tests/visual/**/*.png` are stale. Regenerate them locally:
+
+```bash
+npx playwright test --update-snapshots
+git status                          # review which baselines moved
+git add tests/visual                # stage the new baselines
+git commit -m "test(visual): regenerate baselines for v2 aesthetic arc"
+```
+
+Run on the same machine + browser that produces the CI baselines —
+otherwise the next CI run will fail with anti-aliasing diffs. Default
+is Chromium on Darwin per the existing `.spec.ts-snapshots/` naming.
+
+### 2. Finish the tokenisation sweep (optional)
+
+Eleven files remain in `.stylelintignore` with raw rgba / hex
+violations. These don't block the v2 aesthetic shift, but the longer
+they stay ignored the more drift accumulates. Suggested order
+(smallest-first to build momentum):
+
+```
+src/lib/components/ConfigStagingBanner.svelte   (~21 raw values)
+src/lib/components/IntelligencePanel.svelte
+src/lib/components/EndpointDrawer.svelte
+src/lib/components/CompanionPanel.svelte
+src/lib/components/SharePopover.svelte
+src/lib/components/SettingsDrawer.svelte
+src/lib/components/EndpointRow.svelte
+src/lib/components/ScopeCanvas.svelte
+src/lib/components/LiveView.svelte              (deeper rewrite)
+src/lib/components/LocalProofPanel.svelte
+src/app.css                                     (global)
+```
+
+The pattern: replace `rgba(8, 14, 24, 0.62)` with
+`color-mix(in srgb, black 40%, transparent)` (or
+`color-mix(in srgb, var(--shell-panel) 75%, transparent)` when the
+intent is "tinted panel surface, not blacker than the page"). The
+existing `Topbar.svelte`, `OverviewView.svelte`, and
+`NetworkTopology.svelte` are good references for which patterns to
+use where.
+
+### 3. Things worth re-introducing later
+
+The v2 aesthetic arc dropped a few Chronoscope-specific moats. Bring
+them back in v2's aesthetic language when you're ready:
+
+- **Score numeral.** Dropped from the verdict card. If you want it
+  back, render it as a small monospace number in the verdict-kickers
+  row next to the severity pill — *not* as a ring.
+- **T+MM:SS elapsed counter.** Dropped from the topbar. If you want it
+  back, render it adjacent to the Live indicator in zinc-500 mono.
+- **Measured Fact / Interpretation labels.** Dropped. The two
+  paragraphs survive as typography. If you want the labels back for
+  screen-reader clarity, add them as `.sr-only` headings rather than
+  visible bold prefixes.
+
+### 4. Live testing reminder
+
+Per saved memory: any browser-based review of the deployed app must
+**click Stop** on the running measurement before closing the session.
+Persistent pinging against shared infrastructure (google.com,
+cloudflare.com) is the failure mode this rule prevents.

--- a/src/lib/components/KeyboardOverlay.svelte
+++ b/src/lib/components/KeyboardOverlay.svelte
@@ -135,7 +135,7 @@
   }
 
   .dialog {
-    background: rgba(12,10,20,.75);
+    background: color-mix(in srgb, var(--shell-panel) 75%, transparent);
     backdrop-filter: blur(40px) saturate(1.4);
     -webkit-backdrop-filter: blur(40px) saturate(1.4);
     border: 1px solid var(--glass-border);
@@ -144,7 +144,7 @@
     min-width: 360px;
     max-width: 480px;
     width: 100%;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+    box-shadow: 0 8px 32px color-mix(in srgb, black 60%, transparent);
     outline: none;
     position: relative;
     overflow: hidden;
@@ -224,7 +224,7 @@
   }
 
   .shortcut-table tr:not(:last-child) td {
-    border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+    border-bottom: 1px solid color-mix(in srgb, var(--t1) 4%, transparent);
   }
 
   kbd {

--- a/src/lib/components/SharedResultsBanner.svelte
+++ b/src/lib/components/SharedResultsBanner.svelte
@@ -58,7 +58,7 @@
     justify-content: space-between;
     gap: var(--spacing-sm);
     padding: var(--spacing-xs) var(--spacing-md);
-    background: rgba(12,10,20,.65);
+    background: color-mix(in srgb, var(--shell-panel) 65%, transparent);
     backdrop-filter: blur(24px) saturate(1.3);
     -webkit-backdrop-filter: blur(24px) saturate(1.3);
     border-bottom: 1px solid var(--glass-border);


### PR DESCRIPTION
## Summary
Final PR in the v2 aesthetic arc.

**Tokenisation — partial sweep:**
- \`SharedResultsBanner.svelte\` (1 raw rgba → color-mix)
- \`KeyboardOverlay.svelte\` (3 raw rgba → color-mix)
- Both removed from \`.stylelintignore\`
- 11 deeper files remain; handoff doc lists them in suggested order

**Handoff document** — \`docs/v2-aesthetic-arc-handoff.md\` covers:
- What landed in each of PRs 1–7
- **Playwright visual-baseline regeneration step you need to run locally** (CI baselines are stale; \`npx playwright test --update-snapshots\` on Chromium / Darwin)
- Remaining 11 ignore-listed files in suggested order
- Three dropped Chronoscope-specific moats (score numeral, T+MM:SS counter, MF/I labels) with notes on how to re-introduce each in v2's aesthetic language if wanted later
- Reminder about the stop-the-live-test rule

## Arc complete
PR 1/7 ✅ — verdict card
PR 2/7 ✅ — NetworkTopology
PR 3/7 ✅ — palette
PR 4/7 ✅ — topbar + nav
PR 5/7 ✅ — endpoint rows + event log
PR 6/7 ✅ — Live + Investigate + Report
PR 7/7 — this PR

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npm run lint:css\` — clean (after the two ignore-list removals)
- [x] \`npm test\` — 1138 / 1138 passing
- [x] \`npm run build\` — succeeds
- [ ] You run \`npx playwright test --update-snapshots\` locally and commit the new baselines (see handoff doc)