### PR TITLE
fix(live): use p95 (not p99) for axis target so single spikes don't flatten the chart

### DIFF
--- a/src/lib/components/LiveView.svelte
+++ b/src/lib/components/LiveView.svelte
@@ -18,12 +18,20 @@
   const measurements = $derived($measurementStore);
   const stats = $derived($statisticsStore);
 
-  // Cross-endpoint p99 — computed across ALL monitored endpoints (not just
-  // visible or focused). Passed identically to every ScopeCanvas instance so
-  // the unified/split/solo modes all share the same y-axis ceiling.
-  // DO NOT use stats[ep.id]?.p99 per-row in split mode — that destroys the
-  // cross-endpoint comparability invariant (D7).
-  const p99Across = $derived(Math.max(0, ...monitored.map((ep) => stats[ep.id]?.p99 ?? 0)));
+  // Cross-endpoint axis-target percentile — uses p95 (not p99) on
+  // /live so a single >120 ms spike doesn't drag the y-axis ceiling up
+  // for the whole window, leaving 80 % of the chart empty above the
+  // typical data range. p99 outliers still render correctly via
+  // ScopeCanvas's overflow markers. Computed across ALL monitored
+  // endpoints (not just visible/focused) so unified/split/solo modes
+  // all share the same y-axis ceiling — required for the cross-
+  // endpoint comparability invariant (D7). The prop is named
+  // p99Across on ScopeCanvas for historical reasons; what it means in
+  // practice is "the latency target the chart should fit".
+  const p99Across = $derived(Math.max(
+    0,
+    ...monitored.map((ep) => stats[ep.id]?.p95 ?? stats[ep.id]?.p99 ?? 0),
+  ));
   const threshold = $derived($settingsStore.healthThreshold);
   const liveOptions = $derived($uiStore.liveOptions);
   const focusedId = $derived($uiStore.focusedEndpointId);


### PR DESCRIPTION
## Summary
PR #194 added detail-scale + area fill so the chart could fit low-latency data. The deployed result still showed the chart empty-at-top because \`p99Across\` was being driven up by a single brief spike in the recent window, which kept the axis pinned at 150 ms even when typical data was 20-40 ms.

Switch the axis target from p99 to p95 — stable summary across the window, not dragged by single outliers. For typical healthy data (LAST 25-45 ms, p95 30-50 ms) the axis now sits 60-90 ms and the chart fills. Spikes that exceed the chosen axis still render via the existing overflow markers.

Falls back to p99 only when p95 is missing (very early in the run, before stats are ready).

## Why
You: "I still can't even see the graph." Confirmed via the deployed screenshot — axis was 150 even though typical data was 20-40 ms. The bundle was the new code; the *math* was the issue.

## Test plan
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 1138 / 1138 passing
- [x] \`npm run build\` — succeeds